### PR TITLE
Make getActiveElement a pure query; move controller creation to ensureController (#38)

### DIFF
--- a/src/content-script/text-input-manager.test.ts
+++ b/src/content-script/text-input-manager.test.ts
@@ -1,5 +1,6 @@
 import { TextInputManager, textInputElementsSelector } from "./text-input-manager";
 import { HangulImeController } from "../composition/hangul-ime-controller";
+import { KeyCode } from "../keyboard/korean-keyboard-map";
 
 function element(html: string): HTMLElement {
     const wrapper = document.createElement("div");
@@ -51,5 +52,34 @@ describe("TextInputManager DOM-removal cleanup", () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(dispose).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("TextInputManager.enterCharacter", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+        document.body.innerHTML = "";
+    });
+
+    it("returns false when no editable element is focused", () => {
+        const manager = new TextInputManager();
+
+        expect(manager.enterCharacter("a", KeyCode.KeyA)).toBe(false);
+    });
+
+    it("creates a controller for the focused element and routes the character", () => {
+        const addCharacter = jest.spyOn(HangulImeController.prototype, "addCharacter").mockImplementation(() => {});
+        const manager = new TextInputManager();
+
+        const input = document.createElement("input");
+        document.body.appendChild(input);
+        input.focus();
+
+        // No setActiveElement call first: enterCharacter must create the
+        // controller itself (via ensureController), not rely on a getter side effect.
+        const handled = manager.enterCharacter("a", KeyCode.KeyA);
+
+        expect(handled).toBe(true);
+        expect(addCharacter).toHaveBeenCalledWith("a", KeyCode.KeyA);
     });
 });

--- a/src/content-script/text-input-manager.ts
+++ b/src/content-script/text-input-manager.ts
@@ -46,7 +46,7 @@ export class TextInputManager {
     public setActiveElement(element: HTMLElement): SupportedCompositionFeatures | undefined {
         // check if element matches the selector `textInputElementsSelector`
         if (element.matches(textInputElementsSelector)) {
-            return this.processElement(element);
+            return this.ensureController(element).getCompositionFeatures();
         }
         return;
     }
@@ -87,11 +87,7 @@ export class TextInputManager {
             return false;
         }
 
-        const imeController = this.imeControllers.get(activeElement);
-
-        if (!imeController) {
-            return false;
-        }
+        const imeController = this.ensureController(activeElement);
 
         if (isHangulOrJamo(char)) {
             imeController.addJamo(char, keyCode);
@@ -106,7 +102,12 @@ export class TextInputManager {
         return true;
     }
 
-    private processElement(element: HTMLElement) {
+    /**
+     * Get (creating if necessary) the IME controller for an element, with its
+     * active state synced to the current text-entry mode. This is the single
+     * place that creates controllers; `getActiveElement` stays a pure query.
+     */
+    private ensureController(element: HTMLElement): HangulImeController {
         let imeController = this.imeControllers.get(element);
 
         if (!imeController) {
@@ -124,7 +125,7 @@ export class TextInputManager {
             }
         }
 
-        return imeController.getCompositionFeatures();
+        return imeController;
     }
 
     // An element that leaves the DOM keeps its IME controller alive via this
@@ -148,6 +149,12 @@ export class TextInputManager {
         }
     }
 
+    /**
+     * Pure query: find the focused editable element, descending into same-origin
+     * iframes/objects. Returns null if there's no match (or a cross-origin
+     * boundary blocks the walk). Creates nothing — controller creation is the
+     * caller's job via `ensureController`.
+     */
     private getActiveElement(document: Document): HTMLElement | null {
         const isActiveElementInChildDocument =
             document.activeElement &&
@@ -170,7 +177,6 @@ export class TextInputManager {
         }
 
         if (element instanceof HTMLElement && element.matches(textInputElementsSelector)) {
-            this.processElement(element);
             return element;
         }
 


### PR DESCRIPTION
## Summary

`TextInputManager.getActiveElement()` was named and typed like a getter but created and registered a `HangulImeController` as a side effect (and lazily started the removal `MutationObserver`) — and because it recurses into same-origin iframes, that mutation could fire at any depth of the walk. This separates the concerns.

- **`getActiveElement` is now a pure query**: it locates the focused editable element (descending into same-origin frames), returns it, and creates nothing.
- **Controller creation moves into `ensureController`** (renamed from `processElement`), which now returns the controller. It is the single place that creates controllers and syncs their active state to the current mode.
- **Callers updated:** `setActiveElement` and `enterCharacter` call `ensureController` explicitly. The `InsertTextAfterSelection` path only needed the element, so it no longer triggers wasted controller creation.

## Behaviour is unchanged

Previously the getter's side effect meant `enterCharacter`'s controller always already existed by the time it did `imeControllers.get(...)` — so its `if (!controller) return false` was effectively dead. Now `enterCharacter` creates the controller explicitly via `ensureController`, reaching the same end state.

## Tests

- The existing DOM-removal cleanup test (controller disposed when its element leaves the DOM) still passes — confirms `setActiveElement` → `ensureController` still creates the controller and starts the observer.
- New: `enterCharacter` returns `false` when nothing is focused, and creates the controller itself for a focused input **without a prior `setActiveElement`** — proving the explicit creation path works rather than relying on a getter side effect.

Gate: `check` + `lint` + `test` (148 passing) + `build-dev` all green.

Closes #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)