### PR TITLE
Add Hangul typing and physical key controls

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -59,6 +59,18 @@
     "options_hanYong_heading": {
         "message": "Han/Yong (한/영) toggle"
     },
+    "options_hanYong_enabled_label": {
+        "message": "Enable Korean (Hangul) typing"
+    },
+    "options_hanYong_disabled_hint": {
+        "message": "When off, all Han/Yong switching is disabled and the Right Alt / Han/Yong key does nothing."
+    },
+    "options_hanYong_keyboardKeyEnabled_label": {
+        "message": "Enable Right Alt / Han/Yong key toggle"
+    },
+    "options_hanYong_keyboardKeyEnabled_description": {
+        "message": "Applies to the physical keyboard key. On Korean keyboards, this is the dedicated Han/Yong key to the right of the spacebar."
+    },
     "options_hanYong_hint": {
         "message": "Switches between Hangul and Latin input."
     },

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -59,6 +59,18 @@
     "options_hanYong_heading": {
         "message": "Alternancia Han/Yong (한/영)"
     },
+    "options_hanYong_enabled_label": {
+        "message": "Activar escritura coreana (hangul)"
+    },
+    "options_hanYong_disabled_hint": {
+        "message": "Cuando está desactivado, toda la conmutación Han/Yong se deshabilita y la tecla Alt derecha / Han-Yong no hace nada."
+    },
+    "options_hanYong_keyboardKeyEnabled_label": {
+        "message": "Activar alternancia con la tecla Alt derecha / Han-Yong"
+    },
+    "options_hanYong_keyboardKeyEnabled_description": {
+        "message": "Se aplica a la tecla física del teclado. En los teclados coreanos, es la tecla dedicada Han/Yong a la derecha de la barra espaciadora."
+    },
     "options_hanYong_hint": {
         "message": "Alterna entre la entrada de hangul y la latina."
     },

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -59,6 +59,18 @@
     "options_hanYong_heading": {
         "message": "한/영 전환"
     },
+    "options_hanYong_enabled_label": {
+        "message": "한글 입력 사용"
+    },
+    "options_hanYong_disabled_hint": {
+        "message": "끄면 모든 한/영 전환이 비활성화되고 오른쪽 Alt/한영 키도 동작하지 않습니다."
+    },
+    "options_hanYong_keyboardKeyEnabled_label": {
+        "message": "오른쪽 Alt/한영 키 전환 사용"
+    },
+    "options_hanYong_keyboardKeyEnabled_description": {
+        "message": "실제 키보드 키에 적용됩니다. 한국어 키보드에서는 스페이스바 오른쪽의 전용 한/영 키가 이에 해당합니다."
+    },
     "options_hanYong_hint": {
         "message": "한글과 로마자 입력을 전환합니다."
     },

--- a/src/content-script/content-script-controller.test.ts
+++ b/src/content-script/content-script-controller.test.ts
@@ -1,0 +1,124 @@
+import { ContentScriptController } from "./content-script-controller";
+import { KeyCode } from "../keyboard/korean-keyboard-map";
+import { KoreanKeyboardMode } from "../extension-state/korean-keyboard-mode";
+import { ServiceScriptMessageAction } from "../messaging/service-to-content-messages";
+import { ContentScriptRequestAction } from "../messaging/content-to-service-messages";
+
+jest.mock("./on-screen-keyboard/on-screen-keyboard-controller", () => ({
+    OnScreenKeyboardController: class OnScreenKeyboardController {},
+}));
+
+describe("ContentScriptController AltRight handling", () => {
+    it("only intercepts AltRight when Hangul typing and the keyboard-key option are both enabled", () => {
+        const listeners: Array<(message: unknown) => void> = [];
+        const sendMessage = jest.fn();
+
+        Object.assign(globalThis, {
+            chrome: {
+                runtime: {
+                    sendMessage,
+                    onMessage: {
+                        addListener: (listener: (message: unknown) => void) => listeners.push(listener),
+                    },
+                },
+            },
+        });
+
+        const controller = new ContentScriptController();
+        controller.initialize(false);
+        sendMessage.mockClear();
+
+        const handleMessage = listeners[0];
+        handleMessage({
+            type: "serviceScriptMessage",
+            action: ServiceScriptMessageAction.UpdateState,
+            data: {
+                isHanYongEnabled: false,
+                isHanYongKeyboardKeyEnabled: true,
+                isOnScreenKeyboardEnabled: false,
+                koreanKeyboardMode: KoreanKeyboardMode.English,
+            },
+        });
+
+        const disabledKeydown = new KeyboardEvent("keydown", {
+            bubbles: true,
+            cancelable: true,
+            code: KeyCode.AltRight,
+        });
+        const disabledKeyup = new KeyboardEvent("keyup", {
+            bubbles: true,
+            cancelable: true,
+            code: KeyCode.AltRight,
+        });
+
+        document.dispatchEvent(disabledKeydown);
+        document.dispatchEvent(disabledKeyup);
+
+        expect(disabledKeydown.defaultPrevented).toBe(false);
+        expect(disabledKeyup.defaultPrevented).toBe(false);
+        expect(sendMessage).not.toHaveBeenCalled();
+
+        handleMessage({
+            type: "serviceScriptMessage",
+            action: ServiceScriptMessageAction.UpdateState,
+            data: {
+                isHanYongEnabled: true,
+                isHanYongKeyboardKeyEnabled: false,
+                isOnScreenKeyboardEnabled: false,
+                koreanKeyboardMode: KoreanKeyboardMode.English,
+            },
+        });
+        sendMessage.mockClear();
+
+        const keySettingDisabledKeydown = new KeyboardEvent("keydown", {
+            bubbles: true,
+            cancelable: true,
+            code: KeyCode.AltRight,
+        });
+        const keySettingDisabledKeyup = new KeyboardEvent("keyup", {
+            bubbles: true,
+            cancelable: true,
+            code: KeyCode.AltRight,
+        });
+
+        document.dispatchEvent(keySettingDisabledKeydown);
+        document.dispatchEvent(keySettingDisabledKeyup);
+
+        expect(keySettingDisabledKeydown.defaultPrevented).toBe(false);
+        expect(keySettingDisabledKeyup.defaultPrevented).toBe(false);
+        expect(sendMessage).not.toHaveBeenCalled();
+
+        handleMessage({
+            type: "serviceScriptMessage",
+            action: ServiceScriptMessageAction.UpdateState,
+            data: {
+                isHanYongEnabled: true,
+                isHanYongKeyboardKeyEnabled: true,
+                isOnScreenKeyboardEnabled: false,
+                koreanKeyboardMode: KoreanKeyboardMode.English,
+            },
+        });
+        sendMessage.mockClear();
+
+        const enabledKeydown = new KeyboardEvent("keydown", {
+            bubbles: true,
+            cancelable: true,
+            code: KeyCode.AltRight,
+        });
+        const enabledKeyup = new KeyboardEvent("keyup", {
+            bubbles: true,
+            cancelable: true,
+            code: KeyCode.AltRight,
+        });
+
+        document.dispatchEvent(enabledKeydown);
+        document.dispatchEvent(enabledKeyup);
+
+        expect(enabledKeydown.defaultPrevented).toBe(true);
+        expect(enabledKeyup.defaultPrevented).toBe(true);
+        expect(sendMessage).toHaveBeenCalledWith({
+            type: "contentScriptRequest",
+            action: ContentScriptRequestAction.ToggleHanYongMode,
+        });
+    });
+});

--- a/src/content-script/content-script-controller.ts
+++ b/src/content-script/content-script-controller.ts
@@ -17,6 +17,8 @@ import {
 import { api } from "../platform/browser-api";
 
 export class ContentScriptController {
+    private isHanYongEnabled = false;
+    private isHanYongKeyboardKeyEnabled = false;
     private textEntryMode = KoreanKeyboardMode.English;
     private textInputManager = new TextInputManager();
     private keyboardController?: OnScreenKeyboardController;
@@ -72,8 +74,14 @@ export class ContentScriptController {
     }
 
     private handleTabStateMessage(message: TabStateMessage) {
-        if (message.data.koreanKeyboardMode !== this.textEntryMode) {
-            this.setTextEntryMode(message.data.koreanKeyboardMode);
+        this.isHanYongEnabled = message.data.isHanYongEnabled;
+        this.isHanYongKeyboardKeyEnabled = message.data.isHanYongKeyboardKeyEnabled;
+        this.keyboardController?.setHanYongEnabled(message.data.isHanYongEnabled);
+
+        const nextMode = message.data.isHanYongEnabled ? message.data.koreanKeyboardMode : KoreanKeyboardMode.English;
+
+        if (nextMode !== this.textEntryMode) {
+            this.setTextEntryMode(nextMode);
         }
 
         if (message.data.isOnScreenKeyboardEnabled) {
@@ -87,7 +95,12 @@ export class ContentScriptController {
         document.addEventListener(
             "keydown",
             (e) => {
-                if (e.code === KeyCode.AltRight && !e.repeat) {
+                if (
+                    this.isHanYongEnabled &&
+                    this.isHanYongKeyboardKeyEnabled &&
+                    e.code === KeyCode.AltRight &&
+                    !e.repeat
+                ) {
                     api.runtime.sendMessage<ContentScriptRequestMessage>({
                         type: "contentScriptRequest",
                         action: ContentScriptRequestAction.ToggleHanYongMode,
@@ -105,7 +118,7 @@ export class ContentScriptController {
         document.addEventListener(
             "keyup",
             (e) => {
-                if (e.code === KeyCode.AltRight) {
+                if (this.isHanYongEnabled && this.isHanYongKeyboardKeyEnabled && e.code === KeyCode.AltRight) {
                     e.preventDefault();
                 }
             },

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
@@ -24,6 +24,7 @@ export class OnScreenKeyboardController {
     };
 
     private _mode = KoreanKeyboardMode.English;
+    private _isHanYongEnabled = false;
     private _isShift = false;
     private _compositionFeatures: SupportedCompositionFeatures | undefined;
     private _keyElements = new Map<KeyCode, HTMLElement>();
@@ -43,6 +44,11 @@ export class OnScreenKeyboardController {
 
         this._keyboardElement.classList.toggle("hanMode", isHanMode);
         this._keyboardElement.classList.toggle("yongMode", !isHanMode);
+    }
+
+    public setHanYongEnabled(enabled: boolean) {
+        this._isHanYongEnabled = enabled;
+        this._keyElements.get(KeyCode.AltRight)?.classList.toggle("disabled", !enabled);
     }
 
     public setShift(shift: boolean) {
@@ -275,6 +281,9 @@ export class OnScreenKeyboardController {
         } else if (key.label === "Shift") {
             this.setShift(!isShift);
         } else if (keyCode === KeyCode.AltRight) {
+            if (!this._isHanYongEnabled) {
+                return;
+            }
             api.runtime.sendMessage<ContentScriptRequestMessage>({
                 type: "contentScriptRequest",
                 action: ContentScriptRequestAction.ToggleHanYongMode,
@@ -383,5 +392,7 @@ export class OnScreenKeyboardController {
 
             keyboardELement.appendChild(rowElement);
         });
+
+        this.setHanYongEnabled(this._isHanYongEnabled);
     }
 }

--- a/src/extension-state/tab-state.ts
+++ b/src/extension-state/tab-state.ts
@@ -1,6 +1,8 @@
 import { KoreanKeyboardMode } from "./korean-keyboard-mode";
 
 export type TabState = {
+    isHanYongEnabled: boolean;
+    isHanYongKeyboardKeyEnabled: boolean;
     koreanKeyboardMode: KoreanKeyboardMode;
     isOnScreenKeyboardEnabled: boolean;
 };

--- a/src/options-app/HanYongSection.vue
+++ b/src/options-app/HanYongSection.vue
@@ -3,6 +3,7 @@ import { settings } from "./use-settings";
 import { Persistence } from "../settings/settings";
 import { t } from "./i18n";
 import PersistenceSelect from "./PersistenceSelect.vue";
+import LabeledCheckbox from "./LabeledCheckbox.vue";
 
 const optionLabels: Record<Persistence, string> = {
     [Persistence.AlwaysOff]: t("options_hanYong_startOff"),
@@ -14,12 +15,24 @@ const optionLabels: Record<Persistence, string> = {
 <template>
     <section>
         <h2>{{ t("options_hanYong_heading") }}</h2>
-        <p class="description section-hint">{{ t("options_hanYong_hint") }}</p>
-        <PersistenceSelect
-            v-model="settings.hanYong.persistence"
-            :label="t('options_persistence_label')"
-            :option-labels="optionLabels"
+        <LabeledCheckbox
+            v-model="settings.hanYong.enabled"
+            :label="t('options_hanYong_enabled_label')"
         />
+        <template v-if="settings.hanYong.enabled">
+            <p class="description section-hint">{{ t("options_hanYong_hint") }}</p>
+            <LabeledCheckbox
+                v-model="settings.hanYong.keyboardKeyEnabled"
+                :label="t('options_hanYong_keyboardKeyEnabled_label')"
+                :description="t('options_hanYong_keyboardKeyEnabled_description')"
+            />
+            <PersistenceSelect
+                v-model="settings.hanYong.persistence"
+                :label="t('options_persistence_label')"
+                :option-labels="optionLabels"
+            />
+        </template>
+        <p v-else class="description section-hint">{{ t("options_hanYong_disabled_hint") }}</p>
     </section>
 </template>
 

--- a/src/service-worker/state-manager.test.ts
+++ b/src/service-worker/state-manager.test.ts
@@ -71,7 +71,7 @@ beforeEach(() => {
 });
 
 function withSettings(
-    overrides: Partial<Settings> & {
+    overrides: Omit<Partial<Settings>, "onScreenKeyboard" | "hanYong"> & {
         onScreenKeyboard?: Partial<Settings["onScreenKeyboard"]>;
         hanYong?: Partial<Settings["hanYong"]>;
     }
@@ -92,6 +92,16 @@ function lastSentTo(tabId: number): TabState | undefined {
 // state is seeded from the persistence policy (empty session storage models
 // this).
 describe("fresh-session seeding from persistence", () => {
+    it("enables Han/Yong typing by default", async () => {
+        withSettings({});
+        const manager = new StateManager();
+
+        await manager.sendStateToTab(1);
+
+        expect(lastSentTo(1)?.isHanYongEnabled).toBe(true);
+        expect(lastSentTo(1)?.isHanYongKeyboardKeyEnabled).toBe(true);
+    });
+
     it("AlwaysOff starts the feature off", async () => {
         withSettings({ onScreenKeyboard: { persistence: Persistence.AlwaysOff } });
         const manager = new StateManager();
@@ -117,6 +127,16 @@ describe("fresh-session seeding from persistence", () => {
         await manager.sendStateToTab(1);
 
         expect(lastSentTo(1)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
+    });
+
+    it("forces Han/Yong off when Hangul typing is disabled", async () => {
+        withSettings({ hanYong: { enabled: false, persistence: Persistence.AlwaysOn } });
+        const manager = new StateManager();
+
+        await manager.sendStateToTab(1);
+
+        expect(lastSentTo(1)?.isHanYongEnabled).toBe(false);
+        expect(lastSentTo(1)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.English);
     });
 
     it("KeepLastState restores the remembered value from storage.local", async () => {
@@ -197,6 +217,32 @@ describe("mid-session new-tab inheritance", () => {
 });
 
 describe("KeepLastState persistence", () => {
+    it("ignores Han/Yong toggle requests while typing is disabled", async () => {
+        withSettings({ hanYong: { enabled: false, persistence: Persistence.AlwaysOff } });
+        const manager = new StateManager();
+
+        await manager.sendStateToTab(1);
+        sentMessages = [];
+
+        await manager.toggleHanYongMode(1);
+        await manager.sendStateToTab(1);
+
+        expect(sentMessages).toHaveLength(1);
+        expect(lastSentTo(1)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.English);
+        expect(lastSentTo(1)?.isHanYongEnabled).toBe(false);
+    });
+
+    it("still toggles Han/Yong mode when only the physical-key setting is disabled", async () => {
+        withSettings({ hanYong: { keyboardKeyEnabled: false, persistence: Persistence.AlwaysOff } });
+        const manager = new StateManager();
+
+        await manager.toggleHanYongMode(1);
+
+        expect(lastSentTo(1)?.isHanYongEnabled).toBe(true);
+        expect(lastSentTo(1)?.isHanYongKeyboardKeyEnabled).toBe(false);
+        expect(lastSentTo(1)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
+    });
+
     it("writes the toggled value to storage.local", async () => {
         withSettings({ onScreenKeyboard: { persistence: Persistence.KeepLastState } });
         const manager = new StateManager();
@@ -261,6 +307,57 @@ describe("share across tabs", () => {
 
         expect(lastSentTo(1)?.isOnScreenKeyboardEnabled).toBe(true);
         expect(lastSentTo(2)).toBeUndefined();
+    });
+
+    it("pushes disabled Han/Yong state to open tabs immediately", async () => {
+        withSettings({ shareAcrossTabs: false, hanYong: { persistence: Persistence.AlwaysOn } });
+        tabs = [{ id: 1, active: true }, { id: 2 }];
+        session["tabState-1"] = {
+            koreanKeyboardMode: KoreanKeyboardMode.Hangul,
+            isOnScreenKeyboardEnabled: false,
+        };
+        session["tabState-2"] = {
+            koreanKeyboardMode: KoreanKeyboardMode.Hangul,
+            isOnScreenKeyboardEnabled: true,
+        };
+        const manager = new StateManager();
+
+        withSettings({ shareAcrossTabs: false, hanYong: { enabled: false, persistence: Persistence.AlwaysOn } });
+        await manager.onSettingsChanged();
+
+        expect(lastSentTo(1)?.isHanYongEnabled).toBe(false);
+        expect(lastSentTo(1)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.English);
+        expect(lastSentTo(2)?.isHanYongEnabled).toBe(false);
+        expect(lastSentTo(2)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.English);
+        expect(lastSentTo(2)?.isOnScreenKeyboardEnabled).toBe(true);
+    });
+
+    it("pushes disabled physical-key state to open tabs immediately without changing Hangul mode", async () => {
+        withSettings({ shareAcrossTabs: false, hanYong: { persistence: Persistence.AlwaysOn } });
+        tabs = [{ id: 1, active: true }, { id: 2 }];
+        session["tabState-1"] = {
+            koreanKeyboardMode: KoreanKeyboardMode.Hangul,
+            isOnScreenKeyboardEnabled: false,
+        };
+        session["tabState-2"] = {
+            koreanKeyboardMode: KoreanKeyboardMode.Hangul,
+            isOnScreenKeyboardEnabled: true,
+        };
+        const manager = new StateManager();
+
+        withSettings({
+            shareAcrossTabs: false,
+            hanYong: { enabled: true, keyboardKeyEnabled: false, persistence: Persistence.AlwaysOn },
+        });
+        await manager.onSettingsChanged();
+
+        expect(lastSentTo(1)?.isHanYongEnabled).toBe(true);
+        expect(lastSentTo(1)?.isHanYongKeyboardKeyEnabled).toBe(false);
+        expect(lastSentTo(1)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
+        expect(lastSentTo(2)?.isHanYongEnabled).toBe(true);
+        expect(lastSentTo(2)?.isHanYongKeyboardKeyEnabled).toBe(false);
+        expect(lastSentTo(2)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
+        expect(lastSentTo(2)?.isOnScreenKeyboardEnabled).toBe(true);
     });
 });
 

--- a/src/service-worker/state-manager.test.ts
+++ b/src/service-worker/state-manager.test.ts
@@ -252,6 +252,23 @@ describe("KeepLastState persistence", () => {
         expect((local.lastState as Partial<TabState>).isOnScreenKeyboardEnabled).toBe(true);
     });
 
+    it("does not overwrite the remembered Han/Yong mode while typing is disabled", async () => {
+        withSettings({
+            onScreenKeyboard: { persistence: Persistence.KeepLastState },
+            hanYong: { enabled: false, persistence: Persistence.KeepLastState },
+        });
+        local.lastState = {
+            isOnScreenKeyboardEnabled: false,
+            koreanKeyboardMode: KoreanKeyboardMode.Hangul,
+        };
+        const manager = new StateManager();
+
+        await manager.toggleOnScreenKeyboard(1);
+
+        expect((local.lastState as Partial<TabState>).isOnScreenKeyboardEnabled).toBe(true);
+        expect((local.lastState as Partial<TabState>).koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
+    });
+
     it("does NOT persist when the feature is AlwaysOff", async () => {
         withSettings({ onScreenKeyboard: { persistence: Persistence.AlwaysOff } });
         const manager = new StateManager();

--- a/src/service-worker/state-manager.ts
+++ b/src/service-worker/state-manager.ts
@@ -65,13 +65,22 @@ export class StateManager {
     }
 
     public async toggleHanYongMode(tabId: number): Promise<void> {
-        await this.setTabState(tabId, (tabState) => ({
-            ...tabState,
-            koreanKeyboardMode:
-                tabState.koreanKeyboardMode === KoreanKeyboardMode.Hangul
-                    ? KoreanKeyboardMode.English
-                    : KoreanKeyboardMode.Hangul,
-        }));
+        const settings = await loadSettings();
+        if (!settings.hanYong.enabled) {
+            return;
+        }
+
+        await this.setTabState(
+            tabId,
+            (tabState) => ({
+                ...tabState,
+                koreanKeyboardMode:
+                    tabState.koreanKeyboardMode === KoreanKeyboardMode.Hangul
+                        ? KoreanKeyboardMode.English
+                        : KoreanKeyboardMode.Hangul,
+            }),
+            settings
+        );
     }
 
     /**
@@ -88,10 +97,10 @@ export class StateManager {
         return newTabState.isOnScreenKeyboardEnabled;
     }
 
-    public async updatePresentation(tabId: number) {
-        const tabState = await this.getTabState(tabId);
+    public async updatePresentation(tabId: number, tabState?: TabState) {
+        const currentState = tabState ?? (await this.getTabState(tabId));
 
-        const isHangulMode = tabState.koreanKeyboardMode === KoreanKeyboardMode.Hangul;
+        const isHangulMode = currentState.koreanKeyboardMode === KoreanKeyboardMode.Hangul;
         await api.action.setIcon({
             tabId: tabId,
             path: isHangulMode ? icon16h : icon16a,
@@ -106,7 +115,7 @@ export class StateManager {
         // than throwing an unhandled rejection into the presentation path.
         try {
             await api.contextMenus.update(menus.onScreenKeyboard.id, {
-                checked: tabState.isOnScreenKeyboardEnabled,
+                checked: currentState.isOnScreenKeyboardEnabled,
             });
         } catch (error) {
             debugLog("Could not update on-screen-keyboard menu item:", error);
@@ -142,16 +151,15 @@ export class StateManager {
      * tracking whatever tab was last active. Persisting the derived state on
      * first sight anchors the tab so it becomes independent. Returns the state.
      */
-    private async anchorTabState(tabId: number): Promise<TabState> {
+    private async anchorTabState(tabId: number, settings?: Settings): Promise<TabState> {
+        const currentSettings = settings ?? (await loadSettings());
         const key = this.tabStateKey(tabId);
-        const existing = (await api.storage.session.get(key))[key] as TabState | undefined;
-        if (existing) {
-            return this.cloneTabState(existing);
-        }
-
-        const derived = await this.deriveInitialState();
-        await api.storage.session.set({ [key]: derived });
-        return derived;
+        const existing = (await api.storage.session.get(key))[key] as Partial<TabState> | undefined;
+        const anchored = existing
+            ? this.hydrateTabState(existing, currentSettings)
+            : await this.deriveInitialState(currentSettings);
+        await api.storage.session.set({ [key]: anchored });
+        return anchored;
     }
 
     /**
@@ -164,17 +172,34 @@ export class StateManager {
      */
     public async onSettingsChanged(): Promise<void> {
         const settings = await loadSettings();
+        const live = await this.getLiveState(settings);
+        if (live) {
+            await this.setLiveState(live);
+        }
+
         if (!settings.shareAcrossTabs) {
+            const tabs = await api.tabs.query({});
+            await Promise.all(
+                tabs.map(async (tab) => {
+                    if (tab.id === undefined) {
+                        return;
+                    }
+                    await this.sendStateToTab(tab.id, settings);
+                })
+            );
             return;
         }
 
-        let live = await this.getLiveState();
-        if (!live) {
+        let shared = live;
+        if (!shared) {
             const [active] = await api.tabs.query({ active: true, lastFocusedWindow: true });
-            live = active?.id !== undefined ? await this.getTabState(active.id) : await this.deriveInitialState();
-            await this.setLiveState(live);
+            shared =
+                active?.id !== undefined
+                    ? await this.getTabState(active.id, settings)
+                    : await this.deriveInitialState(settings);
+            await this.setLiveState(shared);
         }
-        await this.broadcastState(live);
+        await this.broadcastState(shared);
     }
 
     /**
@@ -187,31 +212,37 @@ export class StateManager {
      * @param tabId The ID of the tab for which to update the state
      * @param updateFn function that takes the current tab state and returns the new tab state
      */
-    private async setTabState(tabId: number, updateFn: (tabState: TabState) => TabState): Promise<TabState> {
-        const settings = await loadSettings();
-        const currentTabState = await this.getTabState(tabId);
-        const newTabState = updateFn(currentTabState);
+    private async setTabState(
+        tabId: number,
+        updateFn: (tabState: TabState) => TabState,
+        settings?: Settings
+    ): Promise<TabState> {
+        const currentSettings = settings ?? (await loadSettings());
+        const currentTabState = await this.anchorTabState(tabId, currentSettings);
+        const newTabState = this.hydrateTabState(updateFn(currentTabState), currentSettings);
 
         await api.storage.session.set({ [this.tabStateKey(tabId)]: newTabState });
-        await this.persistLastState(settings, newTabState);
+        await this.persistLastState(currentSettings, newTabState);
         await this.setLiveState(newTabState);
 
-        if (settings.shareAcrossTabs) {
+        if (currentSettings.shareAcrossTabs) {
             await this.broadcastState(newTabState);
         } else {
-            await this.sendStateToTab(tabId);
+            await this.pushState(tabId, newTabState);
+            await this.updatePresentation(tabId, newTabState);
         }
 
         return newTabState;
     }
 
     /** Push a tab's current state to it and refresh its icon / menu presentation. */
-    public async sendStateToTab(tabId: number) {
+    public async sendStateToTab(tabId: number, settings?: Settings) {
+        const currentSettings = settings ?? (await loadSettings());
         // Anchor on the way out so a freshly loaded/cloned tab persists its
         // inherited state and stops tracking the global live value.
-        const state = await this.anchorTabState(tabId);
+        const state = await this.anchorTabState(tabId, currentSettings);
         await this.pushState(tabId, state);
-        await this.updatePresentation(tabId);
+        await this.updatePresentation(tabId, state);
     }
 
     private async pushState(tabId: number, state: TabState) {
@@ -232,7 +263,7 @@ export class StateManager {
                 }
                 await api.storage.session.set({ [this.tabStateKey(tab.id)]: state });
                 await this.pushState(tab.id, state);
-                await this.updatePresentation(tab.id);
+                await this.updatePresentation(tab.id, state);
             })
         );
     }
@@ -255,16 +286,17 @@ export class StateManager {
         return `focusedFrame-${tabId}`;
     }
 
-    private async getTabState(tabId: number): Promise<TabState> {
+    private async getTabState(tabId: number, settings?: Settings): Promise<TabState> {
+        const currentSettings = settings ?? (await loadSettings());
         const storageKey = this.tabStateKey(tabId);
         const result = await api.storage.session.get(storageKey);
-        const tabState = result[storageKey] as TabState | undefined;
+        const tabState = result[storageKey] as Partial<TabState> | undefined;
 
         if (tabState) {
-            return this.cloneTabState(tabState);
+            return this.hydrateTabState(tabState, currentSettings);
         }
 
-        return this.deriveInitialState();
+        return this.deriveInitialState(currentSettings);
     }
 
     /**
@@ -273,8 +305,9 @@ export class StateManager {
      * fresh session — when no live value exists yet — does persistence policy
      * decide the seed, reading `storage.local` for `KeepLastState`.
      */
-    private async deriveInitialState(): Promise<TabState> {
-        const live = await this.getLiveState();
+    private async deriveInitialState(settings?: Settings): Promise<TabState> {
+        const currentSettings = settings ?? (await loadSettings());
+        const live = await this.getLiveState(currentSettings);
         if (live) {
             return live;
         }
@@ -287,19 +320,21 @@ export class StateManager {
         // every tab seeds identically, and the only paths that make a tab differ
         // from that seed (setTabState / broadcast) also set liveState. So by the
         // time inheritance could differ from the seed, liveState is already set.
-        const settings = await loadSettings();
         const last = await this.getLastState();
         const lastHangul = (last.koreanKeyboardMode ?? KoreanKeyboardMode.English) === KoreanKeyboardMode.Hangul;
 
-        return {
-            isOnScreenKeyboardEnabled: this.seedFeature(
-                settings.onScreenKeyboard.persistence,
-                last.isOnScreenKeyboardEnabled ?? false
-            ),
-            koreanKeyboardMode: this.seedFeature(settings.hanYong.persistence, lastHangul)
-                ? KoreanKeyboardMode.Hangul
-                : KoreanKeyboardMode.English,
-        };
+        return this.hydrateTabState(
+            {
+                isOnScreenKeyboardEnabled: this.seedFeature(
+                    currentSettings.onScreenKeyboard.persistence,
+                    last.isOnScreenKeyboardEnabled ?? false
+                ),
+                koreanKeyboardMode: this.seedFeature(currentSettings.hanYong.persistence, lastHangul)
+                    ? KoreanKeyboardMode.Hangul
+                    : KoreanKeyboardMode.English,
+            },
+            currentSettings
+        );
     }
 
     /** How a feature is seeded on a fresh session, given its persistence policy. */
@@ -345,14 +380,29 @@ export class StateManager {
         return (result[LAST_STATE_KEY] as Partial<TabState> | undefined) ?? {};
     }
 
-    private async getLiveState(): Promise<TabState | undefined> {
+    private async getLiveState(settings?: Settings): Promise<TabState | undefined> {
+        const currentSettings = settings ?? (await loadSettings());
         const result = await api.storage.session.get(LIVE_STATE_KEY);
-        const live = result[LIVE_STATE_KEY] as TabState | undefined;
-        return live ? this.cloneTabState(live) : undefined;
+        const live = result[LIVE_STATE_KEY] as Partial<TabState> | undefined;
+        return live ? this.hydrateTabState(live, currentSettings) : undefined;
     }
 
     private async setLiveState(state: TabState) {
         await api.storage.session.set({ [LIVE_STATE_KEY]: this.cloneTabState(state) });
+    }
+
+    private hydrateTabState(tabState: Partial<TabState>, settings: Settings): TabState {
+        const isHanYongEnabled = settings.hanYong.enabled;
+
+        return {
+            isHanYongEnabled,
+            isHanYongKeyboardKeyEnabled: settings.hanYong.keyboardKeyEnabled,
+            isOnScreenKeyboardEnabled: tabState.isOnScreenKeyboardEnabled ?? false,
+            koreanKeyboardMode:
+                isHanYongEnabled && tabState.koreanKeyboardMode === KoreanKeyboardMode.Hangul
+                    ? KoreanKeyboardMode.Hangul
+                    : KoreanKeyboardMode.English,
+        };
     }
 
     private cloneTabState(tabState: TabState): TabState {

--- a/src/service-worker/state-manager.ts
+++ b/src/service-worker/state-manager.ts
@@ -357,7 +357,8 @@ export class StateManager {
     /** Persist the new value to `storage.local`, but only for KeepLastState features. */
     private async persistLastState(settings: Settings, next: TabState) {
         const oskKeepsState = settings.onScreenKeyboard.persistence === Persistence.KeepLastState;
-        const hanYongKeepsState = settings.hanYong.persistence === Persistence.KeepLastState;
+        const hanYongKeepsState =
+            settings.hanYong.enabled && settings.hanYong.persistence === Persistence.KeepLastState;
 
         if (!oskKeepsState && !hanYongKeepsState) {
             return;

--- a/src/settings/settings-store.test.ts
+++ b/src/settings/settings-store.test.ts
@@ -47,6 +47,8 @@ describe("loadSettings", () => {
 
         expect(settings.shareAcrossTabs).toBe(true);
         expect(settings.hanYong.persistence).toBe(Persistence.KeepLastState);
+        expect(settings.hanYong.enabled).toBe(true);
+        expect(settings.hanYong.keyboardKeyEnabled).toBe(true);
         expect(settings.onScreenKeyboard.persistence).toBe(Persistence.AlwaysOff);
     });
 
@@ -76,6 +78,13 @@ describe("loadSettings", () => {
         stored({ onScreenKeyboard: "garbage" });
 
         expect((await loadSettings()).onScreenKeyboard).toEqual(defaultSettings.onScreenKeyboard);
+    });
+
+    it("keeps newly added nested defaults when older stored objects omit them", async () => {
+        stored({ hanYong: { persistence: Persistence.KeepLastState } });
+
+        expect((await loadSettings()).hanYong.enabled).toBe(true);
+        expect((await loadSettings()).hanYong.keyboardKeyEnabled).toBe(true);
     });
 });
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -10,6 +10,13 @@ export interface FeatureSettings {
     persistence: Persistence;
 }
 
+export interface HanYongSettings extends FeatureSettings {
+    /** Whether Hangul typing is enabled at all. */
+    enabled: boolean;
+    /** Whether the physical Right Alt / Han-Yong key toggles modes. */
+    keyboardKeyEnabled: boolean;
+}
+
 /**
  * The extension's settings. A plain, typed object — persisted to
  * `chrome.storage.sync` (see `settings-store.ts`) and edited by the options
@@ -18,7 +25,7 @@ export interface FeatureSettings {
  */
 export interface Settings {
     onScreenKeyboard: FeatureSettings;
-    hanYong: FeatureSettings;
+    hanYong: HanYongSettings;
     /** Apply changes to every tab at once, not just the focused one. */
     shareAcrossTabs: boolean;
 }
@@ -28,6 +35,8 @@ export const defaultSettings: Settings = {
         persistence: Persistence.AlwaysOff,
     },
     hanYong: {
+        enabled: true,
+        keyboardKeyEnabled: true,
         persistence: Persistence.AlwaysOff,
     },
     shareAcrossTabs: false,


### PR DESCRIPTION
## Summary

- add a master setting to enable or disable Hangul typing
- add a separate physical Right Alt / Han/Yong key toggle setting
- update the options UI, localized strings, and tests for the new controls

## Testing

- npm run validate

Closes #67