### PR TITLE
Add launch configurations for extension debugging (#50)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Extension in Dev Chrome",
+            "type": "chrome",
+            "request": "attach",
+            "address": "localhost",
+            "port": 9222,
+            "webRoot": "${workspaceFolder}",
+            "urlFilter": "http*://*/*",
+            "preLaunchTask": "Start Dev Chrome",
+            "postDebugTask": "Stop Dev Chrome"
+        },
+        {
+            "name": "Debug Options Page in Dev Chrome",
+            "type": "chrome",
+            "request": "attach",
+            "address": "localhost",
+            "port": 9222,
+            "webRoot": "${workspaceFolder}",
+            "urlFilter": "chrome-extension://*/options-app*.html*",
+            "preLaunchTask": "Start Dev Chrome",
+            "postDebugTask": "Stop Dev Chrome"
+        },
+        {
+            "name": "Debug Popup Converter in Dev Chrome",
+            "type": "chrome",
+            "request": "attach",
+            "address": "localhost",
+            "port": 9222,
+            "webRoot": "${workspaceFolder}",
+            "urlFilter": "chrome-extension://*/popup-converter*.html*",
+            "preLaunchTask": "Start Dev Chrome",
+            "postDebugTask": "Stop Dev Chrome"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
         "texteventtarget",
         "vars"
     ],
+    "debug.javascript.autoAttachFilter": "onlyWithFlag",
     "editor.codeActionsOnSave": {
         "source.fixAll": "explicit"
     }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,46 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Start Dev Chrome",
+            "type": "npm",
+            "script": "dev",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "problemMatcher": {
+                "owner": "custom",
+                "fileLocation": "autoDetect",
+                "source": "korean-ime-dev",
+                "pattern": {
+                    "regexp": "^(__never_match__):(\\d+):(\\d+):(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "message": 4
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^\\[dev\\] Word for the Web adapter:",
+                    "endsPattern": "^\\[dev\\] VS Code debugger target ready\\.$"
+                }
+            }
+        },
+        {
+            "label": "Stop Dev Chrome",
+            "type": "process",
+            "command": "node",
+            "args": [
+                "scripts/stop-dev.mjs"
+            ],
+            "presentation": {
+                "reveal": "never",
+                "panel": "dedicated",
+                "close": true
+            },
+            "problemMatcher": []
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ npm run dev -- --enable-word
 
 This sets the `KIME_ENABLE_WORD` build flag (which Parcel inlines). For other builds, set the env var directly, e.g. `KIME_ENABLE_WORD=true npm run build-dev`.
 
+#### Debugging in VS Code
+
+`npm run dev` launches Chrome with the DevTools remote debugging port enabled on `localhost:9222`.
+
+Press `F5` with one of these configs selected:
+
+1. **Debug Extension in Dev Chrome** for content-script debugging on normal `http` and `https` pages
+2. **Debug Options Page in Dev Chrome** for the extension settings page
+3. **Debug Popup Converter in Dev Chrome** for the popup converter window
+
+Stopping any of those debug sessions from VS Code also shuts down the matching Chrome/dev task.
+
+If VS Code auto-attaches to `scripts/dev.mjs`, change the terminal's **Auto Attach** mode to **Only With Flag** or turn it off for that terminal. Auto Attach only targets the Node launcher; Chrome debugging uses the workspace launch configuration above.
+
 ### Releasing
 
 See [RELEASING.md](RELEASING.md) for the step-by-step release checklist.

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -242,7 +242,12 @@ chrome.on("exit", () => {
     shutdown(0);
 });
 
-await waitForChromePageTarget(chromeDebugPort, testUrl);
+try {
+    await waitForChromePageTarget(chromeDebugPort, testUrl);
+} catch (err) {
+    console.error(err instanceof Error ? err.message : err);
+    shutdown(1);
+}
 
 if (firstRun) {
     console.log("\n[dev] First run on this dev profile — load the extension once:");

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -17,11 +17,12 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { createServer } from "node:http";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import * as ChromeLauncher from "chrome-launcher";
 
 const root = process.cwd();
+const DEFAULT_CHROME_DEBUG_PORT = 9222;
 // Dev builds go to dist-dev/ so they can never be mistaken for, or clobber, the
 // production dist/ that `npm run package` ships. Keep this in sync with the
 // --dist-dir in the "start" npm script.
@@ -37,7 +38,45 @@ function wordAdapterRequested() {
     if (cfg !== undefined && cfg !== "false" && cfg !== "0") return true;
     return process.env.KIME_ENABLE_WORD === "true";
 }
+
+function getChromeDebugPort() {
+    const rawPort = process.env.KIME_CHROME_DEBUG_PORT ?? process.env.CHROME_DEBUG_PORT;
+    if (rawPort === undefined || rawPort.trim() === "") return DEFAULT_CHROME_DEBUG_PORT;
+
+    const port = Number(rawPort);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        throw new Error(`Invalid Chrome debug port: ${rawPort}`);
+    }
+
+    return port;
+}
+
+async function waitForChromePageTarget(port, url, timeout = 10000) {
+    const endpoint = `http://127.0.0.1:${port}/json/list`;
+    const deadline = Date.now() + timeout;
+
+    while (Date.now() < deadline) {
+        try {
+            const response = await fetch(endpoint);
+            if (response.ok) {
+                const targets = await response.json();
+                if (Array.isArray(targets) && targets.some((target) => target?.type === "page" && target?.url === url)) {
+                    return;
+                }
+            }
+        } catch {
+            // Chrome starts listening on the debugging port before it publishes targets.
+        }
+
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
+    }
+
+    throw new Error(`[dev] Timed out waiting for a Chrome page target at ${endpoint}.`);
+}
+
 const profileDir = resolve(root, ".chrome-profile");
+const sessionFile = resolve(profileDir, "dev-session.json");
+const chromeDebugPort = getChromeDebugPort();
 
 const TEST_PAGE = `<!DOCTYPE html>
 <html lang="en">
@@ -75,6 +114,27 @@ let watch;
 let chrome;
 let shuttingDown = false;
 
+function removeSessionFile() {
+    rmSync(sessionFile, { force: true });
+}
+
+function writeSessionFile(chromePid) {
+    writeFileSync(
+        sessionFile,
+        JSON.stringify(
+            {
+                devPid: process.pid,
+                chromePid,
+                debugPort: chromeDebugPort,
+                startedAt: new Date().toISOString(),
+                testUrl,
+            },
+            null,
+            2,
+        ),
+    );
+}
+
 // child.kill() only kills the immediate process. `npm start` runs through a
 // shell and spawns Parcel underneath, so on Windows we must kill the whole tree
 // or Parcel keeps holding the HMR port (1234) after we exit.
@@ -94,6 +154,7 @@ function killTree(proc) {
 function shutdown(code = 0) {
     if (shuttingDown) return;
     shuttingDown = true;
+    removeSessionFile();
     killTree(chrome);
     killTree(watch);
     server?.close();
@@ -157,12 +218,20 @@ if (!chromePath) {
 
 const firstRun = !existsSync(profileDir);
 mkdirSync(profileDir, { recursive: true });
+removeSessionFile();
 
 // On first run, also open the extensions page so the one-time load is easy.
 const urls = firstRun ? ["chrome://extensions", testUrl] : [testUrl];
-const args = [`--user-data-dir=${profileDir}`, "--no-first-run", "--no-default-browser-check", ...urls];
+const args = [
+    `--user-data-dir=${profileDir}`,
+    `--remote-debugging-port=${chromeDebugPort}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    ...urls,
+];
 
 chrome = spawn(chromePath, args, { stdio: "ignore" });
+writeSessionFile(chrome.pid ?? null);
 const launchedAt = Date.now();
 
 chrome.on("exit", () => {
@@ -173,6 +242,8 @@ chrome.on("exit", () => {
     shutdown(0);
 });
 
+await waitForChromePageTarget(chromeDebugPort, testUrl);
+
 if (firstRun) {
     console.log("\n[dev] First run on this dev profile — load the extension once:");
     console.log("[dev]   1. On the chrome://extensions tab, turn on \"Developer mode\" (top right).");
@@ -182,5 +253,7 @@ if (firstRun) {
 }
 console.log(`\n[dev] Dev profile:  ${profileDir}`);
 console.log(`[dev] Extension:    ${distDir}`);
+console.log(`[dev] Debug port:   ${chromeDebugPort}`);
 console.log(`[dev] Test page:    ${testUrl}`);
+console.log("[dev] VS Code debugger target ready.");
 console.log("[dev] Edit & save to rebuild (auto-reloads). Close Chrome or press Ctrl+C to stop.\n");

--- a/scripts/stop-dev.mjs
+++ b/scripts/stop-dev.mjs
@@ -1,0 +1,57 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+
+const sessionFile = resolve(process.cwd(), ".chrome-profile", "dev-session.json");
+
+function readSession() {
+    if (!existsSync(sessionFile)) return null;
+
+    try {
+        return JSON.parse(readFileSync(sessionFile, "utf8"));
+    } catch {
+        return null;
+    }
+}
+
+function killTree(pid) {
+    if (!Number.isInteger(pid) || pid <= 0) return;
+
+    if (process.platform === "win32") {
+        spawnSync("taskkill", ["/pid", String(pid), "/T", "/F"], { stdio: "ignore" });
+        return;
+    }
+
+    try {
+        process.kill(pid, "SIGTERM");
+    } catch {
+        /* already gone */
+    }
+}
+
+async function waitForSessionFileToClear(timeout = 5000) {
+    const deadline = Date.now() + timeout;
+
+    while (Date.now() < deadline) {
+        if (!existsSync(sessionFile)) return true;
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
+    }
+
+    return !existsSync(sessionFile);
+}
+
+const session = readSession();
+if (!session) {
+    console.log("[stop-dev] No active dev session found.");
+    process.exit(0);
+}
+
+killTree(session.chromePid);
+
+if (!(await waitForSessionFileToClear())) {
+    killTree(session.devPid);
+    await waitForSessionFileToClear(1000);
+}
+
+rmSync(sessionFile, { force: true });
+console.log("[stop-dev] Dev session stopped.");


### PR DESCRIPTION
* added launch.json and supporting files with three configs
    * Debug Extension
    * Debug Options Page
    * Debug Popup Converter
* to attach a debugger to a node script now requires using `--inspect` e.g. `node --inspect some_script.js`