### PR TITLE
Localize the Options page via chrome.i18n, with Korean translations (#44)

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -40,5 +40,47 @@
     },
     "keyboard_key_controlRight_tooltip": {
         "message": "Convert the selected Hangul to Hanja"
+    },
+    "options_title": {
+        "message": "Korean IME Options"
+    },
+    "options_onScreenKeyboard_heading": {
+        "message": "On-screen keyboard"
+    },
+    "options_hanYong_heading": {
+        "message": "Han/Yong (한/영) toggle"
+    },
+    "options_hanYong_hint": {
+        "message": "Switches between Hangul and Latin input."
+    },
+    "options_persistence_label": {
+        "message": "When the browser starts"
+    },
+    "options_onScreenKeyboard_startOff": {
+        "message": "Start hidden"
+    },
+    "options_onScreenKeyboard_startOn": {
+        "message": "Start shown"
+    },
+    "options_onScreenKeyboard_restore": {
+        "message": "Restore last state"
+    },
+    "options_hanYong_startOff": {
+        "message": "Start in Latin"
+    },
+    "options_hanYong_startOn": {
+        "message": "Start in Hangul"
+    },
+    "options_hanYong_restore": {
+        "message": "Restore last mode"
+    },
+    "options_general_heading": {
+        "message": "General"
+    },
+    "options_shareAcrossTabs_label": {
+        "message": "Share status across tabs"
+    },
+    "options_shareAcrossTabs_description": {
+        "message": "When you turn the on-screen keyboard or Han/Yong mode on or off, apply it to every tab at once, not just the focused one."
     }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -66,7 +66,7 @@
         "message": "Restore last state"
     },
     "options_hanYong_startOff": {
-        "message": "Start in Latin"
+        "message": "Start in English"
     },
     "options_hanYong_startOn": {
         "message": "Start in Hangul"

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -34,5 +34,47 @@
     },
     "keyboard_key_controlRight_tooltip": {
         "message": "선택한 한글을 한자로 변환하십시오"
+    },
+    "options_title": {
+        "message": "한글 입력기 설정"
+    },
+    "options_onScreenKeyboard_heading": {
+        "message": "화면 키보드"
+    },
+    "options_hanYong_heading": {
+        "message": "한/영 전환"
+    },
+    "options_hanYong_hint": {
+        "message": "한글과 로마자 입력을 전환합니다."
+    },
+    "options_persistence_label": {
+        "message": "브라우저를 시작할 때"
+    },
+    "options_onScreenKeyboard_startOff": {
+        "message": "숨긴 상태로 시작"
+    },
+    "options_onScreenKeyboard_startOn": {
+        "message": "표시된 상태로 시작"
+    },
+    "options_onScreenKeyboard_restore": {
+        "message": "마지막 상태 유지"
+    },
+    "options_hanYong_startOff": {
+        "message": "로마자로 시작"
+    },
+    "options_hanYong_startOn": {
+        "message": "한글로 시작"
+    },
+    "options_hanYong_restore": {
+        "message": "마지막 모드 유지"
+    },
+    "options_general_heading": {
+        "message": "일반"
+    },
+    "options_shareAcrossTabs_label": {
+        "message": "모든 탭에서 상태 공유"
+    },
+    "options_shareAcrossTabs_description": {
+        "message": "화면 키보드나 한/영 모드를 켜거나 끄면 현재 탭뿐만 아니라 모든 탭에 동시에 적용됩니다."
     }
 }

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -30,7 +30,7 @@
         "message": "위에 입력하신 한글이 여기에 로마자로 나타납니다"
     },
     "keyboard_key_altRight_tooltip": {
-        "message": "영어와 한글 사이를 전환"
+        "message": "영문과 한글 사이를 전환"
     },
     "keyboard_key_controlRight_tooltip": {
         "message": "선택한 한글을 한자로 변환하십시오"
@@ -60,7 +60,7 @@
         "message": "마지막 상태 유지"
     },
     "options_hanYong_startOff": {
-        "message": "로마자로 시작"
+        "message": "영문으로 시작"
     },
     "options_hanYong_startOn": {
         "message": "한글로 시작"

--- a/src/options-app/HanYongSection.vue
+++ b/src/options-app/HanYongSection.vue
@@ -1,22 +1,23 @@
 <script setup lang="ts">
 import { settings } from "./use-settings";
 import { Persistence } from "../settings/settings";
+import { t } from "./i18n";
 import PersistenceSelect from "./PersistenceSelect.vue";
 
 const optionLabels: Record<Persistence, string> = {
-    [Persistence.AlwaysOff]: "Start in Latin",
-    [Persistence.AlwaysOn]: "Start in Hangul",
-    [Persistence.KeepLastState]: "Restore last mode",
+    [Persistence.AlwaysOff]: t("options_hanYong_startOff"),
+    [Persistence.AlwaysOn]: t("options_hanYong_startOn"),
+    [Persistence.KeepLastState]: t("options_hanYong_restore"),
 };
 </script>
 
 <template>
     <section>
-        <h2>Han/Yong (한/영) toggle</h2>
-        <p class="description section-hint">Switches between Hangul and Latin input.</p>
+        <h2>{{ t("options_hanYong_heading") }}</h2>
+        <p class="description section-hint">{{ t("options_hanYong_hint") }}</p>
         <PersistenceSelect
             v-model="settings.hanYong.persistence"
-            label="When the browser starts"
+            :label="t('options_persistence_label')"
             :option-labels="optionLabels"
         />
     </section>

--- a/src/options-app/OnScreenKeyboardSection.vue
+++ b/src/options-app/OnScreenKeyboardSection.vue
@@ -1,21 +1,22 @@
 <script setup lang="ts">
 import { settings } from "./use-settings";
 import { Persistence } from "../settings/settings";
+import { t } from "./i18n";
 import PersistenceSelect from "./PersistenceSelect.vue";
 
 const optionLabels: Record<Persistence, string> = {
-    [Persistence.AlwaysOff]: "Start hidden",
-    [Persistence.AlwaysOn]: "Start shown",
-    [Persistence.KeepLastState]: "Restore last state",
+    [Persistence.AlwaysOff]: t("options_onScreenKeyboard_startOff"),
+    [Persistence.AlwaysOn]: t("options_onScreenKeyboard_startOn"),
+    [Persistence.KeepLastState]: t("options_onScreenKeyboard_restore"),
 };
 </script>
 
 <template>
     <section>
-        <h2>On-screen keyboard</h2>
+        <h2>{{ t("options_onScreenKeyboard_heading") }}</h2>
         <PersistenceSelect
             v-model="settings.onScreenKeyboard.persistence"
-            label="When the browser starts"
+            :label="t('options_persistence_label')"
             :option-labels="optionLabels"
         />
     </section>

--- a/src/options-app/i18n.test.ts
+++ b/src/options-app/i18n.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment node
+ */
+import { t } from "./i18n";
+
+afterEach(() => {
+    delete (globalThis as { chrome?: unknown }).chrome;
+});
+
+function mockI18n(messages: Record<string, string>) {
+    // getMessage returns "" for unknown keys, matching chrome.i18n.
+    Object.assign(globalThis, {
+        chrome: { i18n: { getMessage: (key: string) => messages[key] ?? "" } },
+    });
+}
+
+describe("t", () => {
+    it("returns the localized message when chrome.i18n is available", () => {
+        mockI18n({ options_title: "한글 입력기 설정" });
+
+        expect(t("options_title")).toBe("한글 입력기 설정");
+    });
+
+    it("preserves an intentionally-empty translation instead of falling back to the key", () => {
+        mockI18n({ some_optional_hint: "" });
+
+        expect(t("some_optional_hint")).toBe("");
+    });
+
+    it("returns the key unchanged when chrome.i18n is unavailable", () => {
+        // no chrome on globalThis (test/preview runtime)
+        expect(t("options_title")).toBe("options_title");
+    });
+});

--- a/src/options-app/i18n.ts
+++ b/src/options-app/i18n.ts
@@ -4,9 +4,13 @@
  * `src/_locales/<locale>/messages.json`; Chrome falls back to the default
  * locale (en) for any key a locale doesn't define.
  *
- * The `chrome?.i18n` guard keeps this usable outside the extension runtime
- * (e.g. a unit test or a plain preview), where it returns the key unchanged.
+ * Outside the extension runtime (a unit test or a plain preview) `chrome.i18n`
+ * is absent, so the key is returned unchanged. We only fall back when i18n is
+ * unavailable — not when the resolved message is falsy — because an empty
+ * string can be an intentional translation (e.g. a hint omitted in some
+ * locales); `|| key` would wrongly render the key name in that case.
  */
 export function t(key: string): string {
-    return globalThis.chrome?.i18n?.getMessage(key) || key;
+    const i18n = globalThis.chrome?.i18n;
+    return i18n ? i18n.getMessage(key) : key;
 }

--- a/src/options-app/i18n.ts
+++ b/src/options-app/i18n.ts
@@ -1,0 +1,12 @@
+/**
+ * Resolve a localized message for the options page via `chrome.i18n`, mirroring
+ * how the romanize popup localizes its strings. Keys live in
+ * `src/_locales/<locale>/messages.json`; Chrome falls back to the default
+ * locale (en) for any key a locale doesn't define.
+ *
+ * The `chrome?.i18n` guard keeps this usable outside the extension runtime
+ * (e.g. a unit test or a plain preview), where it returns the key unchanged.
+ */
+export function t(key: string): string {
+    return globalThis.chrome?.i18n?.getMessage(key) || key;
+}

--- a/src/options-app/options-page.vue
+++ b/src/options-app/options-page.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { onMounted } from "vue";
 import { initSettings, settings } from "./use-settings";
+import { t } from "./i18n";
 import OnScreenKeyboardSection from "./OnScreenKeyboardSection.vue";
 import HanYongSection from "./HanYongSection.vue";
 import LabeledCheckbox from "./LabeledCheckbox.vue";
@@ -10,15 +11,15 @@ onMounted(initSettings);
 
 <template>
     <main>
-        <h1>Korean IME Options</h1>
+        <h1>{{ t("options_title") }}</h1>
         <OnScreenKeyboardSection />
         <HanYongSection />
         <section>
-            <h2>General</h2>
+            <h2>{{ t("options_general_heading") }}</h2>
             <LabeledCheckbox
                 v-model="settings.shareAcrossTabs"
-                label="Share status across tabs"
-                description="When you turn the on-screen keyboard or Han/Yong mode on or off, apply it to every tab at once, not just the focused one."
+                :label="t('options_shareAcrossTabs_label')"
+                :description="t('options_shareAcrossTabs_description')"
             />
         </section>
     </main>


### PR DESCRIPTION
## Summary

The Options page hardcoded English strings in the `.vue` files, so it couldn't be translated — unlike the romanize popup, which already uses `chrome.i18n`. This lifts every user-facing options string into `_locales` and adds full **Korean** translations.

## Changes

- **`src/options-app/i18n.ts`** — a small `t(key)` helper wrapping `chrome.i18n.getMessage`, with a `chrome?.i18n` guard so it returns the key unchanged outside the extension runtime (tests / plain preview).
- **`_locales/en/messages.json`** — 14 new `options_*` keys (title, section headings, Han/Yong hint, persistence label, per-feature dropdown options, share setting label + description).
- **`_locales/ko/messages.json`** — Korean translations for all 14, e.g.:
  - `한글 입력기 설정` (title), `화면 키보드`, `한/영 전환`
  - `브라우저를 시작할 때` (When the browser starts)
  - `숨긴 상태로 시작` / `표시된 상태로 시작` / `마지막 상태 유지` (OSK options)
  - `로마자로 시작` / `한글로 시작` / `마지막 모드 유지` (Han/Yong options)
  - `모든 탭에서 상태 공유` (Share status across tabs)
- **`options-page.vue`, `OnScreenKeyboardSection.vue`, `HanYongSection.vue`** — literals replaced with `t(...)` lookups.

`en_GB` needs no additions — none of the options strings differ in British spelling, so they fall back to `en` via Chrome's default-locale mechanism.

## Verification

- en/ko JSON validated; all 14 `options_*` keys present in both (parity checked).
- `t()` fallback verified: returns the key when `chrome` is absent, resolves the message when present.
- Gate: `check` + `lint` + `test` (148 passing) + `build-dev` all green; `_locales` ship in the build.

Manual check recommended: load `dist-dev/`, open Options in English; then set Chrome's UI language to Korean (or the locale) and confirm the page renders in Korean.

Note: a couple of *pre-existing* gaps in `ko` (`extension_short_name`, `menu_onScreenKeyboard`) are unrelated to this change and continue to fall back to `en`.

Closes #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)