### PR TITLE
Introduce a neutral browser API handle (#52)

### DIFF
--- a/src/content-script/content-script-controller.ts
+++ b/src/content-script/content-script-controller.ts
@@ -14,6 +14,7 @@ import {
     TabStateMessage,
     isServiceScriptMessage,
 } from "../messaging/service-to-content-messages";
+import { api } from "../platform/browser-api";
 
 export class ContentScriptController {
     private textEntryMode = KoreanKeyboardMode.English;
@@ -25,7 +26,7 @@ export class ContentScriptController {
             ? new OnScreenKeyboardController((key, keyCode) => {
                   const handled = this.textInputManager.enterCharacter(key, keyCode);
                   if (!handled) {
-                      chrome.runtime.sendMessage<ContentScriptRequestMessage>({
+                      api.runtime.sendMessage<ContentScriptRequestMessage>({
                           type: "contentScriptRequest",
                           action: ContentScriptRequestAction.SendKey,
                           data: { key, keyCode },
@@ -40,14 +41,14 @@ export class ContentScriptController {
     }
 
     private requestState() {
-        chrome.runtime.sendMessage<ContentScriptRequestMessage>({
+        api.runtime.sendMessage<ContentScriptRequestMessage>({
             type: "contentScriptRequest",
             action: ContentScriptRequestAction.RefreshState,
         });
     }
 
     private setupMessageListener() {
-        chrome.runtime.onMessage.addListener((message) => {
+        api.runtime.onMessage.addListener((message) => {
             debugLog("content.js: received message", message);
 
             if (isServiceScriptMessage(message)) {
@@ -87,7 +88,7 @@ export class ContentScriptController {
             "keydown",
             (e) => {
                 if (e.code === KeyCode.AltRight && !e.repeat) {
-                    chrome.runtime.sendMessage<ContentScriptRequestMessage>({
+                    api.runtime.sendMessage<ContentScriptRequestMessage>({
                         type: "contentScriptRequest",
                         action: ContentScriptRequestAction.ToggleHanYongMode,
                     });
@@ -109,7 +110,7 @@ export class ContentScriptController {
                     return;
                 }
 
-                chrome.runtime.sendMessage<ContentScriptBroadcastMessage>({
+                api.runtime.sendMessage<ContentScriptBroadcastMessage>({
                     type: "broadcast",
                     action: ContentScriptBroadcastAction.UpdateCompositionFeatures,
                     data: compositionFeatures,

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
@@ -5,6 +5,7 @@ import { SupportedCompositionFeatures } from "../../composition/composition-adap
 import "./on-screen-keyboard.scss";
 import { ContentScriptRequestAction, ContentScriptRequestMessage } from "../../messaging/content-to-service-messages";
 import { debugLog } from "../../debug-log";
+import { api } from "../../platform/browser-api";
 
 export class OnScreenKeyboardController {
     private _keyboardElement: HTMLDivElement;
@@ -274,7 +275,7 @@ export class OnScreenKeyboardController {
         } else if (key.label === "Shift") {
             this.setShift(!isShift);
         } else if (keyCode === KeyCode.AltRight) {
-            chrome.runtime.sendMessage<ContentScriptRequestMessage>({
+            api.runtime.sendMessage<ContentScriptRequestMessage>({
                 type: "contentScriptRequest",
                 action: ContentScriptRequestAction.ToggleHanYongMode,
             });
@@ -356,7 +357,7 @@ export class OnScreenKeyboardController {
         this.renderSpecialKeyLabels(keyElement, key, keyCode);
 
         if (key.tooltipResourceKey) {
-            keyElement.title = chrome.i18n.getMessage(key.tooltipResourceKey);
+            keyElement.title = api.i18n.getMessage(key.tooltipResourceKey);
         }
 
         rowElement.appendChild(keyElement);

--- a/src/platform/browser-api.ts
+++ b/src/platform/browser-api.ts
@@ -1,0 +1,30 @@
+/**
+ * Neutral handle for the extension (WebExtension) API.
+ *
+ * Chrome exposes only `chrome.*`; Firefox exposes promise-based `browser.*`
+ * (and a `chrome.*` compat alias). Both namespaces are shape-identical and
+ * promise-based for the surface this extension uses, so call sites import `api`
+ * instead of naming a concrete global. This localizes the platform dependency
+ * to one module — groundwork for a future Firefox build.
+ *
+ * Selection is runtime (prefer `browser` when present). It's a Proxy rather than
+ * a captured reference so lookup is lazy per-access: unit tests install their
+ * `chrome` mock after this module is imported, and a Proxy picks it up where a
+ * module-load-time capture would freeze `undefined`.
+ *
+ * Typed as `typeof chrome` (from @types/chrome) — accurate for the common,
+ * identically-shaped subset we use. `browser` satisfies the same shape.
+ */
+const resolveApi = (): typeof chrome => {
+    const candidate = (globalThis as { browser?: typeof chrome }).browser ?? globalThis.chrome;
+    if (!candidate) {
+        throw new Error("No WebExtension API (browser/chrome) available");
+    }
+    return candidate;
+};
+
+export const api: typeof chrome = new Proxy({} as typeof chrome, {
+    get(_target, prop) {
+        return resolveApi()[prop as keyof typeof chrome];
+    },
+});

--- a/src/service-worker/action.ts
+++ b/src/service-worker/action.ts
@@ -1,7 +1,8 @@
 import { StateManager } from "./state-manager";
+import { api } from "../platform/browser-api";
 
 export function setupActionListener(stateManager: StateManager) {
-    chrome.action.onClicked.addListener((tab) => {
+    api.action.onClicked.addListener((tab) => {
         if (!tab.id) {
             return;
         }

--- a/src/service-worker/content-script-listener.ts
+++ b/src/service-worker/content-script-listener.ts
@@ -10,6 +10,7 @@ import {
     ContentScriptBroadcastMessage,
     isContentScriptBroadcastMessage,
 } from "../messaging/content-to-content-messages";
+import { api } from "../platform/browser-api";
 
 /**
  * This class is responsible for listening to messages from the content script.
@@ -27,7 +28,7 @@ export class ContentScriptListener {
         this.isListening = true;
 
         // listen for ContentScriptRequest messages and handle them
-        chrome.runtime.onMessage.addListener(
+        api.runtime.onMessage.addListener(
             (message: ContentScriptRequestMessage | ContentScriptBroadcastMessage, sender) => {
                 debugLog("ContentScriptListener received message: ", message);
 
@@ -64,7 +65,7 @@ export class ContentScriptListener {
         // presentation. The listener stays synchronous (the event ignores a
         // returned promise), so detach and log rather than leaking an unhandled
         // rejection into the service worker.
-        chrome.tabs.onActivated.addListener((activeInfo) => {
+        api.tabs.onActivated.addListener((activeInfo) => {
             void (async () => {
                 await this.stateManager.markTabActive(activeInfo.tabId);
                 await this.stateManager.sendStateToTab(activeInfo.tabId);
@@ -72,7 +73,7 @@ export class ContentScriptListener {
         });
 
         // discard a tab's state when it closes so it doesn't accumulate
-        chrome.tabs.onRemoved.addListener((tabId) => {
+        api.tabs.onRemoved.addListener((tabId) => {
             this.stateManager.clearTabState(tabId).catch((error) => debugLog("clearTabState failed:", error));
         });
     }

--- a/src/service-worker/menus.ts
+++ b/src/service-worker/menus.ts
@@ -1,6 +1,7 @@
 import { romanizeBeside, romanizeInPopup } from "./romanize-menu-actions";
 import { StateManager } from "./state-manager";
 import { debugLog } from "../debug-log";
+import { api } from "../platform/browser-api";
 
 export const menus = Object.freeze({
     onScreenKeyboard: {
@@ -15,7 +16,7 @@ export const menus = Object.freeze({
 });
 
 export function setupMenuListener(stateManager: StateManager) {
-    chrome.contextMenus.onClicked.addListener((event, tab) => {
+    api.contextMenus.onClicked.addListener((event, tab) => {
         if (!tab?.id) {
             return;
         }
@@ -49,26 +50,26 @@ export function setupMenuListener(stateManager: StateManager) {
  * removeAll-then-create sequences can still collide on duplicate ids.
  */
 export async function createMenus() {
-    await chrome.contextMenus.removeAll();
+    await api.contextMenus.removeAll();
 
-    chrome.contextMenus.create({
+    api.contextMenus.create({
         type: "normal",
         id: menus.romanizeInPopup.id,
-        title: chrome.i18n.getMessage(menus.romanizeInPopup.id),
+        title: api.i18n.getMessage(menus.romanizeInPopup.id),
         contexts: ["all"],
     });
 
-    chrome.contextMenus.create({
+    api.contextMenus.create({
         type: "normal",
         id: menus.romanizeBeside.id,
-        title: chrome.i18n.getMessage(menus.romanizeBeside.id),
+        title: api.i18n.getMessage(menus.romanizeBeside.id),
         contexts: ["editable"],
     });
 
-    chrome.contextMenus.create({
+    api.contextMenus.create({
         type: "checkbox",
         id: menus.onScreenKeyboard.id,
-        title: chrome.i18n.getMessage(menus.onScreenKeyboard.id),
+        title: api.i18n.getMessage(menus.onScreenKeyboard.id),
         contexts: ["all"],
     });
 }

--- a/src/service-worker/popup-converter/popup-converter.ts
+++ b/src/service-worker/popup-converter/popup-converter.ts
@@ -1,6 +1,7 @@
 import { HangulImeController } from "../../composition/hangul-ime-controller";
 import { romanize } from "../../romanization/romanize";
 import { PopupConverterData, popupConverterDataKey } from "./popup-converter-data";
+import { api } from "../../platform/browser-api";
 
 const original = document.getElementById("original") as HTMLDivElement,
     roman = document.getElementById("romanized") as HTMLDivElement,
@@ -17,7 +18,7 @@ void populateFromStorage();
  * The entry is removed once consumed so it doesn't linger in session storage.
  */
 async function populateFromStorage() {
-    const win = await chrome.windows.getCurrent();
+    const win = await api.windows.getCurrent();
     if (win.id === undefined) {
         return;
     }
@@ -26,17 +27,17 @@ async function populateFromStorage() {
     const apply = (data: PopupConverterData) => {
         original.innerText = data.original;
         roman.innerText = data.romanized;
-        void chrome.storage.session.remove(key);
+        void api.storage.session.remove(key);
     };
 
-    chrome.storage.session.onChanged.addListener((changes) => {
+    api.storage.session.onChanged.addListener((changes) => {
         const data = changes[key]?.newValue as PopupConverterData | undefined;
         if (data) {
             apply(data);
         }
     });
 
-    const existing = (await chrome.storage.session.get(key))[key] as PopupConverterData | undefined;
+    const existing = (await api.storage.session.get(key))[key] as PopupConverterData | undefined;
     if (existing) {
         apply(existing);
     }
@@ -60,12 +61,12 @@ original.addEventListener("paste", (event) => {
 
 document.querySelectorAll("[data-message]").forEach((el) => {
     const element = el as HTMLElement;
-    element.innerText = element.dataset.message ? chrome.i18n.getMessage(element.dataset.message) : "";
+    element.innerText = element.dataset.message ? api.i18n.getMessage(element.dataset.message) : "";
 });
 
 document.querySelectorAll("[data-placeholder-message]").forEach((el) => {
     const element = el as HTMLElement;
     element.dataset.placeholder = element.dataset.placeholderMessage
-        ? chrome.i18n.getMessage(element.dataset.placeholderMessage)
+        ? api.i18n.getMessage(element.dataset.placeholderMessage)
         : "";
 });

--- a/src/service-worker/romanize-menu-actions.ts
+++ b/src/service-worker/romanize-menu-actions.ts
@@ -3,6 +3,7 @@ import { PopupConverterData, popupConverterDataKey } from "./popup-converter/pop
 import { romanize } from "../romanization/romanize";
 import { sendMessageToTab } from "./send-message-to-tab";
 import popupConverter from "url:./popup-converter/popup-converter.html";
+import { api } from "../platform/browser-api";
 
 export async function romanizeInPopup(event: chrome.contextMenus.OnClickData) {
     const selectionText = event.selectionText || "";
@@ -11,7 +12,7 @@ export async function romanizeInPopup(event: chrome.contextMenus.OnClickData) {
         romanized: romanize(selectionText),
     };
 
-    const newWindow = await chrome.windows.create({
+    const newWindow = await api.windows.create({
         url: popupConverter,
         type: "popup",
         width: 600,
@@ -26,7 +27,7 @@ export async function romanizeInPopup(event: chrome.contextMenus.OnClickData) {
     // Hand the text off via storage rather than messaging the new window on a
     // timer: the popup reads it on load, so there's no load-timing race and no
     // dependence on the window having a content script listening yet.
-    await chrome.storage.session.set({ [popupConverterDataKey(newWindow.id)]: data });
+    await api.storage.session.set({ [popupConverterDataKey(newWindow.id)]: data });
 }
 
 export async function romanizeBeside(event: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab | undefined) {

--- a/src/service-worker/send-message-to-tab.ts
+++ b/src/service-worker/send-message-to-tab.ts
@@ -1,4 +1,5 @@
 import { debugLog } from "../debug-log";
+import { api } from "../platform/browser-api";
 
 // chrome.tabs.sendMessage rejects with "Receiving end does not exist" whenever
 // the target tab/frame has no content script listening — chrome:// pages, the
@@ -11,7 +12,7 @@ export async function sendMessageToTab<M>(
     options?: chrome.tabs.MessageSendOptions
 ): Promise<void> {
     try {
-        await chrome.tabs.sendMessage(tabId, message, options ?? {});
+        await api.tabs.sendMessage(tabId, message, options ?? {});
     } catch (error) {
         const frame = options?.frameId !== undefined ? ` (frame ${options.frameId})` : "";
         debugLog(`Failed to send message to tab ${tabId}${frame}:`, error);

--- a/src/service-worker/service-worker.ts
+++ b/src/service-worker/service-worker.ts
@@ -6,6 +6,7 @@ import { setupActionListener } from "./action";
 import { ContentScriptListener } from "./content-script-listener";
 import { settingsKeys } from "../settings/settings";
 import { debugLog } from "../debug-log";
+import { api } from "../platform/browser-api";
 
 const stateManager = new StateManager();
 const contentScriptListener = new ContentScriptListener(stateManager);
@@ -28,7 +29,7 @@ createMenus()
 // Registered synchronously at the top level so it can wake an idle MV3 service
 // worker. The single storage write is the broadcast — there is no explicit
 // options→service-worker message (see #25/#26).
-chrome.storage.onChanged.addListener((changes, areaName) => {
+api.storage.onChanged.addListener((changes, areaName) => {
     if (areaName !== "sync") {
         return;
     }

--- a/src/service-worker/state-manager.ts
+++ b/src/service-worker/state-manager.ts
@@ -12,6 +12,7 @@ import { sendMessageToTab } from "./send-message-to-tab";
 import { Persistence, Settings } from "../settings/settings";
 import { loadSettings } from "../settings/settings-store";
 import { debugLog } from "../debug-log";
+import { api } from "../platform/browser-api";
 
 /**
  * Global current live state (browser-session-lived). New tabs inherit it, and
@@ -40,18 +41,18 @@ const LAST_STATE_KEY = "lastState";
 export class StateManager {
     public constructor() {
         // ensure we are only referenced from the service worker
-        if (!chrome.runtime.onMessage) {
+        if (!api.runtime.onMessage) {
             throw new Error("StateManager can only be used from the service worker");
         }
     }
 
     public async setFocusedFrame(tabId: number, frameId: number) {
-        await chrome.storage.session.set({ [this.focusedFrameKey(tabId)]: frameId });
+        await api.storage.session.set({ [this.focusedFrameKey(tabId)]: frameId });
     }
 
     public async routeSendKey(tabId: number, data: SendKeyServiceMessage["data"]) {
         const key = this.focusedFrameKey(tabId);
-        const frameId = (await chrome.storage.session.get(key))[key] as number | undefined;
+        const frameId = (await api.storage.session.get(key))[key] as number | undefined;
         if (frameId === undefined) {
             return;
         }
@@ -91,7 +92,7 @@ export class StateManager {
         const tabState = await this.getTabState(tabId);
 
         const isHangulMode = tabState.koreanKeyboardMode === KoreanKeyboardMode.Hangul;
-        await chrome.action.setIcon({
+        await api.action.setIcon({
             tabId: tabId,
             path: isHangulMode ? icon16h : icon16a,
         });
@@ -100,7 +101,7 @@ export class StateManager {
         // yet (it's created on service-worker startup); tolerate that rather
         // than throwing an unhandled rejection into the presentation path.
         try {
-            await chrome.contextMenus.update(menus.onScreenKeyboard.id, {
+            await api.contextMenus.update(menus.onScreenKeyboard.id, {
                 checked: tabState.isOnScreenKeyboardEnabled,
             });
         } catch (error) {
@@ -115,7 +116,7 @@ export class StateManager {
      * enabled on-screen keyboard until the next state change.
      */
     public async refreshActiveTabPresentation(): Promise<void> {
-        const [active] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+        const [active] = await api.tabs.query({ active: true, lastFocusedWindow: true });
         if (active?.id !== undefined) {
             await this.updatePresentation(active.id);
         }
@@ -139,13 +140,13 @@ export class StateManager {
      */
     private async anchorTabState(tabId: number): Promise<TabState> {
         const key = this.tabStateKey(tabId);
-        const existing = (await chrome.storage.session.get(key))[key] as TabState | undefined;
+        const existing = (await api.storage.session.get(key))[key] as TabState | undefined;
         if (existing) {
             return this.cloneTabState(existing);
         }
 
         const derived = await this.deriveInitialState();
-        await chrome.storage.session.set({ [key]: derived });
+        await api.storage.session.set({ [key]: derived });
         return derived;
     }
 
@@ -165,7 +166,7 @@ export class StateManager {
 
         let live = await this.getLiveState();
         if (!live) {
-            const [active] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+            const [active] = await api.tabs.query({ active: true, lastFocusedWindow: true });
             live = active?.id !== undefined ? await this.getTabState(active.id) : await this.deriveInitialState();
             await this.setLiveState(live);
         }
@@ -187,7 +188,7 @@ export class StateManager {
         const currentTabState = await this.getTabState(tabId);
         const newTabState = updateFn(currentTabState);
 
-        await chrome.storage.session.set({ [this.tabStateKey(tabId)]: newTabState });
+        await api.storage.session.set({ [this.tabStateKey(tabId)]: newTabState });
         await this.persistLastState(settings, newTabState);
         await this.setLiveState(newTabState);
 
@@ -219,13 +220,13 @@ export class StateManager {
 
     /** Apply one state to every open tab (used in "share across tabs" mode). */
     private async broadcastState(state: TabState) {
-        const tabs = await chrome.tabs.query({});
+        const tabs = await api.tabs.query({});
         await Promise.all(
             tabs.map(async (tab) => {
                 if (tab.id === undefined) {
                     return;
                 }
-                await chrome.storage.session.set({ [this.tabStateKey(tab.id)]: state });
+                await api.storage.session.set({ [this.tabStateKey(tab.id)]: state });
                 await this.pushState(tab.id, state);
                 await this.updatePresentation(tab.id);
             })
@@ -239,7 +240,7 @@ export class StateManager {
      * close anyway — this just reclaims it promptly during a long session.
      */
     public async clearTabState(tabId: number) {
-        await chrome.storage.session.remove([this.tabStateKey(tabId), this.focusedFrameKey(tabId)]);
+        await api.storage.session.remove([this.tabStateKey(tabId), this.focusedFrameKey(tabId)]);
     }
 
     private tabStateKey(tabId: number) {
@@ -252,7 +253,7 @@ export class StateManager {
 
     private async getTabState(tabId: number): Promise<TabState> {
         const storageKey = this.tabStateKey(tabId);
-        const result = await chrome.storage.session.get(storageKey);
+        const result = await api.storage.session.get(storageKey);
         const tabState = result[storageKey] as TabState | undefined;
 
         if (tabState) {
@@ -332,22 +333,22 @@ export class StateManager {
             updated.koreanKeyboardMode = next.koreanKeyboardMode;
         }
 
-        await chrome.storage.local.set({ [LAST_STATE_KEY]: updated });
+        await api.storage.local.set({ [LAST_STATE_KEY]: updated });
     }
 
     private async getLastState(): Promise<Partial<TabState>> {
-        const result = await chrome.storage.local.get(LAST_STATE_KEY);
+        const result = await api.storage.local.get(LAST_STATE_KEY);
         return (result[LAST_STATE_KEY] as Partial<TabState> | undefined) ?? {};
     }
 
     private async getLiveState(): Promise<TabState | undefined> {
-        const result = await chrome.storage.session.get(LIVE_STATE_KEY);
+        const result = await api.storage.session.get(LIVE_STATE_KEY);
         const live = result[LIVE_STATE_KEY] as TabState | undefined;
         return live ? this.cloneTabState(live) : undefined;
     }
 
     private async setLiveState(state: TabState) {
-        await chrome.storage.session.set({ [LIVE_STATE_KEY]: this.cloneTabState(state) });
+        await api.storage.session.set({ [LIVE_STATE_KEY]: this.cloneTabState(state) });
     }
 
     private cloneTabState(tabState: TabState): TabState {

--- a/src/settings/settings-store.ts
+++ b/src/settings/settings-store.ts
@@ -1,4 +1,5 @@
 import { Settings, defaultSettings } from "./settings";
+import { api } from "../platform/browser-api";
 
 /**
  * Load/save the settings to `chrome.storage.sync`.
@@ -8,14 +9,14 @@ import { Settings, defaultSettings } from "./settings";
  * so there is no separate options→service-worker message (see #25/#26).
  */
 export async function loadSettings(): Promise<Settings> {
-    const stored = (await chrome.storage.sync.get(null)) as Record<string, unknown>;
+    const stored = (await api.storage.sync.get(null)) as Record<string, unknown>;
     const result = structuredClone(defaultSettings);
     overlayStored(result as unknown as Record<string, unknown>, stored);
     return result;
 }
 
 export async function saveSettings(settings: Settings): Promise<void> {
-    await chrome.storage.sync.set(settings);
+    await api.storage.sync.set(settings);
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary

Adds `src/platform/browser-api.ts` exporting a single `api` handle, and migrates all runtime `chrome.*` calls to it. This localizes the platform dependency to one module — groundwork for a future Firefox target. **No behaviour change.**

## How it works

```ts
export const api: typeof chrome = new Proxy({} as typeof chrome, {
    get: (_t, prop) => resolveApi()[prop],
});
```

- Resolves to `globalThis.browser` (Firefox's native, promise-based namespace) when present, else `globalThis.chrome`.
- A **Proxy** (lazy per-access resolution) rather than a captured reference — necessary because the unit tests install their `chrome` mock *after* this module is imported; a load-time capture would freeze `undefined`.
- Typed as `typeof chrome` (from `@types/chrome`), accurate for the common, identically-shaped, promise-based subset we use; `browser` satisfies the same shape.

## Scope

Migrated runtime calls across the service worker, content script, and settings store (11 files).

**Deliberately left as `chrome.*`:**
- **Type references** (`chrome.tabs.Tab`, `chrome.contextMenus.OnClickData`, `chrome.tabs.MessageSendOptions`) — these come from `@types/chrome` and are namespace-agnostic.
- **`i18n.ts`** — it intentionally reads `globalThis.chrome?.i18n` as its API-presence guard, since it must safely no-op when the API is absent (tests/preview), where `api` would throw.
- **Tests** that set up/assert on `globalThis.chrome`.

## Why runtime selection (for now)

Both `chrome.*` and `browser.*` are promise-based and shape-identical for our API surface, so a runtime `browser ?? chrome` selection is sufficient and lets Firefox work without bundler changes. The `api` seam is also the right place to later switch to build-time namespace selection if we want single-namespace bundles. (Firefox also needs a manifest/background split — separate future work.)

## Verification

Gate: `check` + `lint` + `test` (151 passing, unchanged) + `build-dev` all green. The existing tests that mock `globalThis.chrome` still pass, confirming the lazy Proxy resolution.

Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)