### PR TITLE
Define Vue feature flags to silence Options-page console warning (#29)

### DIFF
--- a/src/options-app/options-app.ts
+++ b/src/options-app/options-app.ts
@@ -1,4 +1,18 @@
 import { createApp } from "vue";
 import App from "./options-page.vue";
 
+// Define Vue's compile-time feature flags before the app is created. Vue's
+// esm-bundler build warns when these are undefined and can't tree-shake the
+// guarded code out. The options page is Composition-API-only (every SFC uses
+// `<script setup>`), so the Options API can be disabled too.
+declare global {
+    var __VUE_OPTIONS_API__: boolean;
+    var __VUE_PROD_DEVTOOLS__: boolean;
+    var __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: boolean;
+}
+
+globalThis.__VUE_OPTIONS_API__ = false;
+globalThis.__VUE_PROD_DEVTOOLS__ = false;
+globalThis.__VUE_PROD_HYDRATION_MISMATCH_DETAILS__ = false;
+
 createApp(App).mount("#app");


### PR DESCRIPTION
## Summary

Defines Vue's three compile-time feature flags before `createApp` in `options-app.ts`, silencing the esm-bundler console warning on the Options page:

```
Feature flags __VUE_OPTIONS_API__, __VUE_PROD_DEVTOOLS__, __VUE_PROD_HYDRATION_MISMATCH_DETAILS__ are not explicitly defined...
```

The options page is **Composition-API-only** (verified: all 5 SFCs use `<script setup>`, and Vue mounts nowhere else), so `__VUE_OPTIONS_API__` is safely `false`; the other two are `false` for a production extension build.

## Scope note — this addresses Warning 1 only

#29 listed two warnings. Investigation outcome:

- **Warning 1 (Vue feature flags)** — fixed here.
- **Warning 2 (Parcel CSS tree-shaking)** — **won't fix.** It's hardcoded in `@parcel/transformer-vue` (it unconditionally emits `require('style:./Component.vue').default` for any SFC with a `<style>` block), not configurable, appears only in the production build, and is purely cosmetic. Silencing it would mean moving styles out of SFC `<style scoped>` blocks and losing scoped encapsulation — not worth it. Documented on #29.

## Caveat

This silences the runtime warning (the issue's main goal) but does **not** enable the static tree-shaking the warning also mentions — that requires compile-time constant replacement, which Parcel has no built-in `define` for. For an options page the dead-code saving is marginal, so runtime assignment on `globalThis` is the pragmatic choice.

## Verification

- Confirmed the flags are defined in the built bundle before Vue's `initFeatureFlags` runs.
- Gate: `check` + `lint` + `test` (144 passing) + `build-dev` all green.
- Manual: load `dist-dev/`, open the Options page, confirm no feature-flag warning in the console.

Addresses #29 (Warning 1; Warning 2 documented as won't-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)