### PR TITLE
refactor: unify onMessage dispatch via routeByAction (#36)

### DIFF
--- a/src/content-script/content-script-controller.ts
+++ b/src/content-script/content-script-controller.ts
@@ -15,6 +15,7 @@ import {
     isServiceScriptMessage,
 } from "../messaging/service-to-content-messages";
 import { api } from "../platform/browser-api";
+import { routeByAction } from "../messaging/route-message";
 
 export class ContentScriptController {
     private isHanYongEnabled = false;
@@ -54,21 +55,18 @@ export class ContentScriptController {
             debugLog("content.js: received message", message);
 
             if (isServiceScriptMessage(message)) {
-                switch (message.action) {
-                    case ServiceScriptMessageAction.UpdateState:
-                        this.handleTabStateMessage(message);
-                        break;
-                }
-            }
-
-            this.textInputManager.handleMessage(message);
-
-            if (isContentScriptBroadcastMessage(message)) {
-                switch (message.action) {
-                    case ContentScriptBroadcastAction.UpdateCompositionFeatures:
-                        this.keyboardController?.setCompositionFeatures(message.data);
-                        break;
-                }
+                routeByAction(message, {
+                    [ServiceScriptMessageAction.UpdateState]: (m) => this.handleTabStateMessage(m),
+                    [ServiceScriptMessageAction.SendKey]: (m) =>
+                        this.textInputManager.enterCharacter(m.data.key, m.data.keyCode),
+                    [ServiceScriptMessageAction.InsertTextAfterSelection]: (m) =>
+                        this.textInputManager.insertTextAfterSelection(m.data),
+                });
+            } else if (isContentScriptBroadcastMessage(message)) {
+                routeByAction(message, {
+                    [ContentScriptBroadcastAction.UpdateCompositionFeatures]: (m) =>
+                        this.keyboardController?.setCompositionFeatures(m.data),
+                });
             }
         });
     }

--- a/src/content-script/text-input-manager.ts
+++ b/src/content-script/text-input-manager.ts
@@ -4,13 +4,6 @@ import { CompositionAdapterFactory } from "../composition/composition-adapter-fa
 import { isHangulOrJamo } from "../composition/hangul-maps";
 import { KeyCode } from "../keyboard/korean-keyboard-map";
 import { SupportedCompositionFeatures } from "../composition/composition-adapters/composition-adapter-interface";
-import { ContentScriptBroadcastMessage } from "../messaging/content-to-content-messages";
-import {
-    ServiceScriptMessage,
-    ServiceScriptMessageAction,
-    SendKeyServiceMessage,
-    isServiceScriptMessage,
-} from "../messaging/service-to-content-messages";
 
 const nonTextInputTypes = ["button", "checkbox", "file", "hidden", "image", "radio", "range", "submit", "password"];
 const inputSelector = `input:not(${nonTextInputTypes.map((t) => `[type=${t}]`).join(",")})`;
@@ -24,12 +17,6 @@ export class TextInputManager {
     private imeControllers = new Map<HTMLElement, HangulImeController>();
     private textEntryMode: KoreanKeyboardMode = KoreanKeyboardMode.English;
     private removalObserver?: MutationObserver;
-
-    public handleMessage(message: ContentScriptBroadcastMessage | ServiceScriptMessage) {
-        if (isServiceScriptMessage(message)) {
-            this.handleServiceScriptRequest(message);
-        }
-    }
 
     public setMode(mode: KoreanKeyboardMode) {
         this.textEntryMode = mode;
@@ -51,34 +38,27 @@ export class TextInputManager {
         return;
     }
 
-    private handleServiceScriptRequest(message: ServiceScriptMessage) {
-        switch (message.action) {
-            case ServiceScriptMessageAction.SendKey: {
-                const { key, keyCode } = (message as SendKeyServiceMessage).data;
-                this.enterCharacter(key, keyCode);
-                break;
-            }
-            case ServiceScriptMessageAction.InsertTextAfterSelection: {
-                const element = this.getActiveElement(document);
+    // Insert text at the caret in the active editable, replacing any selection.
+    // Driven by the InsertTextAfterSelection service message (routed from the
+    // content-script controller).
+    public insertTextAfterSelection(text: string) {
+        const element = this.getActiveElement(document);
 
-                if (!element) {
-                    return;
-                }
-
-                const compositionAdapter = CompositionAdapterFactory.createCompositionAdapter(element);
-
-                if (!compositionAdapter) {
-                    return;
-                }
-
-                // todo: implement an insertAfter method in the composition adapter
-                compositionAdapter.collapseSelection();
-                compositionAdapter.beginComposition(message.data, KeyCode.KeyK); // KeyK is arbitrary
-                compositionAdapter.updateComposition(message.data, KeyCode.KeyK); // KeyK is arbitrary
-                compositionAdapter.endComposition(message.data);
-                break;
-            }
+        if (!element) {
+            return;
         }
+
+        const compositionAdapter = CompositionAdapterFactory.createCompositionAdapter(element);
+
+        if (!compositionAdapter) {
+            return;
+        }
+
+        // todo: implement an insertAfter method in the composition adapter
+        compositionAdapter.collapseSelection();
+        compositionAdapter.beginComposition(text, KeyCode.KeyK); // KeyK is arbitrary
+        compositionAdapter.updateComposition(text, KeyCode.KeyK); // KeyK is arbitrary
+        compositionAdapter.endComposition(text);
     }
 
     public enterCharacter(char: string, keyCode: KeyCode): boolean {

--- a/src/messaging/route-message.test.ts
+++ b/src/messaging/route-message.test.ts
@@ -1,0 +1,22 @@
+import { routeByAction } from "./route-message";
+
+type Msg = { action: "a"; data: number } | { action: "b"; data: string } | { action: "c" };
+
+describe("routeByAction", () => {
+    it("calls the handler matching the action, narrowed to that variant, and no other", () => {
+        const onA = jest.fn();
+        const onB = jest.fn();
+
+        routeByAction<Msg>({ action: "b", data: "hi" }, { a: onA, b: onB });
+
+        expect(onB).toHaveBeenCalledWith({ action: "b", data: "hi" });
+        expect(onA).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when no handler is registered for the action", () => {
+        const onA = jest.fn();
+
+        expect(() => routeByAction<Msg>({ action: "c" }, { a: onA })).not.toThrow();
+        expect(onA).not.toHaveBeenCalled();
+    });
+});

--- a/src/messaging/route-message.ts
+++ b/src/messaging/route-message.ts
@@ -1,0 +1,17 @@
+/**
+ * Typed dispatch for a discriminated message union.
+ *
+ * Each `onMessage` listener narrows a message with its `isX` type-guard and then
+ * needs to fan out on `message.action`. Rather than hand-roll a `switch` at every
+ * listener, pass a handler table keyed by action: `routeByAction` looks up the
+ * handler for the message's action and calls it with the message narrowed to that
+ * action's variant. An action with no entry is simply ignored.
+ */
+type ActionHandlers<M extends { action: string }> = {
+    [A in M["action"]]?: (message: Extract<M, { action: A }>) => void;
+};
+
+export function routeByAction<M extends { action: string }>(message: M, handlers: ActionHandlers<M>): void {
+    const handler = handlers[message.action as M["action"]] as ((message: M) => void) | undefined;
+    handler?.(message);
+}

--- a/src/service-worker/content-script-listener.ts
+++ b/src/service-worker/content-script-listener.ts
@@ -1,8 +1,5 @@
-import {
-    ContentScriptRequestMessage,
-    ContentScriptRequestAction,
-    SendKeyRequestMessage,
-} from "../messaging/content-to-service-messages";
+import { ContentScriptRequestMessage, ContentScriptRequestAction } from "../messaging/content-to-service-messages";
+import { routeByAction } from "../messaging/route-message";
 import { StateManager } from "./state-manager";
 import { sendMessageToTab } from "./send-message-to-tab";
 import { debugLog } from "../debug-log";
@@ -35,43 +32,32 @@ export class ContentScriptListener {
                 if (!sender.tab?.id) {
                     return;
                 }
+                const tabId = sender.tab.id;
 
                 if (isContentScriptBroadcastMessage(message)) {
                     if (sender.frameId !== undefined) {
-                        this.stateManager.setFocusedFrame(sender.tab.id, sender.frameId);
+                        this.stateManager.setFocusedFrame(tabId, sender.frameId);
                     }
-                    sendMessageToTab(sender.tab.id, message);
+                    sendMessageToTab(tabId, message);
                     return;
                 }
 
-                // These StateManager calls are async; attach a catch so a failure
-                // (e.g. storage error) is logged rather than becoming an unhandled
-                // rejection that could destabilize the MV3 worker.
-                switch (message.action) {
-                    case ContentScriptRequestAction.ToggleHanYongMode:
-                        this.stateManager
-                            .toggleHanYongMode(sender.tab.id)
-                            .catch((error) => debugLog("toggleHanYongMode failed:", error));
-                        break;
+                // The StateManager calls are async; log a failure rather than
+                // letting it become an unhandled rejection that could destabilize
+                // the MV3 worker.
+                const run = (label: string, work: Promise<unknown>) =>
+                    void work.catch((error) => debugLog(`${label} failed:`, error));
 
-                    case ContentScriptRequestAction.RefreshState:
-                        this.stateManager
-                            .sendStateToTab(sender.tab.id)
-                            .catch((error) => debugLog("sendStateToTab failed:", error));
-                        break;
-
-                    case ContentScriptRequestAction.SendKey:
-                        this.stateManager
-                            .routeSendKey(sender.tab.id, (message as SendKeyRequestMessage).data)
-                            .catch((error) => debugLog("routeSendKey failed:", error));
-                        break;
-
-                    case ContentScriptRequestAction.DisableOnScreenKeyboard:
-                        this.stateManager
-                            .setOnScreenKeyboardEnabled(sender.tab.id, false)
-                            .catch((error) => debugLog("setOnScreenKeyboardEnabled failed:", error));
-                        break;
-                }
+                routeByAction(message, {
+                    [ContentScriptRequestAction.ToggleHanYongMode]: () =>
+                        run("toggleHanYongMode", this.stateManager.toggleHanYongMode(tabId)),
+                    [ContentScriptRequestAction.RefreshState]: () =>
+                        run("sendStateToTab", this.stateManager.sendStateToTab(tabId)),
+                    [ContentScriptRequestAction.SendKey]: (m) =>
+                        run("routeSendKey", this.stateManager.routeSendKey(tabId, m.data)),
+                    [ContentScriptRequestAction.DisableOnScreenKeyboard]: () =>
+                        run("setOnScreenKeyboardEnabled", this.stateManager.setOnScreenKeyboardEnabled(tabId, false)),
+                });
             }
         );
 


### PR DESCRIPTION
Closes #36

Unifies the two `runtime.onMessage` listeners behind a single typed `routeByAction` dispatch helper, and consolidates the content-script's previously split `ServiceScriptMessage` handling into one place.
