### PR TITLE
feat: persist OSK position per-site and collapsed state globally (#74)

### DIFF
--- a/src/content-script/content-script-controller.test.ts
+++ b/src/content-script/content-script-controller.test.ts
@@ -1,12 +1,28 @@
 import { ContentScriptController } from "./content-script-controller";
+import { OnScreenKeyboardController } from "./on-screen-keyboard/on-screen-keyboard-controller";
 import { KeyCode } from "../keyboard/korean-keyboard-map";
 import { KoreanKeyboardMode } from "../extension-state/korean-keyboard-mode";
 import { ServiceScriptMessageAction } from "../messaging/service-to-content-messages";
 import { ContentScriptRequestAction } from "../messaging/content-to-service-messages";
 
 jest.mock("./on-screen-keyboard/on-screen-keyboard-controller", () => ({
-    OnScreenKeyboardController: class OnScreenKeyboardController {},
+    OnScreenKeyboardController: jest.fn().mockImplementation(() => ({
+        showKeyboard: jest.fn(),
+        hideKeyboard: jest.fn(),
+        applyPersistedLayout: jest.fn(),
+        setHanYongEnabled: jest.fn(),
+        setMode: jest.fn(),
+        setCompositionFeatures: jest.fn(),
+    })),
 }));
+
+// The most recently constructed (mocked) keyboard controller.
+const lastOsk = () =>
+    (OnScreenKeyboardController as unknown as jest.Mock).mock.results.at(-1)?.value as {
+        showKeyboard: jest.Mock;
+        hideKeyboard: jest.Mock;
+        applyPersistedLayout: jest.Mock;
+    };
 
 describe("ContentScriptController AltRight handling", () => {
     it("only intercepts AltRight when Hangul typing and the keyboard-key option are both enabled", () => {
@@ -120,5 +136,70 @@ describe("ContentScriptController AltRight handling", () => {
             type: "contentScriptRequest",
             action: ContentScriptRequestAction.ToggleHanYongMode,
         });
+    });
+});
+
+describe("ContentScriptController on-screen-keyboard layout", () => {
+    let listeners: Array<(message: unknown) => void>;
+    let sendMessage: jest.Mock;
+
+    beforeEach(() => {
+        (OnScreenKeyboardController as unknown as jest.Mock).mockClear();
+        listeners = [];
+        sendMessage = jest.fn();
+        Object.assign(globalThis, {
+            chrome: {
+                runtime: {
+                    sendMessage,
+                    onMessage: { addListener: (listener: (message: unknown) => void) => listeners.push(listener) },
+                },
+            },
+        });
+    });
+
+    const updateState = (isOnScreenKeyboardEnabled: boolean) => ({
+        type: "serviceScriptMessage",
+        action: ServiceScriptMessageAction.UpdateState,
+        data: {
+            isHanYongEnabled: false,
+            isHanYongKeyboardKeyEnabled: false,
+            isOnScreenKeyboardEnabled,
+            koreanKeyboardMode: KoreanKeyboardMode.English,
+        },
+    });
+
+    it("requests the saved layout on init in the top window", () => {
+        new ContentScriptController().initialize(true);
+
+        expect(sendMessage.mock.calls.map((c) => c[0])).toContainEqual(
+            expect.objectContaining({ action: ContentScriptRequestAction.RequestOnScreenKeyboardLayout })
+        );
+    });
+
+    it("gates the first show until the saved layout arrives, then applies and shows it", () => {
+        new ContentScriptController().initialize(true);
+        const dispatch = listeners[0];
+
+        // Enabled, but no layout yet -> must not show (no default-then-jump).
+        dispatch(updateState(true));
+        expect(lastOsk().showKeyboard).not.toHaveBeenCalled();
+
+        // Layout arrives -> apply it, then show.
+        dispatch({
+            type: "serviceScriptMessage",
+            action: ServiceScriptMessageAction.OnScreenKeyboardLayout,
+            data: { collapsed: false },
+        });
+        expect(lastOsk().applyPersistedLayout).toHaveBeenCalledWith({ collapsed: false });
+        expect(lastOsk().showKeyboard).toHaveBeenCalled();
+    });
+
+    it("hides immediately without waiting on the layout", () => {
+        new ContentScriptController().initialize(true);
+        const dispatch = listeners[0];
+
+        dispatch(updateState(false));
+        expect(lastOsk().hideKeyboard).toHaveBeenCalled();
+        expect(lastOsk().showKeyboard).not.toHaveBeenCalled();
     });
 });

--- a/src/content-script/content-script-controller.ts
+++ b/src/content-script/content-script-controller.ts
@@ -16,6 +16,7 @@ import {
 } from "../messaging/service-to-content-messages";
 import { api } from "../platform/browser-api";
 import { routeByAction } from "../messaging/route-message";
+import { currentOskSite } from "./osk-site";
 
 export class ContentScriptController {
     private isHanYongEnabled = false;
@@ -23,6 +24,10 @@ export class ContentScriptController {
     private textEntryMode = KoreanKeyboardMode.English;
     private textInputManager = new TextInputManager();
     private keyboardController?: OnScreenKeyboardController;
+    // The keyboard's first show is gated on its saved layout arriving, so a
+    // restored position never appears at the default corner and then jumps.
+    private isOskLayoutApplied = false;
+    private shouldShowOsk = false;
 
     public initialize(isTopWindow: boolean) {
         this.keyboardController = isTopWindow
@@ -41,12 +46,26 @@ export class ContentScriptController {
         this.setupMessageListener();
         this.setupDocumentListeners();
         this.requestState();
+
+        // Only the top window hosts the keyboard, so only it needs the saved
+        // layout. The reply gates the first show (see updateOskVisibility).
+        if (isTopWindow) {
+            this.requestOnScreenKeyboardLayout();
+        }
     }
 
     private requestState() {
         api.runtime.sendMessage<ContentScriptRequestMessage>({
             type: "contentScriptRequest",
             action: ContentScriptRequestAction.RefreshState,
+        });
+    }
+
+    private requestOnScreenKeyboardLayout() {
+        api.runtime.sendMessage<ContentScriptRequestMessage>({
+            type: "contentScriptRequest",
+            action: ContentScriptRequestAction.RequestOnScreenKeyboardLayout,
+            data: { site: currentOskSite() },
         });
     }
 
@@ -61,6 +80,11 @@ export class ContentScriptController {
                         this.textInputManager.enterCharacter(m.data.key, m.data.keyCode),
                     [ServiceScriptMessageAction.InsertTextAfterSelection]: (m) =>
                         this.textInputManager.insertTextAfterSelection(m.data),
+                    [ServiceScriptMessageAction.OnScreenKeyboardLayout]: (m) => {
+                        this.keyboardController?.applyPersistedLayout(m.data);
+                        this.isOskLayoutApplied = true;
+                        this.updateOskVisibility();
+                    },
                 });
             } else if (isContentScriptBroadcastMessage(message)) {
                 routeByAction(message, {
@@ -96,10 +120,18 @@ export class ContentScriptController {
             this.keyboardController?.setMode(message.data.koreanKeyboardMode);
         }
 
-        if (message.data.isOnScreenKeyboardEnabled) {
-            this.keyboardController?.showKeyboard();
-        } else {
+        this.shouldShowOsk = message.data.isOnScreenKeyboardEnabled;
+        this.updateOskVisibility();
+    }
+
+    // Show the keyboard only once it's both wanted and its saved layout has been
+    // applied, so a restored position isn't shown at the default corner first.
+    // Hiding needs no layout and happens immediately.
+    private updateOskVisibility() {
+        if (!this.shouldShowOsk) {
             this.keyboardController?.hideKeyboard();
+        } else if (this.isOskLayoutApplied) {
+            this.keyboardController?.showKeyboard();
         }
     }
 

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
@@ -482,3 +482,102 @@ describe("OnScreenKeyboardController anchor guides", () => {
         }
     });
 });
+
+describe("OnScreenKeyboardController persisted layout", () => {
+    let sendMessage: jest.Mock;
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        sendMessage = jest.fn();
+        Object.assign(globalThis, {
+            chrome: { runtime: { sendMessage }, i18n: { getMessage: () => "" } },
+        });
+        Object.defineProperty(window, "innerWidth", { configurable: true, value: 1200 });
+        Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
+    });
+
+    const host = () => document.querySelector("[id^='kb-']") as HTMLElement;
+
+    const sizedKeyboard = () => {
+        const el = host();
+        // jsdom has no layout; give the keyboard a real size so placement clamps.
+        Object.defineProperty(el, "offsetWidth", { configurable: true, value: 480 });
+        Object.defineProperty(el, "offsetHeight", { configurable: true, value: 250 });
+        return el;
+    };
+
+    const persistCalls = () =>
+        sendMessage.mock.calls
+            .map((call) => call[0])
+            .filter((m) => m.action === ContentScriptRequestAction.PersistOnScreenKeyboardLayout);
+
+    it("applies a restored position and collapsed state, used on the next show", () => {
+        const controller = new OnScreenKeyboardController(() => {});
+        const el = sizedKeyboard();
+
+        controller.applyPersistedLayout({
+            position: { originX: "left", originY: "top", x: 30, y: 40 },
+            collapsed: true,
+        });
+        expect(el.classList.contains("collapsed")).toBe(true);
+
+        controller.showKeyboard();
+
+        // Restored to the saved top-left anchor, not the default bottom-right.
+        expect(el.style.left).toBe("30px");
+        expect(el.style.top).toBe("40px");
+        expect(el.style.right).toBe("");
+        expect(el.style.bottom).toBe("");
+    });
+
+    it("persists the new position (with the site key) on drag-drop", () => {
+        const controller = new OnScreenKeyboardController(() => {});
+        const el = sizedKeyboard();
+        controller.showKeyboard();
+        sendMessage.mockClear();
+
+        (el.querySelector(".kb-handle") as HTMLElement).dispatchEvent(
+            new MouseEvent("mousedown", { bubbles: true, button: 0, clientX: 600, clientY: 400 })
+        );
+        document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, buttons: 1, clientX: 560, clientY: 360 }));
+        document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 0 }));
+
+        const calls = persistCalls();
+        expect(calls).toHaveLength(1);
+        expect(calls[0].data.site).toBe("localhost"); // jsdom default hostname
+        expect(calls[0].data.position).toMatchObject({
+            originX: expect.any(String),
+            originY: expect.any(String),
+            x: expect.any(Number),
+            y: expect.any(Number),
+        });
+    });
+
+    it("does not persist on a bare header click with no movement", () => {
+        const controller = new OnScreenKeyboardController(() => {});
+        const el = sizedKeyboard();
+        controller.showKeyboard();
+        sendMessage.mockClear();
+
+        (el.querySelector(".kb-handle") as HTMLElement).dispatchEvent(
+            new MouseEvent("mousedown", { bubbles: true, button: 0, clientX: 600, clientY: 400 })
+        );
+        document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 0 }));
+
+        expect(persistCalls()).toHaveLength(0);
+    });
+
+    it("persists the collapsed state globally (no site) when toggled", () => {
+        const controller = new OnScreenKeyboardController(() => {});
+        const el = sizedKeyboard();
+        controller.showKeyboard();
+        sendMessage.mockClear();
+
+        (el.querySelector(".kb-collapse") as HTMLButtonElement).click();
+
+        const calls = persistCalls();
+        expect(calls).toHaveLength(1);
+        expect(calls[0].data.collapsed).toBe(true);
+        expect(calls[0].data.site).toBeUndefined();
+    });
+});

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
@@ -7,6 +7,8 @@ import { ContentScriptRequestAction, ContentScriptRequestMessage } from "../../m
 import { debugLog } from "../../debug-log";
 import { api } from "../../platform/browser-api";
 import { modeIconHangul, modeIconEnglish } from "./mode-icons";
+import { KeyboardPlacement, OnScreenKeyboardLayout } from "../../extension-state/osk-layout";
+import { currentOskSite } from "../osk-site";
 
 /** Full keyboard width, and the narrower width used while collapsed. */
 const KEYBOARD_WIDTH_PX = 480;
@@ -35,9 +37,9 @@ const GUIDE_EDGE_THICKNESS_PX = (GUIDE_EDGE_THICKNESS_MM * 96) / 25.4;
 
 export class OnScreenKeyboardController {
     private _keyboardElement: HTMLDivElement;
-    private _keyboardPlacement = {
-        originX: "right" as "right" | "left",
-        originY: "bottom" as "bottom" | "top",
+    private _keyboardPlacement: KeyboardPlacement = {
+        originX: "right",
+        originY: "bottom",
         x: 0,
         y: 0,
     };
@@ -48,6 +50,9 @@ export class OnScreenKeyboardController {
             startY: 0,
         },
     };
+    // Whether the keyboard actually moved during the current drag, so a drop
+    // persists the new position only after a real move (not a bare header click).
+    private _movedDuringDrag = false;
 
     private _mode = KoreanKeyboardMode.English;
     // `undefined` until the first state update, so the first call to
@@ -146,10 +151,60 @@ export class OnScreenKeyboardController {
 
         // A drag is an explicit move, so re-anchor to the corner it lands in.
         this.placeKeyboard(true);
+        this._movedDuringDrag = true;
 
         // Surface which two edges it's now anchored to (placeKeyboard has just
         // resolved them) for as long as the drag continues.
         this.showGuides();
+    }
+
+    private endDrag() {
+        this._keyboardMovement.mouse.down = false;
+        this.hideGuidesAfterDrop();
+
+        // Persist the landing spot only after an actual move, so a bare header
+        // click doesn't rewrite the saved position.
+        if (this._movedDuringDrag) {
+            this._movedDuringDrag = false;
+            this.persistLayout({ position: this._keyboardPlacement });
+        }
+    }
+
+    /**
+     * Apply a persisted layout before the keyboard is first shown: the per-site
+     * position (when one was saved) and the global collapsed state. The content
+     * script gates the first show on this, so there's no default-then-jump.
+     */
+    public applyPersistedLayout(layout: OnScreenKeyboardLayout) {
+        if (layout.position) {
+            this._keyboardPlacement = { ...layout.position };
+        }
+        this.setCollapsed(layout.collapsed);
+    }
+
+    // Ask the service worker to persist whichever layout fields changed. A
+    // position needs a site key; the collapsed state is global. Failures are
+    // logged, not surfaced — persistence is best-effort.
+    private persistLayout(update: { position?: KeyboardPlacement; collapsed?: boolean }) {
+        const data: { site?: string; position?: KeyboardPlacement; collapsed?: boolean } = {
+            collapsed: update.collapsed,
+        };
+
+        if (update.position) {
+            const site = currentOskSite();
+            // Nothing meaningful to key a position on (e.g. file://) — skip it.
+            if (!site) {
+                return;
+            }
+            data.site = site;
+            data.position = update.position;
+        }
+
+        api.runtime.sendMessage<ContentScriptRequestMessage>({
+            type: "contentScriptRequest",
+            action: ContentScriptRequestAction.PersistOnScreenKeyboardLayout,
+            data,
+        });
     }
 
     hideKeyboard() {
@@ -269,6 +324,7 @@ export class OnScreenKeyboardController {
             // Drag only from the header bar, and not from its buttons.
             if (e.target.closest(".kb-header") && !e.target.closest("button") && !e.target.closest(".kb-mode")) {
                 this._keyboardMovement.mouse.down = true;
+                this._movedDuringDrag = false;
                 // clientX/Y (CSS px, viewport-relative), not screenX/Y (device px):
                 // the placement math is in CSS px, so a device-px delta would move
                 // the keyboard at the wrong rate under page zoom (e.g. 2x at 200%).
@@ -281,15 +337,13 @@ export class OnScreenKeyboardController {
 
         document.addEventListener("mouseup", (e) => {
             if (e.button === 0) {
-                this._keyboardMovement.mouse.down = false;
-                this.hideGuidesAfterDrop();
+                this.endDrag();
             }
         });
 
         document.addEventListener("mousemove", (e) => {
             if ((e.buttons & 1) === 0) {
-                this._keyboardMovement.mouse.down = false;
-                this.hideGuidesAfterDrop();
+                this.endDrag();
             }
 
             if (this._keyboardMovement.mouse.down) {
@@ -547,7 +601,22 @@ export class OnScreenKeyboardController {
     }
 
     private toggleCollapsed() {
-        const collapsed = this._keyboardElement.classList.toggle("collapsed");
+        const collapsed = !this._keyboardElement.classList.contains("collapsed");
+        this.setCollapsed(collapsed);
+
+        // The keyboard's size changed, so re-clamp it to stay on-screen (its
+        // anchor is preserved).
+        this.placeKeyboard();
+
+        // The collapsed state is remembered globally (not per-site).
+        this.persistLayout({ collapsed });
+    }
+
+    // Apply the collapsed/expanded visual state without re-clamping or
+    // persisting — shared by the user toggle and by restoring a saved layout
+    // (which runs before the keyboard is shown, so placement happens on show).
+    private setCollapsed(collapsed: boolean) {
+        this._keyboardElement.classList.toggle("collapsed", collapsed);
 
         // Collapsed, only the header shows (the keys are hidden), so shrink the
         // keyboard to fit its header contents; expanded, restore the full width.
@@ -557,10 +626,6 @@ export class OnScreenKeyboardController {
             this._collapseButton.textContent = collapsed ? "\u{1F5D6}" : "\u{1F5D5}";
             this._collapseButton.title = api.i18n.getMessage(collapsed ? "keyboard_restore" : "keyboard_minimise");
         }
-
-        // The keyboard's size changed, so re-clamp it to stay on-screen (its
-        // anchor is preserved).
-        this.placeKeyboard();
     }
 
     // Toggles Hangul/Latin: the shared per-tab mode when Hangul typing is enabled

--- a/src/content-script/osk-site.test.ts
+++ b/src/content-script/osk-site.test.ts
@@ -1,0 +1,23 @@
+import { currentOskSite } from "./osk-site";
+
+describe("currentOskSite", () => {
+    it("lowercases the hostname", () => {
+        expect(currentOskSite("Example.COM")).toBe("example.com");
+    });
+
+    it("strips a single leading www.", () => {
+        expect(currentOskSite("www.example.com")).toBe("example.com");
+    });
+
+    it("strips only one leading www.", () => {
+        expect(currentOskSite("www.www.example.com")).toBe("www.example.com");
+    });
+
+    it("keeps subdomains distinct", () => {
+        expect(currentOskSite("mail.example.com")).toBe("mail.example.com");
+    });
+
+    it("returns undefined for an empty hostname (file://, about:blank)", () => {
+        expect(currentOskSite("")).toBeUndefined();
+    });
+});

--- a/src/content-script/osk-site.ts
+++ b/src/content-script/osk-site.ts
@@ -1,0 +1,17 @@
+/**
+ * The "site" key the on-screen-keyboard position is remembered under: the
+ * lowercased `location.hostname` with a single leading `www.` removed. Scheme
+ * and port are ignored and subdomains are distinct, so `mail.example.com` and
+ * `docs.example.com` differ while `www.example.com` and `example.com` match.
+ *
+ * Returns `undefined` for an empty hostname (e.g. `file://`, `about:blank`),
+ * which has nothing meaningful to key a position on — callers skip persisting a
+ * position in that case (the global collapsed state is still remembered).
+ */
+export function currentOskSite(hostname: string = location.hostname): string | undefined {
+    const host = hostname.toLowerCase();
+    if (!host) {
+        return undefined;
+    }
+    return host.startsWith("www.") ? host.slice("www.".length) : host;
+}

--- a/src/extension-state/osk-layout.ts
+++ b/src/extension-state/osk-layout.ts
@@ -1,0 +1,19 @@
+/**
+ * Persisted on-screen-keyboard layout. The position (corner anchor + offset) is
+ * remembered per-site; the collapsed/minimised state is a single global value.
+ * Both are stored by the service worker in `chrome.storage.local` and exchanged
+ * with the content script via the layout messages (see `route-message` callers).
+ */
+export type KeyboardPlacement = {
+    originX: "left" | "right";
+    originY: "top" | "bottom";
+    x: number;
+    y: number;
+};
+
+export type OnScreenKeyboardLayout = {
+    /** Per-site position; absent when the site has no saved position yet. */
+    position?: KeyboardPlacement;
+    /** Global minimised/maximised state. */
+    collapsed: boolean;
+};

--- a/src/messaging/content-to-service-messages.ts
+++ b/src/messaging/content-to-service-messages.ts
@@ -1,6 +1,7 @@
 // messages sent from content scripts to the background script
 
 import { KeyCode } from "../keyboard/korean-keyboard-map";
+import { KeyboardPlacement } from "../extension-state/osk-layout";
 import { hasProperties } from "../types/objects";
 
 export enum ContentScriptRequestAction {
@@ -12,12 +13,28 @@ export enum ContentScriptRequestAction {
     SendKey = "sendKey",
     /** request the service script to turn the on-screen keyboard off */
     DisableOnScreenKeyboard = "disableOnScreenKeyboard",
+    /** request the saved on-screen-keyboard layout for this site */
+    RequestOnScreenKeyboardLayout = "requestOnScreenKeyboardLayout",
+    /** ask the service script to persist the on-screen-keyboard layout */
+    PersistOnScreenKeyboardLayout = "persistOnScreenKeyboardLayout",
 }
 
 export type SendKeyRequestMessage = {
     type: "contentScriptRequest";
     action: ContentScriptRequestAction.SendKey;
     data: { key: string; keyCode: KeyCode };
+};
+
+export type RequestOnScreenKeyboardLayoutMessage = {
+    type: "contentScriptRequest";
+    action: ContentScriptRequestAction.RequestOnScreenKeyboardLayout;
+    data: { site?: string };
+};
+
+export type PersistOnScreenKeyboardLayoutMessage = {
+    type: "contentScriptRequest";
+    action: ContentScriptRequestAction.PersistOnScreenKeyboardLayout;
+    data: { site?: string; position?: KeyboardPlacement; collapsed?: boolean };
 };
 
 export type ContentScriptRequestMessage =
@@ -28,7 +45,9 @@ export type ContentScriptRequestMessage =
               | ContentScriptRequestAction.ToggleHanYongMode
               | ContentScriptRequestAction.DisableOnScreenKeyboard;
       }
-    | SendKeyRequestMessage;
+    | SendKeyRequestMessage
+    | RequestOnScreenKeyboardLayoutMessage
+    | PersistOnScreenKeyboardLayoutMessage;
 
 export function isContentScriptRequestMessage(message: unknown): message is ContentScriptRequestMessage {
     return (

--- a/src/messaging/service-to-content-messages.ts
+++ b/src/messaging/service-to-content-messages.ts
@@ -1,11 +1,13 @@
 import { KeyCode } from "../keyboard/korean-keyboard-map";
 import { hasProperties } from "../types/objects";
 import { TabState } from "../extension-state/tab-state";
+import { OnScreenKeyboardLayout } from "../extension-state/osk-layout";
 
 export enum ServiceScriptMessageAction {
     InsertTextAfterSelection = "insertTextAfterSelection",
     UpdateState = "updateState",
     SendKey = "sendKey",
+    OnScreenKeyboardLayout = "onScreenKeyboardLayout",
 }
 
 export type TabStateMessage = {
@@ -26,7 +28,17 @@ export type SendKeyServiceMessage = {
     data: { key: string; keyCode: KeyCode };
 };
 
-export type ServiceScriptMessage = TabStateMessage | InsertTextAfterSelectionMessage | SendKeyServiceMessage;
+export type OnScreenKeyboardLayoutMessage = {
+    type: "serviceScriptMessage";
+    action: ServiceScriptMessageAction.OnScreenKeyboardLayout;
+    data: OnScreenKeyboardLayout;
+};
+
+export type ServiceScriptMessage =
+    | TabStateMessage
+    | InsertTextAfterSelectionMessage
+    | SendKeyServiceMessage
+    | OnScreenKeyboardLayoutMessage;
 
 export function isServiceScriptMessage(message: unknown): message is ServiceScriptMessage {
     return (

--- a/src/service-worker/content-script-listener.ts
+++ b/src/service-worker/content-script-listener.ts
@@ -1,7 +1,9 @@
 import { ContentScriptRequestMessage, ContentScriptRequestAction } from "../messaging/content-to-service-messages";
+import { ServiceScriptMessage, ServiceScriptMessageAction } from "../messaging/service-to-content-messages";
 import { routeByAction } from "../messaging/route-message";
 import { StateManager } from "./state-manager";
 import { sendMessageToTab } from "./send-message-to-tab";
+import { getOnScreenKeyboardLayout, saveOnScreenKeyboardLayout } from "./osk-layout-store";
 import { debugLog } from "../debug-log";
 import {
     ContentScriptBroadcastMessage,
@@ -57,6 +59,13 @@ export class ContentScriptListener {
                         run("routeSendKey", this.stateManager.routeSendKey(tabId, m.data)),
                     [ContentScriptRequestAction.DisableOnScreenKeyboard]: () =>
                         run("setOnScreenKeyboardEnabled", this.stateManager.setOnScreenKeyboardEnabled(tabId, false)),
+                    [ContentScriptRequestAction.RequestOnScreenKeyboardLayout]: (m) =>
+                        run(
+                            "sendOnScreenKeyboardLayout",
+                            this.sendOnScreenKeyboardLayout(tabId, sender.frameId, m.data.site)
+                        ),
+                    [ContentScriptRequestAction.PersistOnScreenKeyboardLayout]: (m) =>
+                        run("saveOnScreenKeyboardLayout", saveOnScreenKeyboardLayout(m.data)),
                 });
             }
         );
@@ -77,5 +86,19 @@ export class ContentScriptListener {
         api.tabs.onRemoved.addListener((tabId) => {
             this.stateManager.clearTabState(tabId).catch((error) => debugLog("clearTabState failed:", error));
         });
+    }
+
+    /** Reply to the requesting frame with the saved layout for its site. */
+    private async sendOnScreenKeyboardLayout(tabId: number, frameId: number | undefined, site?: string) {
+        const layout = await getOnScreenKeyboardLayout(site);
+        await sendMessageToTab<ServiceScriptMessage>(
+            tabId,
+            {
+                type: "serviceScriptMessage",
+                action: ServiceScriptMessageAction.OnScreenKeyboardLayout,
+                data: layout,
+            },
+            frameId !== undefined ? { frameId } : undefined
+        );
     }
 }

--- a/src/service-worker/osk-layout-store.test.ts
+++ b/src/service-worker/osk-layout-store.test.ts
@@ -1,0 +1,60 @@
+import { getOnScreenKeyboardLayout, saveOnScreenKeyboardLayout } from "./osk-layout-store";
+import { KeyboardPlacement } from "../extension-state/osk-layout";
+
+describe("osk-layout-store", () => {
+    let store: Record<string, unknown>;
+
+    beforeEach(() => {
+        store = {};
+        Object.assign(globalThis, {
+            chrome: {
+                runtime: { onMessage: {} },
+                storage: {
+                    local: {
+                        get: jest.fn(async (key: string) => ({ [key]: store[key] })),
+                        set: jest.fn(async (obj: Record<string, unknown>) => {
+                            Object.assign(store, obj);
+                        }),
+                    },
+                },
+            },
+        });
+    });
+
+    const placement = (overrides: Partial<KeyboardPlacement> = {}): KeyboardPlacement => ({
+        originX: "left",
+        originY: "top",
+        x: 1,
+        y: 2,
+        ...overrides,
+    });
+
+    it("remembers a position per site and defaults collapsed to false", async () => {
+        await saveOnScreenKeyboardLayout({ site: "a.com", position: placement({ x: 1 }) });
+        await saveOnScreenKeyboardLayout({ site: "b.com", position: placement({ originX: "right", x: 9 }) });
+
+        // Both sites are kept (read-modify-write of the single map, not clobbered).
+        expect(await getOnScreenKeyboardLayout("a.com")).toEqual({ position: placement({ x: 1 }), collapsed: false });
+        expect((await getOnScreenKeyboardLayout("b.com")).position).toEqual(placement({ originX: "right", x: 9 }));
+    });
+
+    it("persists collapsed globally, independent of any site", async () => {
+        await saveOnScreenKeyboardLayout({ collapsed: true });
+
+        expect((await getOnScreenKeyboardLayout("anything.com")).collapsed).toBe(true);
+        expect((await getOnScreenKeyboardLayout(undefined)).collapsed).toBe(true);
+    });
+
+    it("returns no position for an unknown or undefined site", async () => {
+        await saveOnScreenKeyboardLayout({ site: "a.com", position: placement() });
+
+        expect((await getOnScreenKeyboardLayout("none.com")).position).toBeUndefined();
+        expect((await getOnScreenKeyboardLayout(undefined)).position).toBeUndefined();
+    });
+
+    it("ignores a corrupt stored placement", async () => {
+        store["oskPositions"] = { "a.com": { originX: "sideways", x: 1 } };
+
+        expect((await getOnScreenKeyboardLayout("a.com")).position).toBeUndefined();
+    });
+});

--- a/src/service-worker/osk-layout-store.ts
+++ b/src/service-worker/osk-layout-store.ts
@@ -1,0 +1,69 @@
+import { KeyboardPlacement, OnScreenKeyboardLayout } from "../extension-state/osk-layout";
+import { api } from "../platform/browser-api";
+
+/**
+ * Service-worker-owned persistence for the on-screen-keyboard layout, in
+ * `chrome.storage.local` (per-device — a pixel position is only meaningful on
+ * the screen it was set on). Positions are a single map keyed by site; the
+ * collapsed state is one global value.
+ *
+ * Only the service worker reads/writes these, so the read-modify-write of the
+ * positions map is single-context and concurrent tabs can't clobber each other.
+ */
+const POSITIONS_KEY = "oskPositions";
+const COLLAPSED_KEY = "oskCollapsed";
+
+type PositionsMap = Record<string, KeyboardPlacement>;
+
+function isPlacement(value: unknown): value is KeyboardPlacement {
+    if (typeof value !== "object" || value === null) {
+        return false;
+    }
+    const p = value as Record<string, unknown>;
+    return (
+        (p.originX === "left" || p.originX === "right") &&
+        (p.originY === "top" || p.originY === "bottom") &&
+        typeof p.x === "number" &&
+        typeof p.y === "number"
+    );
+}
+
+async function getPositions(): Promise<PositionsMap> {
+    const stored = (await api.storage.local.get(POSITIONS_KEY))[POSITIONS_KEY];
+    if (typeof stored !== "object" || stored === null) {
+        return {};
+    }
+    // Keep only well-formed entries, so a corrupt/partial stored value can't
+    // surface a malformed placement to the keyboard.
+    const result: PositionsMap = {};
+    for (const [site, placement] of Object.entries(stored as Record<string, unknown>)) {
+        if (isPlacement(placement)) {
+            result[site] = placement;
+        }
+    }
+    return result;
+}
+
+/** The layout to restore for a site: its saved position (if any) + the global collapsed state. */
+export async function getOnScreenKeyboardLayout(site?: string): Promise<OnScreenKeyboardLayout> {
+    const collapsed = (await api.storage.local.get(COLLAPSED_KEY))[COLLAPSED_KEY] === true;
+    const position = site ? (await getPositions())[site] : undefined;
+    return { position, collapsed };
+}
+
+/** Persist whichever fields are present: the per-site position and/or the global collapsed state. */
+export async function saveOnScreenKeyboardLayout(update: {
+    site?: string;
+    position?: KeyboardPlacement;
+    collapsed?: boolean;
+}): Promise<void> {
+    if (update.position && update.site) {
+        const positions = await getPositions();
+        positions[update.site] = update.position;
+        await api.storage.local.set({ [POSITIONS_KEY]: positions });
+    }
+
+    if (update.collapsed !== undefined) {
+        await api.storage.local.set({ [COLLAPSED_KEY]: update.collapsed });
+    }
+}


### PR DESCRIPTION
Closes #74

The on-screen keyboard now remembers its position per-site and its minimised/maximised state globally, restoring both when it's next shown.

Note: the saved layout is delivered over a dedicated layout message rather than riding in the shared `TabState` (as the issue's implementation note suggested) — position is per-site, so it can't live in the state that's inherited/broadcast across tabs.
