### PR TITLE
Independent ephemeral OSK Han/Yong toggle when Hangul typing is off

### DIFF
--- a/src/composition/hangul-ime-controller.test.ts
+++ b/src/composition/hangul-ime-controller.test.ts
@@ -1,5 +1,6 @@
 import { HangulImeController } from "./hangul-ime-controller";
 import { InputAdapter } from "./composition-adapters/input-adapter";
+import { KeyCode } from "../keyboard/korean-keyboard-map";
 
 function dispatchKeydown(target: EventTarget, code: string, key: string): KeyboardEvent {
     const event = new KeyboardEvent("keydown", { code, key, bubbles: true, cancelable: true });
@@ -88,5 +89,52 @@ describe("HangulImeController functional keys during composition", () => {
         const r = dispatchKeydown(element, "KeyR", "r");
 
         expect(r.defaultPrevented).toBe(true);
+    });
+});
+
+describe("HangulImeController flushes OSK-driven compositions while inactive", () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    // Mirrors "Hangul typing disabled": the on-screen keyboard drives composition
+    // through the public addJamo() path while the controller is inactive (the
+    // physical keyboard stays Latin). A focus/caret change must still flush the
+    // in-progress composition, otherwise the next OSK jamo attaches to the stale
+    // block. (addJamo is the same entry point enterCharacter / the OSK uses; the
+    // inactive keydown path is intentionally ignored, so we can't go via keydown.)
+    function inactiveController() {
+        jest.spyOn(InputAdapter.prototype, "beginComposition").mockImplementation(() => {});
+        jest.spyOn(InputAdapter.prototype, "updateComposition").mockImplementation(() => {});
+        jest.spyOn(InputAdapter.prototype, "endComposition").mockImplementation(() => {});
+        const blur = jest.spyOn(InputAdapter.prototype, "blur");
+
+        const element = document.createElement("textarea");
+        const controller = new HangulImeController(element); // deliberately NOT activated
+        return { element, controller, blur };
+    }
+
+    it("flushes an in-progress OSK composition on blur", () => {
+        const { element, controller, blur } = inactiveController();
+
+        controller.addJamo("ㅂ", KeyCode.KeyQ); // OSK-driven composition begins
+        element.dispatchEvent(new FocusEvent("blur"));
+
+        expect(blur).toHaveBeenCalled();
+    });
+
+    it("flushes an in-progress OSK composition on mousedown", () => {
+        const { element, controller, blur } = inactiveController();
+
+        controller.addJamo("ㅂ", KeyCode.KeyQ);
+        element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+
+        expect(blur).toHaveBeenCalled();
+    });
+
+    it("does nothing on blur when there is no composition", () => {
+        const { element, blur } = inactiveController();
+
+        element.dispatchEvent(new FocusEvent("blur"));
+
+        expect(blur).not.toHaveBeenCalled();
     });
 });

--- a/src/composition/hangul-ime-controller.test.ts
+++ b/src/composition/hangul-ime-controller.test.ts
@@ -130,6 +130,16 @@ describe("HangulImeController flushes OSK-driven compositions while inactive", (
         expect(blur).toHaveBeenCalled();
     });
 
+    it("flushes an in-progress OSK composition when a physical key is pressed, and lets the key through", () => {
+        const { element, controller, blur } = inactiveController();
+
+        controller.addJamo("ㅂ", KeyCode.KeyQ); // OSK-driven composition begins
+        const keydown = dispatchKeydown(element, "KeyS", "s"); // physical Latin key
+
+        expect(blur).toHaveBeenCalled(); // Korean composition committed/cleared
+        expect(keydown.defaultPrevented).toBe(false); // physical key still types Latin
+    });
+
     it("does nothing on blur when there is no composition", () => {
         const { element, blur } = inactiveController();
 

--- a/src/composition/hangul-ime-controller.ts
+++ b/src/composition/hangul-ime-controller.ts
@@ -212,23 +212,23 @@ export class HangulImeController {
             event.stopImmediatePropagation();
             event.stopPropagation();
         },
-        blur: () => {
-            if (!this._isActive) {
-                return;
-            }
-
-            this.compositor.reset();
-            this.compositionAdapter.blur();
-        },
-        mousedown: () => {
-            if (!this._isActive) {
-                return;
-            }
-
-            this.compositor.reset();
-            this.compositionAdapter.blur();
-        },
+        blur: () => this.flushComposition(),
+        mousedown: () => this.flushComposition(),
     };
+
+    // Commit and clear any in-progress composition. Runs when the controller is
+    // active, or when a composition is in progress even though inactive: the
+    // on-screen keyboard can drive composition while the physical keyboard is
+    // inactive (Hangul typing disabled), and a focus/caret change must still
+    // flush it — otherwise the next OSK jamo would attach to a stale block.
+    private flushComposition() {
+        if (!this._isActive && !this.compositor.isCompositing()) {
+            return;
+        }
+
+        this.compositor.reset();
+        this.compositionAdapter.blur();
+    }
 
     /**
      * Add a non-Hangul character to the composition adapter.

--- a/src/composition/hangul-ime-controller.ts
+++ b/src/composition/hangul-ime-controller.ts
@@ -114,6 +114,12 @@ export class HangulImeController {
             }
 
             if (!this._isActive) {
+                // The on-screen keyboard may have a composition in progress even
+                // though the physical keyboard is inactive (Hangul typing disabled).
+                // A physical keystroke moves past it, so commit/clear it first —
+                // otherwise the next OSK jamo would attach to a stale block.
+                this.flushComposition();
+
                 if (event.altKey && this.lastAlt === KeyCode.AltRight) {
                     // insert character manually when "han/yong" key is down so that a menu isn't triggered
                     this.compositionAdapter.inputCharacter(event.key, code);
@@ -217,10 +223,10 @@ export class HangulImeController {
     };
 
     // Commit and clear any in-progress composition. Runs when the controller is
-    // active, or when a composition is in progress even though inactive: the
+    // active, or whenever a composition is in progress even though inactive — the
     // on-screen keyboard can drive composition while the physical keyboard is
-    // inactive (Hangul typing disabled), and a focus/caret change must still
-    // flush it — otherwise the next OSK jamo would attach to a stale block.
+    // inactive (Hangul typing disabled), so a focus/caret change or a physical
+    // keystroke must still flush it, or the next OSK jamo attaches to a stale block.
     private flushComposition() {
         if (!this._isActive && !this.compositor.isCompositing()) {
             return;

--- a/src/content-script/content-script-controller.ts
+++ b/src/content-script/content-script-controller.ts
@@ -76,12 +76,26 @@ export class ContentScriptController {
     private handleTabStateMessage(message: TabStateMessage) {
         this.isHanYongEnabled = message.data.isHanYongEnabled;
         this.isHanYongKeyboardKeyEnabled = message.data.isHanYongKeyboardKeyEnabled;
+
+        // Tell the on-screen keyboard about the master state first, so it can
+        // reset its independent (master-off) mode when the regime changes.
         this.keyboardController?.setHanYongEnabled(message.data.isHanYongEnabled);
 
-        const nextMode = message.data.isHanYongEnabled ? message.data.koreanKeyboardMode : KoreanKeyboardMode.English;
+        // The physical keyboard follows the shared mode only while Hangul typing
+        // is enabled; otherwise it is locked to Latin.
+        const physicalMode = message.data.isHanYongEnabled
+            ? message.data.koreanKeyboardMode
+            : KoreanKeyboardMode.English;
 
-        if (nextMode !== this.textEntryMode) {
-            this.setTextEntryMode(nextMode);
+        if (physicalMode !== this.textEntryMode) {
+            this.setTextEntryMode(physicalMode);
+        }
+
+        // Mirror the shared mode onto the on-screen keyboard only while Hangul
+        // typing is enabled. While it is disabled the OSK owns its own mode (an
+        // ephemeral, tab-local toggle), so we must not overwrite it here.
+        if (message.data.isHanYongEnabled) {
+            this.keyboardController?.setMode(message.data.koreanKeyboardMode);
         }
 
         if (message.data.isOnScreenKeyboardEnabled) {
@@ -147,6 +161,10 @@ export class ContentScriptController {
         );
     }
 
+    // Drives only the physical keyboard's composition mode. The on-screen
+    // keyboard's mode is handled separately in handleTabStateMessage, because
+    // while Hangul typing is disabled the OSK runs an independent local mode
+    // that the physical keyboard must not share.
     private setTextEntryMode(mode: KoreanKeyboardMode) {
         if (mode == this.textEntryMode) {
             return;
@@ -155,6 +173,5 @@ export class ContentScriptController {
         this.textEntryMode = mode;
 
         this.textInputManager.setMode(mode);
-        this.keyboardController?.setMode(mode);
     }
 }

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
@@ -1,0 +1,76 @@
+import { OnScreenKeyboardController } from "./on-screen-keyboard-controller";
+import { KeyCode } from "../../keyboard/korean-keyboard-map";
+import { ContentScriptRequestAction } from "../../messaging/content-to-service-messages";
+
+// The controller side-effect-imports its stylesheet; Parcel handles that at
+// build time, so stub it for the test runner (cf. the `url:` asset mocks in
+// state-manager.test / menus.test).
+jest.mock("./on-screen-keyboard.scss", () => ({}), { virtual: true });
+
+describe("OnScreenKeyboardController han/yong key", () => {
+    let sendMessage: jest.Mock;
+    let onSendKey: jest.Mock;
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        sendMessage = jest.fn();
+        onSendKey = jest.fn();
+        Object.assign(globalThis, {
+            chrome: {
+                runtime: { sendMessage },
+                i18n: { getMessage: () => "" },
+            },
+        });
+    });
+
+    const keyboard = () => document.querySelector("[id^='kb-']") as HTMLElement;
+
+    const clickKey = (keyCode: KeyCode) => {
+        const el = document.querySelector(`kbd.${keyCode}`);
+        if (!el) {
+            throw new Error(`key ${keyCode} was not rendered`);
+        }
+        el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    };
+
+    it("toggles the shared mode via the service worker when Hangul typing is enabled", () => {
+        const controller = new OnScreenKeyboardController(onSendKey);
+        controller.setHanYongEnabled(true);
+
+        clickKey(KeyCode.AltRight);
+
+        expect(sendMessage).toHaveBeenCalledWith({
+            type: "contentScriptRequest",
+            action: ContentScriptRequestAction.ToggleHanYongMode,
+        });
+    });
+
+    it("toggles an independent OSK-only mode without messaging the service worker when Hangul typing is disabled", () => {
+        const controller = new OnScreenKeyboardController(onSendKey);
+        controller.setHanYongEnabled(false);
+
+        // starts in Latin
+        expect(keyboard().classList.contains("yongMode")).toBe(true);
+
+        clickKey(KeyCode.AltRight);
+
+        // flipped locally to Hangul; nothing sent to the service worker
+        expect(keyboard().classList.contains("hanMode")).toBe(true);
+        expect(sendMessage).not.toHaveBeenCalled();
+
+        // and clicking a jamo key now emits a jamo
+        clickKey(KeyCode.KeyQ);
+        expect(onSendKey).toHaveBeenCalledWith("ㅂ", KeyCode.KeyQ);
+    });
+
+    it("resets the OSK-local mode to Latin when the master regime changes", () => {
+        const controller = new OnScreenKeyboardController(onSendKey);
+        controller.setHanYongEnabled(false);
+
+        clickKey(KeyCode.AltRight);
+        expect(keyboard().classList.contains("hanMode")).toBe(true);
+
+        controller.setHanYongEnabled(true);
+        expect(keyboard().classList.contains("yongMode")).toBe(true);
+    });
+});

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
@@ -1,5 +1,6 @@
 import { OnScreenKeyboardController } from "./on-screen-keyboard-controller";
 import { KeyCode } from "../../keyboard/korean-keyboard-map";
+import { KoreanKeyboardMode } from "../../extension-state/korean-keyboard-mode";
 import { ContentScriptRequestAction } from "../../messaging/content-to-service-messages";
 
 // The controller side-effect-imports its stylesheet; Parcel handles that at
@@ -45,32 +46,41 @@ describe("OnScreenKeyboardController han/yong key", () => {
         });
     });
 
-    it("toggles an independent OSK-only mode without messaging the service worker when Hangul typing is disabled", () => {
+    it("starts in Hangul and toggles an independent OSK-only mode when Hangul typing is disabled", () => {
         const controller = new OnScreenKeyboardController(onSendKey);
         controller.setHanYongEnabled(false);
 
-        // starts in Latin
-        expect(keyboard().classList.contains("yongMode")).toBe(true);
-
-        clickKey(KeyCode.AltRight);
-
-        // flipped locally to Hangul; nothing sent to the service worker
+        // the OSK is the only way to type Korean here, so it starts in Hangul
         expect(keyboard().classList.contains("hanMode")).toBe(true);
-        expect(sendMessage).not.toHaveBeenCalled();
 
-        // and clicking a jamo key now emits a jamo
+        // clicking a jamo emits a jamo, without messaging the service worker
         clickKey(KeyCode.KeyQ);
         expect(onSendKey).toHaveBeenCalledWith("ㅂ", KeyCode.KeyQ);
+        expect(sendMessage).not.toHaveBeenCalled();
+
+        // the 한/영 key flips it locally to Latin, still without messaging
+        clickKey(KeyCode.AltRight);
+        expect(keyboard().classList.contains("yongMode")).toBe(true);
+        expect(sendMessage).not.toHaveBeenCalled();
     });
 
-    it("resets the OSK-local mode to Latin when the master regime changes", () => {
+    it("keeps the OSK-local mode across redundant state updates", () => {
         const controller = new OnScreenKeyboardController(onSendKey);
-        controller.setHanYongEnabled(false);
+        controller.setHanYongEnabled(false); // starts in Hangul
 
-        clickKey(KeyCode.AltRight);
-        expect(keyboard().classList.contains("hanMode")).toBe(true);
-
-        controller.setHanYongEnabled(true);
+        clickKey(KeyCode.AltRight); // user flips to Latin
         expect(keyboard().classList.contains("yongMode")).toBe(true);
+
+        controller.setHanYongEnabled(false); // redundant push must not re-seed it
+        expect(keyboard().classList.contains("yongMode")).toBe(true);
+    });
+
+    it("re-seeds the OSK to Hangul when Hangul typing is turned off", () => {
+        const controller = new OnScreenKeyboardController(onSendKey);
+        controller.setHanYongEnabled(true);
+        controller.setMode(KoreanKeyboardMode.English); // content script mirrors the shared Latin mode
+
+        controller.setHanYongEnabled(false); // regime change -> default to Hangul
+        expect(keyboard().classList.contains("hanMode")).toBe(true);
     });
 });

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
@@ -47,8 +47,17 @@ export class OnScreenKeyboardController {
     }
 
     public setHanYongEnabled(enabled: boolean) {
+        if (enabled === this._isHanYongEnabled) {
+            return;
+        }
+
         this._isHanYongEnabled = enabled;
-        this._keyElements.get(KeyCode.AltRight)?.classList.toggle("disabled", !enabled);
+
+        // Switching regime starts the on-screen keyboard in Latin. When Hangul
+        // typing is enabled the shared mode is pushed in immediately afterwards
+        // (see ContentScriptController); when it is disabled this is the
+        // ephemeral, never-saved OSK-local mode, which resets to Latin here.
+        this.setMode(KoreanKeyboardMode.English);
     }
 
     public setShift(shift: boolean) {
@@ -281,13 +290,21 @@ export class OnScreenKeyboardController {
         } else if (key.label === "Shift") {
             this.setShift(!isShift);
         } else if (keyCode === KeyCode.AltRight) {
-            if (!this._isHanYongEnabled) {
-                return;
+            if (this._isHanYongEnabled) {
+                // Hangul typing is enabled: behave like the toolbar toggle and
+                // the physical Right Alt key — flip the shared per-tab mode.
+                api.runtime.sendMessage<ContentScriptRequestMessage>({
+                    type: "contentScriptRequest",
+                    action: ContentScriptRequestAction.ToggleHanYongMode,
+                });
+            } else {
+                // Hangul typing is disabled: this is an independent, ephemeral,
+                // OSK-only toggle. It never leaves this tab, is never saved, and
+                // does not affect the physical keyboard.
+                this.setMode(
+                    this._mode === KoreanKeyboardMode.Hangul ? KoreanKeyboardMode.English : KoreanKeyboardMode.Hangul
+                );
             }
-            api.runtime.sendMessage<ContentScriptRequestMessage>({
-                type: "contentScriptRequest",
-                action: ContentScriptRequestAction.ToggleHanYongMode,
-            });
         } else if (keyCode === KeyCode.Space) {
             this.sendKey(" ", keyCode);
         } else if (keyCode === KeyCode.Backspace) {
@@ -392,7 +409,5 @@ export class OnScreenKeyboardController {
 
             keyboardELement.appendChild(rowElement);
         });
-
-        this.setHanYongEnabled(this._isHanYongEnabled);
     }
 }

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
@@ -24,7 +24,9 @@ export class OnScreenKeyboardController {
     };
 
     private _mode = KoreanKeyboardMode.English;
-    private _isHanYongEnabled = false;
+    // `undefined` until the first state update, so the first call to
+    // setHanYongEnabled always counts as entering a regime and seeds the mode.
+    private _isHanYongEnabled?: boolean;
     private _isShift = false;
     private _compositionFeatures: SupportedCompositionFeatures | undefined;
     private _keyElements = new Map<KeyCode, HTMLElement>();
@@ -53,11 +55,13 @@ export class OnScreenKeyboardController {
 
         this._isHanYongEnabled = enabled;
 
-        // Switching regime starts the on-screen keyboard in Latin. When Hangul
-        // typing is enabled the shared mode is pushed in immediately afterwards
-        // (see ContentScriptController); when it is disabled this is the
-        // ephemeral, never-saved OSK-local mode, which resets to Latin here.
-        this.setMode(KoreanKeyboardMode.English);
+        // Seed the on-screen keyboard's mode when entering a regime:
+        //  - Hangul typing off: the OSK is the only way to type Korean, so start
+        //    in Hangul. The mode is ephemeral (tab-local, never saved) — the user
+        //    can still flip it, and it re-seeds to Hangul on the next page load.
+        //  - Hangul typing on: start in Latin; ContentScriptController mirrors the
+        //    shared mode in immediately afterwards, so this is a transient seed.
+        this.setMode(enabled ? KoreanKeyboardMode.English : KoreanKeyboardMode.Hangul);
     }
 
     public setShift(shift: boolean) {


### PR DESCRIPTION
## Summary

Implements #71. When **"Enable Korean (Hangul) typing"** is off, the on-screen keyboard's 한/영 switch becomes an independent, ephemeral control instead of being greyed out — so people who keep their physical keyboard Latin-only (occasional Korean, unknown layout, mouse/accessibility input) can still click Korean on the OSK.

## Behaviour

- **Hangul typing ON** (unchanged): the OSK 한/영 switch toggles the shared per-tab mode, exactly like the toolbar toggle and the Right Alt key (propagates across tabs / persists per the start-state setting).
- **Hangul typing OFF**:
  - the OSK 한/영 switch is live (no longer greyed) and toggles an OSK-only mode;
  - it **defaults to Hangul** (the OSK is the only way to type Korean here, so this saves a 한/영 click each session; the user can still flip it to Latin);
  - it affects only what the OSK types — the physical keyboard stays Latin;
  - the mode is tab-local (never broadcast, even with "share across tabs") and never saved (re-seeds to Hangul on page load).

No new settings and no service-worker/storage changes — the ephemeral mode lives entirely in the content script.

## Implementation

- `content-script-controller.ts`: drive the physical keyboard's mode and the OSK's mode separately; the OSK is mirrored to the shared mode only while Hangul typing is enabled (while disabled, the OSK owns its mode).
- `on-screen-keyboard-controller.ts`: the 한/영 key toggles the shared mode when enabled and a local mode when disabled; `setHanYongEnabled` seeds the OSK mode on a regime change (Hangul when typing is off, Latin when on); the key is no longer greyed.

## Testing

- `npm run validate`
- New `on-screen-keyboard-controller.test.ts`: global toggle (message sent) vs. local toggle (no message, defaults to Hangul, jamo emitted), local mode is sticky across redundant updates, and re-seeds to Hangul when Hangul typing is turned off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
