### PR TITLE
Create context menus on every service-worker startup (#28)

### DIFF
--- a/src/service-worker/menus.test.ts
+++ b/src/service-worker/menus.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment node
+ */
+import { createMenus, menus } from "./menus";
+
+// createMenus reaches romanize-menu-actions → a `url:` HTML asset import that
+// Parcel resolves at build time; stub it for the test.
+jest.mock("url:./popup-converter/popup-converter.html", () => "popup.html", { virtual: true });
+
+let created: { id?: string }[];
+let removeAllCalls: number;
+let removeAllResolvedBeforeCreate: boolean;
+
+beforeEach(() => {
+    created = [];
+    removeAllCalls = 0;
+    removeAllResolvedBeforeCreate = false;
+
+    Object.assign(globalThis, {
+        chrome: {
+            contextMenus: {
+                removeAll: jest.fn(async () => {
+                    removeAllCalls++;
+                    created = []; // model real chrome: clears all existing items
+                }),
+                create: jest.fn((options: { id?: string }) => {
+                    // Records whether removeAll has been awaited by the time any
+                    // item is created — i.e. the clear happens first.
+                    if (created.length === 0) {
+                        removeAllResolvedBeforeCreate = removeAllCalls > 0;
+                    }
+                    created.push(options);
+                }),
+            },
+            i18n: { getMessage: (key: string) => key },
+        },
+    });
+});
+
+describe("createMenus", () => {
+    it("clears existing menus before creating, so repeated calls don't collide", async () => {
+        await createMenus();
+
+        expect(removeAllCalls).toBe(1);
+        expect(removeAllResolvedBeforeCreate).toBe(true);
+    });
+
+    it("creates the three expected menu items", async () => {
+        await createMenus();
+
+        expect(created.map((c) => c.id)).toEqual([
+            menus.romanizeInPopup.id,
+            menus.romanizeBeside.id,
+            menus.onScreenKeyboard.id,
+        ]);
+    });
+
+    it("is safe to call repeatedly (idempotent)", async () => {
+        await createMenus();
+        await createMenus();
+
+        // Each run clears first, so after two runs there are exactly three items, not six.
+        expect(removeAllCalls).toBe(2);
+        expect(created).toHaveLength(3);
+    });
+});

--- a/src/service-worker/menus.test.ts
+++ b/src/service-worker/menus.test.ts
@@ -9,25 +9,31 @@ jest.mock("url:./popup-converter/popup-converter.html", () => "popup.html", { vi
 
 let created: { id?: string }[];
 let removeAllCalls: number;
-let removeAllResolvedBeforeCreate: boolean;
+let removeAllCompleted: boolean;
+let createdBeforeRemoveAllCompleted: boolean;
 
 beforeEach(() => {
     created = [];
     removeAllCalls = 0;
-    removeAllResolvedBeforeCreate = false;
+    removeAllCompleted = false;
+    createdBeforeRemoveAllCompleted = false;
 
     Object.assign(globalThis, {
         chrome: {
             contextMenus: {
                 removeAll: jest.fn(async () => {
                     removeAllCalls++;
+                    // Real async boundary: `completed` flips only after a
+                    // microtask, so the ordering assertions below pass only if
+                    // createMenus actually awaits removeAll rather than firing
+                    // it and proceeding straight to create.
+                    await Promise.resolve();
+                    removeAllCompleted = true;
                     created = []; // model real chrome: clears all existing items
                 }),
                 create: jest.fn((options: { id?: string }) => {
-                    // Records whether removeAll has been awaited by the time any
-                    // item is created — i.e. the clear happens first.
-                    if (created.length === 0) {
-                        removeAllResolvedBeforeCreate = removeAllCalls > 0;
+                    if (!removeAllCompleted) {
+                        createdBeforeRemoveAllCompleted = true;
                     }
                     created.push(options);
                 }),
@@ -38,11 +44,11 @@ beforeEach(() => {
 });
 
 describe("createMenus", () => {
-    it("clears existing menus before creating, so repeated calls don't collide", async () => {
+    it("awaits removeAll before creating, so repeated calls don't collide", async () => {
         await createMenus();
 
         expect(removeAllCalls).toBe(1);
-        expect(removeAllResolvedBeforeCreate).toBe(true);
+        expect(createdBeforeRemoveAllCompleted).toBe(false);
     });
 
     it("creates the three expected menu items", async () => {

--- a/src/service-worker/menus.ts
+++ b/src/service-worker/menus.ts
@@ -35,7 +35,19 @@ export function setupMenuListener(stateManager: StateManager) {
     });
 }
 
-export function createMenus() {
+/**
+ * (Re)create the context menus. Idempotent: clears any existing items first, so
+ * it's safe to call on every service-worker startup.
+ *
+ * MV3 service workers are ephemeral and `onInstalled` only fires on
+ * install/update — not on a normal wake — so creating menus there alone left
+ * them missing whenever the worker started for any other reason (#28). Call this
+ * from a single top-level site instead. Keep it a single caller: two concurrent
+ * removeAll-then-create sequences can still collide on duplicate ids.
+ */
+export async function createMenus() {
+    await chrome.contextMenus.removeAll();
+
     chrome.contextMenus.create({
         type: "normal",
         id: menus.romanizeInPopup.id,

--- a/src/service-worker/on-install.ts
+++ b/src/service-worker/on-install.ts
@@ -1,7 +1,0 @@
-import { createMenus } from "./menus";
-import { debugLog } from "../debug-log";
-
-export function onInstall(_details: chrome.runtime.InstalledDetails): void {
-    debugLog("onInstall _details: ", _details);
-    createMenus();
-}

--- a/src/service-worker/service-worker.ts
+++ b/src/service-worker/service-worker.ts
@@ -1,20 +1,24 @@
 // Copyright © 2012-2023 Vincent McNabb
 
 import { StateManager } from "./state-manager";
-import { onInstall } from "./on-install";
-import { setupMenuListener } from "./menus";
+import { createMenus, setupMenuListener } from "./menus";
 import { setupActionListener } from "./action";
 import { ContentScriptListener } from "./content-script-listener";
 import { settingsKeys } from "../settings/settings";
 import { debugLog } from "../debug-log";
-
-chrome.runtime.onInstalled.addListener(onInstall);
 
 const stateManager = new StateManager();
 const contentScriptListener = new ContentScriptListener(stateManager);
 contentScriptListener.listen();
 setupMenuListener(stateManager);
 setupActionListener(stateManager);
+
+// Create the context menus on every service-worker startup, not just on
+// install. MV3 workers are ephemeral and `onInstalled` doesn't fire on a normal
+// wake, which previously left the menus missing until a reload (#28).
+// createMenus is idempotent (it clears first), so running it on each startup is
+// safe. Keep this the single caller to avoid concurrent create collisions.
+createMenus().catch((error) => debugLog("createMenus failed:", error));
 
 // React to settings changes (written by the options page to storage.sync).
 // Registered synchronously at the top level so it can wake an idle MV3 service

--- a/src/service-worker/service-worker.ts
+++ b/src/service-worker/service-worker.ts
@@ -18,7 +18,11 @@ setupActionListener(stateManager);
 // wake, which previously left the menus missing until a reload (#28).
 // createMenus is idempotent (it clears first), so running it on each startup is
 // safe. Keep this the single caller to avoid concurrent create collisions.
-createMenus().catch((error) => debugLog("createMenus failed:", error));
+// Recreating the checkbox resets it to unchecked, so refresh the active tab's
+// presentation afterwards to restore the real on-screen-keyboard state.
+createMenus()
+    .then(() => stateManager.refreshActiveTabPresentation())
+    .catch((error) => debugLog("menu setup failed:", error));
 
 // React to settings changes (written by the options page to storage.sync).
 // Registered synchronously at the top level so it can wake an idle MV3 service

--- a/src/service-worker/state-manager.test.ts
+++ b/src/service-worker/state-manager.test.ts
@@ -262,3 +262,33 @@ describe("share across tabs", () => {
         expect(lastSentTo(2)).toBeUndefined();
     });
 });
+
+describe("refreshActiveTabPresentation", () => {
+    it("sets the menu checkbox to the active tab's persisted OSK state", async () => {
+        // After menus are recreated on startup the checkbox defaults to
+        // unchecked; this must restore it to the real (enabled) state.
+        withSettings({});
+        session["tabState-1"] = {
+            koreanKeyboardMode: KoreanKeyboardMode.English,
+            isOnScreenKeyboardEnabled: true,
+        };
+        const manager = new StateManager();
+
+        await manager.refreshActiveTabPresentation();
+
+        expect(chrome.contextMenus.update).toHaveBeenCalledWith(
+            "menu_onScreenKeyboard",
+            expect.objectContaining({ checked: true })
+        );
+    });
+
+    it("does nothing when there is no active tab", async () => {
+        withSettings({});
+        tabs = [];
+        const manager = new StateManager();
+
+        await manager.refreshActiveTabPresentation();
+
+        expect(chrome.contextMenus.update).not.toHaveBeenCalled();
+    });
+});

--- a/src/service-worker/state-manager.ts
+++ b/src/service-worker/state-manager.ts
@@ -97,14 +97,27 @@ export class StateManager {
         });
 
         // Update the on-screen-keyboard menu checkbox. The menu may not exist
-        // yet (it's created on install); tolerate that rather than throwing an
-        // unhandled rejection into the presentation path.
+        // yet (it's created on service-worker startup); tolerate that rather
+        // than throwing an unhandled rejection into the presentation path.
         try {
             await chrome.contextMenus.update(menus.onScreenKeyboard.id, {
                 checked: tabState.isOnScreenKeyboardEnabled,
             });
         } catch (error) {
             debugLog("Could not update on-screen-keyboard menu item:", error);
+        }
+    }
+
+    /**
+     * Refresh the action icon and menu checkbox for the currently active tab.
+     * Called after the menus are (re)created on service-worker startup: the
+     * checkbox is recreated unchecked, so without this it would misrepresent an
+     * enabled on-screen keyboard until the next state change.
+     */
+    public async refreshActiveTabPresentation(): Promise<void> {
+        const [active] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+        if (active?.id !== undefined) {
+            await this.updatePresentation(active.id);
         }
     }
 


### PR DESCRIPTION
## Summary

Context menus (romanize-in-popup, romanize-beside, on-screen-keyboard) didn't reliably appear on load: they were created only from `onInstalled`, which in MV3 fires on install/update but **not** on a normal service-worker wake. Once the ephemeral worker was torn down and respawned, the menus were missing until something forced an install event (a reload/clone) — and code updating them threw `Cannot find menu item with id menu_onScreenKeyboard`.

## Fix

- **`createMenus()` is now idempotent** — it `removeAll()`s first, then creates — and is called from a **single top-level site** in `service-worker.ts`. That runs on *every* startup (install, browser start, idle respawn), so the menus are always present, without duplicate-id collisions. Kept to one caller deliberately: two concurrent removeAll-then-create sequences could still collide.
- **Removed `on-install.ts` and the `onInstalled` listener.** It only created the menus (now handled at startup) plus a debug log, so it became dead weight.

## Tests

New `menus.test.ts` (node env): verifies `removeAll` runs before any `create` (clear-before-create ordering), the three expected items are created, and repeated calls stay idempotent (two runs → three items, not six).

Gate: `check` + `lint` + `test` (142 passing) + `build-dev` all green.

## Verification note

The root behaviour (menu present after the SW has been idle and respawned) is a service-worker-lifecycle effect that unit tests can't reproduce, so it's worth a manual check: load `dist-dev/`, confirm the right-click menu appears on a fresh tab without a reload, and ideally after letting the worker go idle.

Closes #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)