### PR TITLE
Toolbar icon tooltip reflects the current mode (#59)

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -20,6 +20,12 @@
     "menu_openOptions": {
         "message": "Options"
     },
+    "action_title_hangul": {
+        "message": "Korean IME — Hangul"
+    },
+    "action_title_english": {
+        "message": "Korean IME — English"
+    },
     "romanize_popup_title": {
         "message": "Korean IME - Romanization"
     },

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -20,6 +20,12 @@
     "menu_openOptions": {
         "message": "설정"
     },
+    "action_title_hangul": {
+        "message": "한글 입력기 — 한글"
+    },
+    "action_title_english": {
+        "message": "한글 입력기 — 영문"
+    },
     "romanize_popup_title": {
         "message": "한글 입력기 - 로마자 변환"
     },

--- a/src/service-worker/state-manager.test.ts
+++ b/src/service-worker/state-manager.test.ts
@@ -63,8 +63,9 @@ beforeEach(() => {
                     sentMessages.push({ tabId, data: message.data });
                 }),
             },
-            action: { setIcon: jest.fn(async () => {}) },
+            action: { setIcon: jest.fn(async () => {}), setTitle: jest.fn(async () => {}) },
             contextMenus: { update: jest.fn(async () => {}) },
+            i18n: { getMessage: (key: string) => key },
         },
     });
 });
@@ -290,5 +291,37 @@ describe("refreshActiveTabPresentation", () => {
         await manager.refreshActiveTabPresentation();
 
         expect(chrome.contextMenus.update).not.toHaveBeenCalled();
+    });
+});
+
+describe("action title (tooltip)", () => {
+    it("sets the Hangul-mode title when in Hangul mode", async () => {
+        withSettings({});
+        session["tabState-1"] = {
+            koreanKeyboardMode: KoreanKeyboardMode.Hangul,
+            isOnScreenKeyboardEnabled: false,
+        };
+        const manager = new StateManager();
+
+        await manager.sendStateToTab(1);
+
+        expect(chrome.action.setTitle).toHaveBeenCalledWith(
+            expect.objectContaining({ tabId: 1, title: "action_title_hangul" })
+        );
+    });
+
+    it("sets the English-mode title when in English mode", async () => {
+        withSettings({});
+        session["tabState-1"] = {
+            koreanKeyboardMode: KoreanKeyboardMode.English,
+            isOnScreenKeyboardEnabled: false,
+        };
+        const manager = new StateManager();
+
+        await manager.sendStateToTab(1);
+
+        expect(chrome.action.setTitle).toHaveBeenCalledWith(
+            expect.objectContaining({ tabId: 1, title: "action_title_english" })
+        );
     });
 });

--- a/src/service-worker/state-manager.ts
+++ b/src/service-worker/state-manager.ts
@@ -96,6 +96,10 @@ export class StateManager {
             tabId: tabId,
             path: isHangulMode ? icon16h : icon16a,
         });
+        await api.action.setTitle({
+            tabId: tabId,
+            title: api.i18n.getMessage(isHangulMode ? "action_title_hangul" : "action_title_english"),
+        });
 
         // Update the on-screen-keyboard menu checkbox. The menu may not exist
         // yet (it's created on service-worker startup); tolerate that rather


### PR DESCRIPTION
`StateManager.updatePresentation` now sets the action title alongside the icon, so hovering the toolbar icon shows the current mode — "Korean IME — Hangul" / "Korean IME — English" (Korean: 한글 / 영문). Localized via `chrome.i18n`; new `action_title_hangul` / `action_title_english` keys in `en` and `ko`.

Adds per-mode title tests. 155 tests pass; both builds + `web-ext lint` green.

Closes #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)