### PR TITLE
Make the runtime respect the settings (#26)

### DIFF
--- a/src/service-worker/content-script-listener.ts
+++ b/src/service-worker/content-script-listener.ts
@@ -59,10 +59,11 @@ export class ContentScriptListener {
             }
         );
 
-        // listen for active tab changes and send the state to the new tab
+        // listen for active tab changes: record the newly active tab as the
+        // live state (so later-opened tabs inherit it) and refresh its presentation
         chrome.tabs.onActivated.addListener(async (activeInfo) => {
+            await this.stateManager.markTabActive(activeInfo.tabId);
             await this.stateManager.sendStateToTab(activeInfo.tabId);
-            await this.stateManager.updatePresentation(activeInfo.tabId);
         });
 
         // discard a tab's state when it closes so it doesn't accumulate

--- a/src/service-worker/content-script-listener.ts
+++ b/src/service-worker/content-script-listener.ts
@@ -60,15 +60,20 @@ export class ContentScriptListener {
         );
 
         // listen for active tab changes: record the newly active tab as the
-        // live state (so later-opened tabs inherit it) and refresh its presentation
-        chrome.tabs.onActivated.addListener(async (activeInfo) => {
-            await this.stateManager.markTabActive(activeInfo.tabId);
-            await this.stateManager.sendStateToTab(activeInfo.tabId);
+        // live state (so later-opened tabs inherit it) and refresh its
+        // presentation. The listener stays synchronous (the event ignores a
+        // returned promise), so detach and log rather than leaking an unhandled
+        // rejection into the service worker.
+        chrome.tabs.onActivated.addListener((activeInfo) => {
+            void (async () => {
+                await this.stateManager.markTabActive(activeInfo.tabId);
+                await this.stateManager.sendStateToTab(activeInfo.tabId);
+            })().catch((error) => debugLog("onActivated handling failed:", error));
         });
 
         // discard a tab's state when it closes so it doesn't accumulate
         chrome.tabs.onRemoved.addListener((tabId) => {
-            this.stateManager.clearTabState(tabId);
+            this.stateManager.clearTabState(tabId).catch((error) => debugLog("clearTabState failed:", error));
         });
     }
 }

--- a/src/service-worker/service-worker.ts
+++ b/src/service-worker/service-worker.ts
@@ -5,6 +5,7 @@ import { onInstall } from "./on-install";
 import { setupMenuListener } from "./menus";
 import { setupActionListener } from "./action";
 import { ContentScriptListener } from "./content-script-listener";
+import { settingsKeys } from "../settings/settings";
 
 chrome.runtime.onInstalled.addListener(onInstall);
 
@@ -13,3 +14,17 @@ const contentScriptListener = new ContentScriptListener(stateManager);
 contentScriptListener.listen();
 setupMenuListener(stateManager);
 setupActionListener(stateManager);
+
+// React to settings changes (written by the options page to storage.sync).
+// Registered synchronously at the top level so it can wake an idle MV3 service
+// worker. The single storage write is the broadcast — there is no explicit
+// options→service-worker message (see #25/#26).
+chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== "sync") {
+        return;
+    }
+    if (!Object.keys(changes).some((key) => (settingsKeys as string[]).includes(key))) {
+        return;
+    }
+    stateManager.onSettingsChanged();
+});

--- a/src/service-worker/service-worker.ts
+++ b/src/service-worker/service-worker.ts
@@ -6,6 +6,7 @@ import { setupMenuListener } from "./menus";
 import { setupActionListener } from "./action";
 import { ContentScriptListener } from "./content-script-listener";
 import { settingsKeys } from "../settings/settings";
+import { debugLog } from "../debug-log";
 
 chrome.runtime.onInstalled.addListener(onInstall);
 
@@ -26,5 +27,8 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
     if (!Object.keys(changes).some((key) => (settingsKeys as string[]).includes(key))) {
         return;
     }
-    stateManager.onSettingsChanged();
+    // The listener must stay synchronous (storage.onChanged ignores a returned
+    // promise), so detach and log rather than letting a rejection surface as an
+    // unhandled promise rejection in the service worker.
+    stateManager.onSettingsChanged().catch((error) => debugLog("onSettingsChanged failed:", error));
 });

--- a/src/service-worker/state-manager.test.ts
+++ b/src/service-worker/state-manager.test.ts
@@ -1,0 +1,183 @@
+/**
+ * @jest-environment node
+ *
+ * Pure logic over the chrome.* storage/tabs APIs, no DOM — run in the `node`
+ * env (project default is jsdom) so `structuredClone` and friends match the
+ * browser runtimes the service worker actually ships to.
+ */
+import { StateManager } from "./state-manager";
+import { Persistence, Settings, defaultSettings } from "../settings/settings";
+import { KoreanKeyboardMode } from "../extension-state/korean-keyboard-mode";
+import { TabState } from "../extension-state/tab-state";
+
+// `url:` asset imports reached transitively (state-manager → menus →
+// romanize-menu-actions). Parcel resolves these at build time; stub them here.
+jest.mock("url:../images/icon16h.png", () => "icon16h", { virtual: true });
+jest.mock("url:../images/icon16a.png", () => "icon16a", { virtual: true });
+jest.mock("url:./popup-converter/popup-converter.html", () => "popup.html", { virtual: true });
+
+// In-memory stand-ins for the three storage areas the manager touches.
+let sync: Record<string, unknown>;
+let session: Record<string, unknown>;
+let local: Record<string, unknown>;
+let tabs: { id: number; active?: boolean }[];
+let sentMessages: { tabId: number; data: TabState }[];
+
+function area(store: () => Record<string, unknown>) {
+    return {
+        get: jest.fn(async (key: string | null) => {
+            if (key === null) {
+                return { ...store() };
+            }
+            return key in store() ? { [key]: store()[key] } : {};
+        }),
+        set: jest.fn(async (items: Record<string, unknown>) => {
+            Object.assign(store(), items);
+        }),
+        remove: jest.fn(async (keys: string[]) => {
+            for (const key of keys) {
+                delete store()[key];
+            }
+        }),
+    };
+}
+
+beforeEach(() => {
+    sync = {};
+    session = {};
+    local = {};
+    tabs = [{ id: 1, active: true }];
+    sentMessages = [];
+
+    Object.assign(globalThis, {
+        chrome: {
+            runtime: { onMessage: {} },
+            storage: {
+                sync: area(() => sync),
+                session: area(() => session),
+                local: area(() => local),
+            },
+            tabs: {
+                query: jest.fn(async (q: { active?: boolean }) => (q.active ? tabs.filter((t) => t.active) : tabs)),
+                sendMessage: jest.fn(async (tabId: number, message: { data: TabState }) => {
+                    sentMessages.push({ tabId, data: message.data });
+                }),
+            },
+            action: { setIcon: jest.fn(async () => {}) },
+            contextMenus: { update: jest.fn(async () => {}) },
+        },
+    });
+});
+
+function withSettings(
+    overrides: Partial<Settings> & {
+        onScreenKeyboard?: Partial<Settings["onScreenKeyboard"]>;
+        hanYong?: Partial<Settings["hanYong"]>;
+    }
+) {
+    sync = {
+        ...defaultSettings,
+        ...overrides,
+        onScreenKeyboard: { ...defaultSettings.onScreenKeyboard, ...overrides.onScreenKeyboard },
+        hanYong: { ...defaultSettings.hanYong, ...overrides.hanYong },
+    };
+}
+
+function lastSentTo(tabId: number): TabState | undefined {
+    return [...sentMessages].reverse().find((m) => m.tabId === tabId)?.data;
+}
+
+describe("initial state derivation", () => {
+    it("AlwaysOff starts the feature off", async () => {
+        withSettings({ onScreenKeyboard: { persistence: Persistence.AlwaysOff } });
+        const manager = new StateManager();
+
+        await manager.sendStateToTab(1);
+
+        expect(lastSentTo(1)?.isOnScreenKeyboardEnabled).toBe(false);
+    });
+
+    it("AlwaysOn starts the feature on", async () => {
+        withSettings({ onScreenKeyboard: { persistence: Persistence.AlwaysOn } });
+        const manager = new StateManager();
+
+        await manager.sendStateToTab(1);
+
+        expect(lastSentTo(1)?.isOnScreenKeyboardEnabled).toBe(true);
+    });
+
+    it("AlwaysOn for Han/Yong starts in Hangul mode", async () => {
+        withSettings({ hanYong: { persistence: Persistence.AlwaysOn } });
+        const manager = new StateManager();
+
+        await manager.sendStateToTab(1);
+
+        expect(lastSentTo(1)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
+    });
+
+    it("KeepLastState restores the remembered value from storage.local", async () => {
+        withSettings({ onScreenKeyboard: { persistence: Persistence.KeepLastState } });
+        local.lastState = { isOnScreenKeyboardEnabled: true };
+        const manager = new StateManager();
+
+        await manager.sendStateToTab(1);
+
+        expect(lastSentTo(1)?.isOnScreenKeyboardEnabled).toBe(true);
+    });
+});
+
+describe("KeepLastState persistence", () => {
+    it("writes the toggled value to storage.local", async () => {
+        withSettings({ onScreenKeyboard: { persistence: Persistence.KeepLastState } });
+        const manager = new StateManager();
+
+        await manager.toggleOnScreenKeyboard(1);
+
+        expect((local.lastState as Partial<TabState>).isOnScreenKeyboardEnabled).toBe(true);
+    });
+
+    it("does NOT persist when the feature is AlwaysOff", async () => {
+        withSettings({ onScreenKeyboard: { persistence: Persistence.AlwaysOff } });
+        const manager = new StateManager();
+
+        await manager.toggleOnScreenKeyboard(1);
+
+        expect((local.lastState as Partial<TabState> | undefined)?.isOnScreenKeyboardEnabled).toBeUndefined();
+    });
+});
+
+describe("share across tabs", () => {
+    it("fans a toggle out to every open tab", async () => {
+        withSettings({ shareAcrossTabs: true });
+        tabs = [{ id: 1, active: true }, { id: 2 }, { id: 3 }];
+        const manager = new StateManager();
+
+        await manager.toggleOnScreenKeyboard(1);
+
+        expect(lastSentTo(1)?.isOnScreenKeyboardEnabled).toBe(true);
+        expect(lastSentTo(2)?.isOnScreenKeyboardEnabled).toBe(true);
+        expect(lastSentTo(3)?.isOnScreenKeyboardEnabled).toBe(true);
+    });
+
+    it("a tab opened later adopts the shared value", async () => {
+        withSettings({ shareAcrossTabs: true });
+        const manager = new StateManager();
+        await manager.toggleOnScreenKeyboard(1);
+
+        // Tab 9 wasn't open during the toggle; its derived state should still match.
+        await manager.sendStateToTab(9);
+
+        expect(lastSentTo(9)?.isOnScreenKeyboardEnabled).toBe(true);
+    });
+
+    it("does not fan out when sharing is off", async () => {
+        withSettings({ shareAcrossTabs: false });
+        tabs = [{ id: 1, active: true }, { id: 2 }];
+        const manager = new StateManager();
+
+        await manager.toggleOnScreenKeyboard(1);
+
+        expect(lastSentTo(1)?.isOnScreenKeyboardEnabled).toBe(true);
+        expect(lastSentTo(2)).toBeUndefined();
+    });
+});

--- a/src/service-worker/state-manager.test.ts
+++ b/src/service-worker/state-manager.test.ts
@@ -171,6 +171,28 @@ describe("mid-session new-tab inheritance", () => {
 
         expect(lastSentTo(2)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
     });
+
+    it("an inherited tab becomes independent and stops tracking the active tab", async () => {
+        // Regression for the cloned-tab bug: a tab that inherits its state must
+        // anchor it, so it does not follow whatever tab is activated next.
+        withSettings({ onScreenKeyboard: { persistence: Persistence.AlwaysOff } });
+        const manager = new StateManager();
+
+        // Tab 1 turns OSK on (becomes the live value).
+        await manager.toggleOnScreenKeyboard(1);
+        // Tab 2 opens and inherits ON, then is turned off and becomes the live value.
+        await manager.sendStateToTab(2);
+        await manager.toggleOnScreenKeyboard(2);
+        // Tab 3 opens, inheriting OFF from tab 2.
+        await manager.sendStateToTab(3);
+
+        // Activating tab 1 moves the live value back to ON...
+        await manager.markTabActive(1);
+        // ...but tab 3 must keep its own anchored OFF.
+        await manager.sendStateToTab(3);
+
+        expect(lastSentTo(3)?.isOnScreenKeyboardEnabled).toBe(false);
+    });
 });
 
 describe("KeepLastState persistence", () => {

--- a/src/service-worker/state-manager.test.ts
+++ b/src/service-worker/state-manager.test.ts
@@ -124,6 +124,19 @@ describe("initial state derivation", () => {
 
         expect(lastSentTo(1)?.isOnScreenKeyboardEnabled).toBe(true);
     });
+
+    it("falls back to off for a corrupt/unknown persistence value in storage", async () => {
+        // Simulates stale storage.sync data that slips past loadSettings' typeof check.
+        sync = {
+            ...defaultSettings,
+            onScreenKeyboard: { persistence: "some-removed-value" as unknown as Persistence },
+        };
+        const manager = new StateManager();
+
+        await manager.sendStateToTab(1);
+
+        expect(lastSentTo(1)?.isOnScreenKeyboardEnabled).toBe(false);
+    });
 });
 
 describe("KeepLastState persistence", () => {
@@ -143,6 +156,18 @@ describe("KeepLastState persistence", () => {
         await manager.toggleOnScreenKeyboard(1);
 
         expect((local.lastState as Partial<TabState> | undefined)?.isOnScreenKeyboardEnabled).toBeUndefined();
+    });
+
+    it("does not touch storage.local when neither feature is KeepLastState", async () => {
+        withSettings({
+            onScreenKeyboard: { persistence: Persistence.AlwaysOff },
+            hanYong: { persistence: Persistence.AlwaysOn },
+        });
+        const manager = new StateManager();
+
+        await manager.toggleOnScreenKeyboard(1);
+
+        expect(chrome.storage.local.set).not.toHaveBeenCalled();
     });
 });
 

--- a/src/service-worker/state-manager.test.ts
+++ b/src/service-worker/state-manager.test.ts
@@ -87,7 +87,10 @@ function lastSentTo(tabId: number): TabState | undefined {
     return [...sentMessages].reverse().find((m) => m.tabId === tabId)?.data;
 }
 
-describe("initial state derivation", () => {
+// On a fresh browser session there is no live value yet, so a tab's initial
+// state is seeded from the persistence policy (empty session storage models
+// this).
+describe("fresh-session seeding from persistence", () => {
     it("AlwaysOff starts the feature off", async () => {
         withSettings({ onScreenKeyboard: { persistence: Persistence.AlwaysOff } });
         const manager = new StateManager();
@@ -136,6 +139,37 @@ describe("initial state derivation", () => {
         await manager.sendStateToTab(1);
 
         expect(lastSentTo(1)?.isOnScreenKeyboardEnabled).toBe(false);
+    });
+});
+
+// Mid-session, a new tab inherits the last active tab's live state — persistence
+// policy does NOT apply once a session is underway.
+describe("mid-session new-tab inheritance", () => {
+    it("a new tab inherits the live value even when persistence says AlwaysOff", async () => {
+        withSettings({ onScreenKeyboard: { persistence: Persistence.AlwaysOff } });
+        const manager = new StateManager();
+
+        // Tab 1 turns the OSK on; that becomes the live value.
+        await manager.toggleOnScreenKeyboard(1);
+
+        // A tab opened afterwards inherits ON, ignoring the AlwaysOff policy.
+        await manager.sendStateToTab(2);
+
+        expect(lastSentTo(2)?.isOnScreenKeyboardEnabled).toBe(true);
+    });
+
+    it("activating a tab makes its state the value later tabs inherit", async () => {
+        withSettings({ hanYong: { persistence: Persistence.AlwaysOff } });
+        session["tabState-1"] = {
+            koreanKeyboardMode: KoreanKeyboardMode.Hangul,
+            isOnScreenKeyboardEnabled: false,
+        };
+        const manager = new StateManager();
+
+        await manager.markTabActive(1);
+        await manager.sendStateToTab(2);
+
+        expect(lastSentTo(2)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
     });
 });
 

--- a/src/service-worker/state-manager.ts
+++ b/src/service-worker/state-manager.ts
@@ -261,6 +261,14 @@ export class StateManager {
             return live;
         }
 
+        // No live value yet, so seed from persistence. This is safe even though
+        // liveState isn't initialised until the first toggle/activation:
+        // liveState lives in storage.session (survives SW respawns, cleared only
+        // on browser close), so the undefined window is just the start of a
+        // fresh session. And there, seeding and inheritance are equivalent —
+        // every tab seeds identically, and the only paths that make a tab differ
+        // from that seed (setTabState / broadcast) also set liveState. So by the
+        // time inheritance could differ from the seed, liveState is already set.
         const settings = await loadSettings();
         const last = await this.getLastState();
         const lastHangul = (last.koreanKeyboardMode ?? KoreanKeyboardMode.English) === KoreanKeyboardMode.Hangul;

--- a/src/service-worker/state-manager.ts
+++ b/src/service-worker/state-manager.ts
@@ -114,7 +114,26 @@ export class StateManager {
      * tab" behaviour).
      */
     public async markTabActive(tabId: number): Promise<void> {
-        await this.setLiveState(await this.getTabState(tabId));
+        await this.setLiveState(await this.anchorTabState(tabId));
+    }
+
+    /**
+     * Ensure a tab has its *own* persisted state. A tab that inherited its state
+     * (a newly opened/cloned tab) has no `tabState-<id>` entry, so every read
+     * would otherwise fall back to the global live value and the tab would keep
+     * tracking whatever tab was last active. Persisting the derived state on
+     * first sight anchors the tab so it becomes independent. Returns the state.
+     */
+    private async anchorTabState(tabId: number): Promise<TabState> {
+        const key = this.tabStateKey(tabId);
+        const existing = (await chrome.storage.session.get(key))[key] as TabState | undefined;
+        if (existing) {
+            return this.cloneTabState(existing);
+        }
+
+        const derived = await this.deriveInitialState();
+        await chrome.storage.session.set({ [key]: derived });
+        return derived;
     }
 
     /**
@@ -170,7 +189,9 @@ export class StateManager {
 
     /** Push a tab's current state to it and refresh its icon / menu presentation. */
     public async sendStateToTab(tabId: number) {
-        const state = await this.getTabState(tabId);
+        // Anchor on the way out so a freshly loaded/cloned tab persists its
+        // inherited state and stops tracking the global live value.
+        const state = await this.anchorTabState(tabId);
         await this.pushState(tabId, state);
         await this.updatePresentation(tabId);
     }

--- a/src/service-worker/state-manager.ts
+++ b/src/service-worker/state-manager.ts
@@ -115,7 +115,7 @@ export class StateManager {
         let shared = await this.getSharedLiveState();
         if (!shared) {
             const [active] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
-            shared = active?.id !== undefined ? await this.getTabState(active.id) : this.defaultTabState();
+            shared = active?.id !== undefined ? await this.getTabState(active.id) : await this.deriveInitialState();
             await this.setSharedLiveState(shared);
         }
         await this.broadcastState(shared);
@@ -195,13 +195,6 @@ export class StateManager {
         return `focusedFrame-${tabId}`;
     }
 
-    private defaultTabState(): TabState {
-        return {
-            koreanKeyboardMode: KoreanKeyboardMode.English,
-            isOnScreenKeyboardEnabled: false,
-        };
-    }
-
     private async getTabState(tabId: number): Promise<TabState> {
         const storageKey = this.tabStateKey(tabId);
         const result = await chrome.storage.session.get(storageKey);
@@ -253,18 +246,29 @@ export class StateManager {
                 return true;
             case Persistence.KeepLastState:
                 return lastValue;
+            default:
+                // loadSettings only type-checks via `typeof`, so a stale or
+                // corrupt persistence value in storage.sync can slip through as
+                // a string. Treat anything unrecognised as "off".
+                return false;
         }
     }
 
     /** Persist the new value to `storage.local`, but only for KeepLastState features. */
     private async persistLastState(settings: Settings, next: TabState) {
-        const last = await this.getLastState();
-        const updated: Partial<TabState> = { ...last };
+        const oskKeepsState = settings.onScreenKeyboard.persistence === Persistence.KeepLastState;
+        const hanYongKeepsState = settings.hanYong.persistence === Persistence.KeepLastState;
 
-        if (settings.onScreenKeyboard.persistence === Persistence.KeepLastState) {
+        if (!oskKeepsState && !hanYongKeepsState) {
+            return;
+        }
+
+        const updated: Partial<TabState> = { ...(await this.getLastState()) };
+
+        if (oskKeepsState) {
             updated.isOnScreenKeyboardEnabled = next.isOnScreenKeyboardEnabled;
         }
-        if (settings.hanYong.persistence === Persistence.KeepLastState) {
+        if (hanYongKeepsState) {
             updated.koreanKeyboardMode = next.koreanKeyboardMode;
         }
 

--- a/src/service-worker/state-manager.ts
+++ b/src/service-worker/state-manager.ts
@@ -9,9 +9,25 @@ import {
 } from "../messaging/service-to-content-messages";
 import { menus } from "./menus";
 import { sendMessageToTab } from "./send-message-to-tab";
+import { Persistence, Settings } from "../settings/settings";
+import { loadSettings } from "../settings/settings-store";
+
+/** Global, browser-session-lived shared value, used when `shareAcrossTabs`. */
+const SHARED_LIVE_STATE_KEY = "sharedLiveState";
+/** Persisted (survives restart) last toggled value, source for KeepLastState. */
+const LAST_STATE_KEY = "lastState";
 
 /**
- * Manages extension state for all tabs
+ * Manages extension state for all tabs.
+ *
+ * Live per-tab state lives in `storage.session` (`tabState-<id>`). Two extra
+ * slots connect it to the user's settings (#26):
+ *  - `storage.session[sharedLiveState]` — when "share across tabs" is on, the
+ *    one value every tab adopts.
+ *  - `storage.local[lastState]` — the remembered value for features set to
+ *    `KeepLastState`, the only state that survives a browser restart.
+ * Initial state is *derived* from `Settings` (see {@link deriveInitialState})
+ * rather than a hardcoded default.
  */
 export class StateManager {
     public constructor() {
@@ -40,25 +56,27 @@ export class StateManager {
     }
 
     public async toggleHanYongMode(tabId: number): Promise<void> {
-        let newMode: KoreanKeyboardMode = KoreanKeyboardMode.Hangul;
+        await this.setTabState(tabId, (tabState) => ({
+            ...tabState,
+            koreanKeyboardMode:
+                tabState.koreanKeyboardMode === KoreanKeyboardMode.Hangul
+                    ? KoreanKeyboardMode.English
+                    : KoreanKeyboardMode.Hangul,
+        }));
+    }
 
-        await this.setTabState(tabId, (tabState) => {
-            const currentMode = tabState.koreanKeyboardMode;
+    /**
+     * Toggles the on-screen keyboard state for the given tab and returns the new state
+     * @param tabId The ID of the tab for which to toggle the on-screen keyboard
+     * @returns true if the on-screen keyboard is now enabled, false if it is now disabled
+     */
+    public async toggleOnScreenKeyboard(tabId: number): Promise<boolean> {
+        const newTabState = await this.setTabState(tabId, (tabState) => ({
+            ...tabState,
+            isOnScreenKeyboardEnabled: !tabState.isOnScreenKeyboardEnabled,
+        }));
 
-            switch (currentMode) {
-                case KoreanKeyboardMode.English:
-                    newMode = KoreanKeyboardMode.Hangul;
-                    break;
-                case KoreanKeyboardMode.Hangul:
-                    newMode = KoreanKeyboardMode.English;
-                    break;
-            }
-
-            return {
-                ...tabState,
-                koreanKeyboardMode: newMode,
-            };
-        });
+        return newTabState.isOnScreenKeyboardEnabled;
     }
 
     public async updatePresentation(tabId: number) {
@@ -77,43 +95,86 @@ export class StateManager {
     }
 
     /**
-     * Toggles the on-screen keyboard state for the given tab and returns the new state
-     * @param tabId The ID of the tab for which to toggle the on-screen keyboard
-     * @returns true if the on-screen keyboard is now enabled, false if it is now disabled
+     * React to a settings change (the service worker's top-level
+     * `storage.onChanged` listener calls this — see #25/#26). Settings only
+     * change how *new* tabs derive their initial state, except for "share
+     * across tabs": flipping it on should immediately converge open tabs, so we
+     * seed the shared value from the active tab and broadcast it.
      */
-    public async toggleOnScreenKeyboard(tabId: number): Promise<boolean> {
-        const tabState = await this.getTabState(tabId);
-        const newTabState = {
-            ...tabState,
-            isOnScreenKeyboardEnabled: !tabState.isOnScreenKeyboardEnabled,
-        };
-        await this.setTabState(tabId, () => newTabState);
+    public async onSettingsChanged(): Promise<void> {
+        const settings = await loadSettings();
 
-        return newTabState.isOnScreenKeyboardEnabled;
+        if (!settings.shareAcrossTabs) {
+            // Persistence changes affect only future tabs/sessions; just refresh
+            // presentation so any settings-derived UI stays correct.
+            const tabs = await chrome.tabs.query({});
+            await Promise.all(tabs.map((tab) => (tab.id !== undefined ? this.updatePresentation(tab.id) : undefined)));
+            return;
+        }
+
+        let shared = await this.getSharedLiveState();
+        if (!shared) {
+            const [active] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+            shared = active?.id !== undefined ? await this.getTabState(active.id) : this.defaultTabState();
+            await this.setSharedLiveState(shared);
+        }
+        await this.broadcastState(shared);
     }
 
     /**
-     * Updates the TabState and sends a message to the content scripts to update the state
+     * Updates the TabState and propagates it. Returns the new state.
+     *
+     * Side effects beyond the per-tab slot: persists to `storage.local` for any
+     * feature set to `KeepLastState`, and — when "share across tabs" is on —
+     * mirrors the new state to the shared slot and every open tab instead of
+     * just this one.
      * @param tabId The ID of the tab for which to update the state
      * @param updateFn function that takes the current tab state and returns the new tab state
      */
-    private async setTabState(tabId: number, updateFn: (tabState: TabState) => TabState) {
+    private async setTabState(tabId: number, updateFn: (tabState: TabState) => TabState): Promise<TabState> {
+        const settings = await loadSettings();
         const currentTabState = await this.getTabState(tabId);
         const newTabState = updateFn(currentTabState);
 
         await chrome.storage.session.set({ [this.tabStateKey(tabId)]: newTabState });
+        await this.persistLastState(settings, newTabState);
 
-        await this.sendStateToTab(tabId);
-        await this.updatePresentation(tabId);
+        if (settings.shareAcrossTabs) {
+            await this.setSharedLiveState(newTabState);
+            await this.broadcastState(newTabState);
+        } else {
+            await this.sendStateToTab(tabId);
+            await this.updatePresentation(tabId);
+        }
+
+        return newTabState;
     }
 
     public async sendStateToTab(tabId: number) {
-        const tabState = await this.getTabState(tabId);
+        await this.pushState(tabId, await this.getTabState(tabId));
+    }
+
+    private async pushState(tabId: number, state: TabState) {
         await sendMessageToTab<ServiceScriptMessage>(tabId, {
             type: "serviceScriptMessage",
             action: ServiceScriptMessageAction.UpdateState,
-            data: tabState,
+            data: state,
         });
+    }
+
+    /** Apply one state to every open tab (used in "share across tabs" mode). */
+    private async broadcastState(state: TabState) {
+        const tabs = await chrome.tabs.query({});
+        await Promise.all(
+            tabs.map(async (tab) => {
+                if (tab.id === undefined) {
+                    return;
+                }
+                await chrome.storage.session.set({ [this.tabStateKey(tab.id)]: state });
+                await this.pushState(tab.id, state);
+                await this.updatePresentation(tab.id);
+            })
+        );
     }
 
     /**
@@ -146,11 +207,83 @@ export class StateManager {
         const result = await chrome.storage.session.get(storageKey);
         const tabState = result[storageKey] as TabState | undefined;
 
-        if (!tabState) {
-            return this.defaultTabState();
+        if (tabState) {
+            return this.cloneTabState(tabState);
         }
 
-        return this.cloneTabState(tabState);
+        return this.deriveInitialState();
+    }
+
+    /**
+     * The state a tab starts in, derived from settings. In share mode an
+     * existing shared value wins (so tabs opened later adopt it); otherwise each
+     * feature follows its persistence policy, reading the remembered value for
+     * `KeepLastState`.
+     */
+    private async deriveInitialState(): Promise<TabState> {
+        const settings = await loadSettings();
+
+        if (settings.shareAcrossTabs) {
+            const shared = await this.getSharedLiveState();
+            if (shared) {
+                return shared;
+            }
+        }
+
+        const last = await this.getLastState();
+
+        const lastHangul = (last.koreanKeyboardMode ?? KoreanKeyboardMode.English) === KoreanKeyboardMode.Hangul;
+
+        return {
+            isOnScreenKeyboardEnabled: this.deriveFeature(
+                settings.onScreenKeyboard.persistence,
+                last.isOnScreenKeyboardEnabled ?? false
+            ),
+            koreanKeyboardMode: this.deriveFeature(settings.hanYong.persistence, lastHangul)
+                ? KoreanKeyboardMode.Hangul
+                : KoreanKeyboardMode.English,
+        };
+    }
+
+    private deriveFeature(persistence: Persistence, lastValue: boolean): boolean {
+        switch (persistence) {
+            case Persistence.AlwaysOff:
+                return false;
+            case Persistence.AlwaysOn:
+                return true;
+            case Persistence.KeepLastState:
+                return lastValue;
+        }
+    }
+
+    /** Persist the new value to `storage.local`, but only for KeepLastState features. */
+    private async persistLastState(settings: Settings, next: TabState) {
+        const last = await this.getLastState();
+        const updated: Partial<TabState> = { ...last };
+
+        if (settings.onScreenKeyboard.persistence === Persistence.KeepLastState) {
+            updated.isOnScreenKeyboardEnabled = next.isOnScreenKeyboardEnabled;
+        }
+        if (settings.hanYong.persistence === Persistence.KeepLastState) {
+            updated.koreanKeyboardMode = next.koreanKeyboardMode;
+        }
+
+        await chrome.storage.local.set({ [LAST_STATE_KEY]: updated });
+    }
+
+    private async getLastState(): Promise<Partial<TabState>> {
+        const result = await chrome.storage.local.get(LAST_STATE_KEY);
+        return (result[LAST_STATE_KEY] as Partial<TabState> | undefined) ?? {};
+    }
+
+    private async getSharedLiveState(): Promise<TabState | undefined> {
+        const result = await chrome.storage.session.get(SHARED_LIVE_STATE_KEY);
+        const shared = result[SHARED_LIVE_STATE_KEY] as TabState | undefined;
+        return shared ? this.cloneTabState(shared) : undefined;
+    }
+
+    private async setSharedLiveState(state: TabState) {
+        await chrome.storage.session.set({ [SHARED_LIVE_STATE_KEY]: this.cloneTabState(state) });
     }
 
     private cloneTabState(tabState: TabState): TabState {

--- a/src/service-worker/state-manager.ts
+++ b/src/service-worker/state-manager.ts
@@ -11,23 +11,31 @@ import { menus } from "./menus";
 import { sendMessageToTab } from "./send-message-to-tab";
 import { Persistence, Settings } from "../settings/settings";
 import { loadSettings } from "../settings/settings-store";
+import { debugLog } from "../debug-log";
 
-/** Global, browser-session-lived shared value, used when `shareAcrossTabs`. */
-const SHARED_LIVE_STATE_KEY = "sharedLiveState";
-/** Persisted (survives restart) last toggled value, source for KeepLastState. */
+/**
+ * Global current live state (browser-session-lived). New tabs inherit it, and
+ * in "share across tabs" mode every tab is kept equal to it. Updated whenever a
+ * tab's state changes or a tab becomes active.
+ */
+const LIVE_STATE_KEY = "liveState";
+/** Persisted (survives restart) last state, source for KeepLastState seeding. */
 const LAST_STATE_KEY = "lastState";
 
 /**
  * Manages extension state for all tabs.
  *
- * Live per-tab state lives in `storage.session` (`tabState-<id>`). Two extra
- * slots connect it to the user's settings (#26):
- *  - `storage.session[sharedLiveState]` — when "share across tabs" is on, the
- *    one value every tab adopts.
- *  - `storage.local[lastState]` — the remembered value for features set to
- *    `KeepLastState`, the only state that survives a browser restart.
- * Initial state is *derived* from `Settings` (see {@link deriveInitialState})
- * rather than a hardcoded default.
+ * Live per-tab state lives in `storage.session` (`tabState-<id>`). Two globals
+ * connect it to the user's settings (#26):
+ *  - `storage.session[liveState]` — the current value new tabs inherit (and
+ *    that all tabs share when "share across tabs" is on). Tracks the last
+ *    active tab.
+ *  - `storage.local[lastState]` — the value remembered across a browser
+ *    restart, used to seed `KeepLastState` features on a fresh session.
+ *
+ * Persistence policy (Always off / Always on / Keep last state) governs only
+ * how a *fresh session* is seeded; mid-session, a new tab simply inherits the
+ * last active tab's state (see {@link deriveInitialState}).
  */
 export class StateManager {
     public constructor() {
@@ -88,45 +96,56 @@ export class StateManager {
             path: isHangulMode ? icon16h : icon16a,
         });
 
-        // update on-screen-keyboard menu item to checked or not
-        await chrome.contextMenus.update(menus.onScreenKeyboard.id, {
-            checked: tabState.isOnScreenKeyboardEnabled,
-        });
+        // Update the on-screen-keyboard menu checkbox. The menu may not exist
+        // yet (it's created on install); tolerate that rather than throwing an
+        // unhandled rejection into the presentation path.
+        try {
+            await chrome.contextMenus.update(menus.onScreenKeyboard.id, {
+                checked: tabState.isOnScreenKeyboardEnabled,
+            });
+        } catch (error) {
+            debugLog("Could not update on-screen-keyboard menu item:", error);
+        }
+    }
+
+    /**
+     * Record that a tab became active. Its state becomes the live value that
+     * subsequently-opened tabs inherit (the "new tab adopts the last active
+     * tab" behaviour).
+     */
+    public async markTabActive(tabId: number): Promise<void> {
+        await this.setLiveState(await this.getTabState(tabId));
     }
 
     /**
      * React to a settings change (the service worker's top-level
-     * `storage.onChanged` listener calls this — see #25/#26). Settings only
-     * change how *new* tabs derive their initial state, except for "share
-     * across tabs": flipping it on should immediately converge open tabs, so we
-     * seed the shared value from the active tab and broadcast it.
+     * `storage.onChanged` listener calls this — see #25/#26).
+     *
+     * Persistence changes are restart-only, so they don't disturb open tabs.
+     * The one live effect is enabling "share across tabs": that should converge
+     * the currently-open tabs onto the shared live value immediately.
      */
     public async onSettingsChanged(): Promise<void> {
         const settings = await loadSettings();
-
         if (!settings.shareAcrossTabs) {
-            // Persistence changes affect only future tabs/sessions; just refresh
-            // presentation so any settings-derived UI stays correct.
-            const tabs = await chrome.tabs.query({});
-            await Promise.all(tabs.map((tab) => (tab.id !== undefined ? this.updatePresentation(tab.id) : undefined)));
             return;
         }
 
-        let shared = await this.getSharedLiveState();
-        if (!shared) {
+        let live = await this.getLiveState();
+        if (!live) {
             const [active] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
-            shared = active?.id !== undefined ? await this.getTabState(active.id) : await this.deriveInitialState();
-            await this.setSharedLiveState(shared);
+            live = active?.id !== undefined ? await this.getTabState(active.id) : await this.deriveInitialState();
+            await this.setLiveState(live);
         }
-        await this.broadcastState(shared);
+        await this.broadcastState(live);
     }
 
     /**
-     * Updates the TabState and propagates it. Returns the new state.
+     * Updates a tab's state and propagates it. Returns the new state.
      *
-     * Side effects beyond the per-tab slot: persists to `storage.local` for any
-     * feature set to `KeepLastState`, and — when "share across tabs" is on —
-     * mirrors the new state to the shared slot and every open tab instead of
+     * Always updates the global live value (so new tabs inherit it) and, for any
+     * `KeepLastState` feature, the persisted `storage.local` value. When "share
+     * across tabs" is on, mirrors the new state to every open tab instead of
      * just this one.
      * @param tabId The ID of the tab for which to update the state
      * @param updateFn function that takes the current tab state and returns the new tab state
@@ -138,20 +157,22 @@ export class StateManager {
 
         await chrome.storage.session.set({ [this.tabStateKey(tabId)]: newTabState });
         await this.persistLastState(settings, newTabState);
+        await this.setLiveState(newTabState);
 
         if (settings.shareAcrossTabs) {
-            await this.setSharedLiveState(newTabState);
             await this.broadcastState(newTabState);
         } else {
             await this.sendStateToTab(tabId);
-            await this.updatePresentation(tabId);
         }
 
         return newTabState;
     }
 
+    /** Push a tab's current state to it and refresh its icon / menu presentation. */
     public async sendStateToTab(tabId: number) {
-        await this.pushState(tabId, await this.getTabState(tabId));
+        const state = await this.getTabState(tabId);
+        await this.pushState(tabId, state);
+        await this.updatePresentation(tabId);
     }
 
     private async pushState(tabId: number, state: TabState) {
@@ -208,37 +229,34 @@ export class StateManager {
     }
 
     /**
-     * The state a tab starts in, derived from settings. In share mode an
-     * existing shared value wins (so tabs opened later adopt it); otherwise each
-     * feature follows its persistence policy, reading the remembered value for
-     * `KeepLastState`.
+     * The state a tab starts in. Mid-session it inherits the global live value
+     * (the last active tab, also the shared value when sharing is on). Only on a
+     * fresh session — when no live value exists yet — does persistence policy
+     * decide the seed, reading `storage.local` for `KeepLastState`.
      */
     private async deriveInitialState(): Promise<TabState> {
-        const settings = await loadSettings();
-
-        if (settings.shareAcrossTabs) {
-            const shared = await this.getSharedLiveState();
-            if (shared) {
-                return shared;
-            }
+        const live = await this.getLiveState();
+        if (live) {
+            return live;
         }
 
+        const settings = await loadSettings();
         const last = await this.getLastState();
-
         const lastHangul = (last.koreanKeyboardMode ?? KoreanKeyboardMode.English) === KoreanKeyboardMode.Hangul;
 
         return {
-            isOnScreenKeyboardEnabled: this.deriveFeature(
+            isOnScreenKeyboardEnabled: this.seedFeature(
                 settings.onScreenKeyboard.persistence,
                 last.isOnScreenKeyboardEnabled ?? false
             ),
-            koreanKeyboardMode: this.deriveFeature(settings.hanYong.persistence, lastHangul)
+            koreanKeyboardMode: this.seedFeature(settings.hanYong.persistence, lastHangul)
                 ? KoreanKeyboardMode.Hangul
                 : KoreanKeyboardMode.English,
         };
     }
 
-    private deriveFeature(persistence: Persistence, lastValue: boolean): boolean {
+    /** How a feature is seeded on a fresh session, given its persistence policy. */
+    private seedFeature(persistence: Persistence, lastValue: boolean): boolean {
         switch (persistence) {
             case Persistence.AlwaysOff:
                 return false;
@@ -280,14 +298,14 @@ export class StateManager {
         return (result[LAST_STATE_KEY] as Partial<TabState> | undefined) ?? {};
     }
 
-    private async getSharedLiveState(): Promise<TabState | undefined> {
-        const result = await chrome.storage.session.get(SHARED_LIVE_STATE_KEY);
-        const shared = result[SHARED_LIVE_STATE_KEY] as TabState | undefined;
-        return shared ? this.cloneTabState(shared) : undefined;
+    private async getLiveState(): Promise<TabState | undefined> {
+        const result = await chrome.storage.session.get(LIVE_STATE_KEY);
+        const live = result[LIVE_STATE_KEY] as TabState | undefined;
+        return live ? this.cloneTabState(live) : undefined;
     }
 
-    private async setSharedLiveState(state: TabState) {
-        await chrome.storage.session.set({ [SHARED_LIVE_STATE_KEY]: this.cloneTabState(state) });
+    private async setLiveState(state: TabState) {
+        await chrome.storage.session.set({ [LIVE_STATE_KEY]: this.cloneTabState(state) });
     }
 
     private cloneTabState(tabState: TabState): TabState {


### PR DESCRIPTION
## Summary

Connects the settings (written to `chrome.storage.sync` by the options page in #25) to the runtime, which previously never read them. `StateManager`'s live per-tab state and the user's settings were two halves of the same feature that were never wired together — this wires them.

- **Persistence policy seeds a fresh browser session.** Each feature's `Persistence` decides the starting value on a new session: `AlwaysOff` → off, `AlwaysOn` → on, `KeepLastState` → the value remembered from last time (kept in `storage.local`, the only state that survives a restart).
- **Mid-session, a new tab inherits the last active tab's state.** No setting governs this — persistence applies only at session start. A tab anchors (persists) its inherited state on first sight so it becomes independent and doesn't keep tracking later tab switches.
- **"Share across tabs"**: when on, a toggle fans out to every open tab, and tabs opened later adopt the shared value — both via the same global live slot.
- **`service-worker.ts`** registers a **top-level synchronous** `chrome.storage.onChanged` listener (filtered to `areaName === "sync"` + the settings keys) that reacts to settings changes via the existing `UpdateState` path. No options→SW message — the storage write *is* the broadcast (decided in #25).

## Storage layout

`TabState` and the `UpdateState` message contract are unchanged, so the content script needs no changes.

| Area | Key | Purpose |
|---|---|---|
| `storage.session` | `tabState-<id>` | live per-tab state |
| `storage.session` | `liveState` | current global value: what new tabs inherit, and the shared value when `shareAcrossTabs` is on. Tracks the last active tab. |
| `storage.local` | `lastState` | value remembered across a browser restart, used to seed `KeepLastState` on a fresh session |

## Tests

`state-manager.test.ts` (node env, like `settings-store.test.ts`) covers: fresh-session seeding for each persistence value, `KeepLastState` round-trip through `storage.local`, mid-session new-tab inheritance, the anchor/independence regression (cloned-tab bug), corrupt-persistence fallback, and share-across-tabs fan-out.

Gate: `check` + `lint` + `test` + `build-dev` all green.

Closes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)