### PR TITLE
Document the PR-only workflow (master is protected)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,10 @@ pull request: branch off `master`, push the branch, open a PR, and merge it
 (GitHub auto-deletes the merged branch). A direct push to `master` will be
 rejected, so don't try it even for a one-line doc fix. Run `npm run validate`
 before pushing so CI passes on the first try. After a merge, **confirm it via the
-PR's merged state, not a local `git` check** — a stale local index can falsely
-look merged.
+PR's merged state** (e.g. `gh pr view <n> --json state`) rather than inferring it
+from local `git` — a local checkout that's behind `origin/master`, or that still
+has the feature branch around, can look merged when it isn't (or vice versa).
+`git checkout master && git pull` first if you do check locally.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,16 @@ browser without an OS-level Korean IME, plus romanization tools and a floating
 on-screen keyboard. TypeScript, bundled with **Parcel**; the options page uses
 **Vue 3**.
 
+## Workflow
+
+**`master` is protected — never commit to it directly.** All changes land via
+pull request: branch off `master`, push the branch, open a PR, and merge it
+(GitHub auto-deletes the merged branch). A direct push to `master` will be
+rejected, so don't try it even for a one-line doc fix. Run `npm run validate`
+before pushing so CI passes on the first try. After a merge, **confirm it via the
+PR's merged state, not a local `git` check** — a stale local index can falsely
+look merged.
+
 ## Commands
 
 | Command | Purpose |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,3 +2,7 @@ If you want to contribute, please discuss with me first
 (email mcnabb.vincent@gmail.com). You could probably just do a pull request,
 and if it fits in with my vision for the project I'll accept it, but
 communication could save us both some time.
+
+`master` is protected: all changes land via pull request — branch off `master`,
+push your branch, and open a PR. Run `npm run validate` before pushing so CI
+passes.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ ever need to.
 
 ## Contributing
 
-Contributions are welcome — please open an issue or pull request on [GitHub](https://github.com/vmcnabb/korean-ime). It's worth discussing your idea first to make sure it fits the direction of the project.
+Contributions are welcome — please open an issue or pull request on [GitHub](https://github.com/vmcnabb/korean-ime). It's worth discussing your idea first to make sure it fits the direction of the project. `master` is protected, so all changes go through a pull request.
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,10 @@ A release checklist so this is a routine, not archaeology. Versioning is
 single-source-of-truth from `package.json`; the build propagates it into the
 manifest (see [CLAUDE.md](CLAUDE.md) → *Releases*).
 
+> **`master` is protected — the version bump and changelog go through a PR like
+> any other change** (see CLAUDE.md → *Workflow*). The release tag is created on
+> the *merged* commit, in step 6, not on a local branch.
+
 ## 1. Pre-flight
 
 ```sh
@@ -11,7 +15,7 @@ git checkout master
 git pull
 git status        # working tree should be clean
 npm ci            # match the lockfile
-npm test          # tests green
+git switch -c release/vX.Y.Z   # release prep goes on a branch
 ```
 
 ## 2. Bump the version
@@ -59,18 +63,25 @@ In each:
 3. Toggle the on-screen keyboard from the context menu.
 4. Open the options page and confirm settings apply.
 
-## 6. Commit and tag
+## 6. PR, merge, then tag
+
+`master` is protected, so commit the bump on the release branch, open a PR, and
+merge it — *then* tag the merged commit on `master`.
 
 ```sh
 git add package.json CHANGELOG.md
 git commit -m "Release vX.Y.Z"
-git tag -a vX.Y.Z -m "vX.Y.Z"
-git push
+git push -u origin release/vX.Y.Z
+gh pr create --base master --title "Release vX.Y.Z" --body "..."
+# review + merge the PR (CI must be green), then:
+git checkout master && git pull          # pull the merged commit
+git tag -a vX.Y.Z -m "vX.Y.Z"            # tag the real merged commit
 git push --tags
 ```
 
-(`src/manifest.json` is generated and gitignored, so it isn't committed. Tags
-`v1.0.1`–`v2.2.2` are approximate, reconstructed after the fact. From 2.3.0
+(`src/manifest.json` is generated and gitignored, so it isn't committed. Tag
+**after** the merge so the tag points at the commit that's actually on `master`.
+Tags `v1.0.1`–`v2.2.2` are approximate, reconstructed after the fact. From 2.3.0
 onward, tags are exact — created at release time from the real commit.)
 
 ## 7. Package for the stores


### PR DESCRIPTION
`master` is now branch-protected — no direct commits. Updates the docs to match (and this PR is itself the first instance of the new rule):

- **CLAUDE.md** — new "Workflow" section near the top: branch → PR → merge, run `validate` before pushing, and confirm merges via the PR's state rather than a local `git` check.
- **RELEASING.md** — release prep (version bump + changelog) now goes on a `release/vX.Y.Z` branch via PR; the tag is created on the *merged* commit on `master`, after the PR merges, not on a local branch.
- **CONTRIBUTING.md** / **README.md** — note that all changes land via pull request.

Docs only; `validate` green (155 tests).