### PR TITLE
Reword Options page for clarity (#43)

### DIFF
--- a/src/options-app/HanYongSection.vue
+++ b/src/options-app/HanYongSection.vue
@@ -1,15 +1,30 @@
 <script setup lang="ts">
 import { settings } from "./use-settings";
+import { Persistence } from "../settings/settings";
 import PersistenceSelect from "./PersistenceSelect.vue";
+
+const optionLabels: Record<Persistence, string> = {
+    [Persistence.AlwaysOff]: "Start in Latin",
+    [Persistence.AlwaysOn]: "Start in Hangul",
+    [Persistence.KeepLastState]: "Restore last mode",
+};
 </script>
 
 <template>
     <section>
         <h2>Han/Yong (한/영) toggle</h2>
+        <p class="description section-hint">Switches between Hangul and Latin input.</p>
         <PersistenceSelect
             v-model="settings.hanYong.persistence"
-            label="Persistence between sessions"
-            description="State of the Han/Yong toggle when the browser starts."
+            label="When the browser starts"
+            :option-labels="optionLabels"
         />
     </section>
 </template>
+
+<style scoped>
+.section-hint {
+    margin-top: -0.25em;
+    margin-bottom: 0.75em;
+}
+</style>

--- a/src/options-app/OnScreenKeyboardSection.vue
+++ b/src/options-app/OnScreenKeyboardSection.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 import { settings } from "./use-settings";
+import { Persistence } from "../settings/settings";
 import PersistenceSelect from "./PersistenceSelect.vue";
+
+const optionLabels: Record<Persistence, string> = {
+    [Persistence.AlwaysOff]: "Start hidden",
+    [Persistence.AlwaysOn]: "Start shown",
+    [Persistence.KeepLastState]: "Restore last state",
+};
 </script>
 
 <template>
@@ -8,8 +15,8 @@ import PersistenceSelect from "./PersistenceSelect.vue";
         <h2>On-screen keyboard</h2>
         <PersistenceSelect
             v-model="settings.onScreenKeyboard.persistence"
-            label="Persistence between sessions"
-            description="State of the on-screen keyboard when the browser starts."
+            label="When the browser starts"
+            :option-labels="optionLabels"
         />
     </section>
 </template>

--- a/src/options-app/PersistenceSelect.vue
+++ b/src/options-app/PersistenceSelect.vue
@@ -1,18 +1,23 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { Persistence } from "../settings/settings";
 
-defineProps<{
+const props = defineProps<{
     label: string;
+    // Display text for each persistence value, supplied per feature so the
+    // wording can be specific (e.g. "Start in Hangul" vs "Start shown").
+    optionLabels: Record<Persistence, string>;
     description?: string;
 }>();
 
 const model = defineModel<Persistence>({ required: true });
 
-const options: { value: Persistence; name: string }[] = [
-    { value: Persistence.AlwaysOff, name: "Always off" },
-    { value: Persistence.AlwaysOn, name: "Always on" },
-    { value: Persistence.KeepLastState, name: "Keep last state" },
-];
+// Fixed order, names from the per-feature prop.
+const options = computed(() => [
+    { value: Persistence.AlwaysOff, name: props.optionLabels[Persistence.AlwaysOff] },
+    { value: Persistence.AlwaysOn, name: props.optionLabels[Persistence.AlwaysOn] },
+    { value: Persistence.KeepLastState, name: props.optionLabels[Persistence.KeepLastState] },
+]);
 </script>
 
 <template>

--- a/src/options-app/options-page.vue
+++ b/src/options-app/options-page.vue
@@ -10,15 +10,15 @@ onMounted(initSettings);
 
 <template>
     <main>
-        <h1>Korean IME options</h1>
+        <h1>Korean IME Options</h1>
         <OnScreenKeyboardSection />
         <HanYongSection />
         <section>
             <h2>General</h2>
             <LabeledCheckbox
                 v-model="settings.shareAcrossTabs"
-                label="Share state across tabs"
-                description="Apply on-screen keyboard and Han/Yong changes to every tab at once, not just the focused one."
+                label="Share status across tabs"
+                description="When you turn the on-screen keyboard or Han/Yong mode on or off, apply it to every tab at once, not just the focused one."
             />
         </section>
     </main>


### PR DESCRIPTION
## Summary

Replaces developer jargon and ambiguous control text on the Options page with plain language. Wording only — no behaviour or settings-model change.

### Before → After

| | Before | After |
|---|---|---|
| Persistence label | Persistence between sessions | **When the browser starts** |
| OSK options | Always off / Always on / Keep last state | **Start hidden / Start shown / Restore last state** |
| Han/Yong options | Always off / Always on / Keep last state | **Start in Latin / Start in Hangul / Restore last mode** |
| Han/Yong section | (no hint) | adds **"Switches between Hangul and Latin input."** |
| Share setting | Share state across tabs | **Share status across tabs** (+ expanded description) |
| Page title | Korean IME options | **Korean IME Options** |

### Why

- **"Persistence between sessions"** was the most prominent text and the most jargony; **"When the browser starts"** is self-explanatory and the dropdown options now read as natural completions of it.
- **"Always off/on"** was ambiguous ("off/on *what*?") — especially for Han/Yong, where "Always on" = "start in Hangul" wasn't obvious. Per-feature option wording fixes that.
- Dropped the per-section descriptions ("State of the … when the browser starts") — the new label + explicit options say it better, and the old text actually *undersold* "Restore last state" (the only option that's really about restart).
- Disambiguated the overloaded word **"state"** in the share setting.

### Implementation note

`PersistenceSelect` previously hardcoded the three option names; it now takes an `optionLabels: Record<Persistence, string>` prop so each section supplies its own wording.

## Tests / verification

Gate: `check` + `lint` + `test` (148 passing) + `build-dev` all green.

Manual check recommended (the options page calls `chrome.storage` on mount, so it needs the real extension, not a plain preview): load `dist-dev/`, open Options, confirm the new wording reads correctly and the dropdowns still drive the same behaviour.

Follow-up: #44 will lift these (now-finalised) strings into `_locales` for i18n.

Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)