### PR TITLE
Allow manual resizing of the on-screen keyboard

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -59,6 +59,9 @@
     "keyboard_close": {
         "message": "Close"
     },
+    "keyboard_resize": {
+        "message": "Drag to resize; double-click to reset"
+    },
     "options_title": {
         "message": "Korean IME Options"
     },

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -59,6 +59,9 @@
     "keyboard_close": {
         "message": "Cerrar"
     },
+    "keyboard_resize": {
+        "message": "Arrastre para cambiar el tamaño; doble clic para restablecer"
+    },
     "options_title": {
         "message": "Opciones de IME coreano"
     },

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -59,6 +59,9 @@
     "keyboard_close": {
         "message": "닫기"
     },
+    "keyboard_resize": {
+        "message": "드래그하여 크기 조절, 더블클릭하여 기본값으로"
+    },
     "options_title": {
         "message": "한글 입력기 설정"
     },

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
@@ -635,3 +635,82 @@ describe("OnScreenKeyboardController persisted layout", () => {
         expect(calls[0].data.site).toBeUndefined();
     });
 });
+
+describe("OnScreenKeyboardController resize", () => {
+    let sendMessage: jest.Mock;
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        sendMessage = jest.fn();
+        Object.assign(globalThis, {
+            chrome: { runtime: { sendMessage }, i18n: { getMessage: () => "" } },
+        });
+        Object.defineProperty(window, "innerWidth", { configurable: true, value: 2000 });
+        Object.defineProperty(window, "innerHeight", { configurable: true, value: 2000 });
+    });
+
+    const host = () => document.querySelector("[id^='kb-']") as HTMLElement;
+    const grip = () => document.querySelector(".kb-resize-grip") as HTMLElement;
+    const persistedKeyUnit = () =>
+        sendMessage.mock.calls
+            .map((c) => c[0])
+            .filter((m) => m.action === ContentScriptRequestAction.PersistOnScreenKeyboardLayout)
+            .map((m) => m.data.keyUnit)
+            .filter((u) => u !== undefined)
+            .at(-1);
+
+    const sized = () => {
+        const el = host();
+        Object.defineProperty(el, "offsetWidth", { configurable: true, value: 480 });
+        Object.defineProperty(el, "offsetHeight", { configurable: true, value: 250 });
+        return el;
+    };
+
+    it("renders a resize grip on the keyboard", () => {
+        new OnScreenKeyboardController(() => {});
+        expect(grip()).not.toBeNull();
+    });
+
+    it("restores a persisted key size, clamped to the allowed range", () => {
+        const controller = new OnScreenKeyboardController(() => {});
+        const el = sized();
+
+        controller.applyPersistedLayout({ collapsed: false, keyUnit: 999 });
+        controller.showKeyboard();
+
+        // Clamped to the max (64), applied as --key-unit.
+        expect(el.style.getPropertyValue("--key-unit")).toBe("64px");
+    });
+
+    it("scales the key size when the grip is dragged, and persists on release", () => {
+        const controller = new OnScreenKeyboardController(() => {});
+        const el = sized();
+        controller.showKeyboard();
+        // Anchored bottom-right by default: anchor corner at rect.right/bottom.
+        el.getBoundingClientRect = () =>
+            ({ left: 100, top: 100, right: 500, bottom: 400, width: 400, height: 300 }) as DOMRect;
+        sendMessage.mockClear();
+
+        const g = grip();
+        // Start distance (anchor to free corner) = hypot(400,300) = 500.
+        g.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+        // Cursor at (250,150): dist from anchor (500,400) = hypot(250,250).
+        g.dispatchEvent(new MouseEvent("pointermove", { bubbles: true, clientX: 250, clientY: 150 }));
+        g.dispatchEvent(new MouseEvent("pointerup", { bubbles: true, button: 0 }));
+
+        expect(persistedKeyUnit()).toBeCloseTo((32 * Math.hypot(250, 250)) / 500, 1);
+    });
+
+    it("resets to the default size on double-clicking the grip", () => {
+        const controller = new OnScreenKeyboardController(() => {});
+        const el = sized();
+        controller.applyPersistedLayout({ collapsed: false, keyUnit: 50 });
+        controller.showKeyboard();
+        sendMessage.mockClear();
+
+        grip().dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+
+        expect(el.style.getPropertyValue("--key-unit")).toBe("32px");
+        expect(persistedKeyUnit()).toBe(32);
+    });
+});

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
@@ -701,6 +701,24 @@ describe("OnScreenKeyboardController resize", () => {
         expect(persistedKeyUnit()).toBeCloseTo((32 * Math.hypot(250, 250)) / 500, 1);
     });
 
+    it("does not resize while collapsed", () => {
+        const controller = new OnScreenKeyboardController(() => {});
+        const el = sized();
+        controller.showKeyboard();
+        el.getBoundingClientRect = () =>
+            ({ left: 100, top: 100, right: 500, bottom: 400, width: 400, height: 300 }) as DOMRect;
+        (el.querySelector(".kb-collapse") as HTMLButtonElement).click(); // collapse
+        sendMessage.mockClear();
+
+        const g = grip();
+        g.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+        g.dispatchEvent(new MouseEvent("pointermove", { bubbles: true, clientX: 50, clientY: 50 }));
+        g.dispatchEvent(new MouseEvent("pointerup", { bubbles: true, button: 0 }));
+        g.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+
+        expect(persistedKeyUnit()).toBeUndefined(); // no size persisted
+    });
+
     it("resets to the default size on double-clicking the grip", () => {
         const controller = new OnScreenKeyboardController(() => {});
         const el = sized();

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
@@ -701,6 +701,29 @@ describe("OnScreenKeyboardController resize", () => {
         expect(persistedKeyUnit()).toBeCloseTo((32 * Math.hypot(250, 250)) / 500, 1);
     });
 
+    it("resizes from any corner, keeping the anchor origin and moving its position", () => {
+        const controller = new OnScreenKeyboardController(() => {});
+        const el = sized();
+        controller.showKeyboard(); // default anchor: bottom-right
+        el.getBoundingClientRect = () =>
+            ({ left: 100, top: 100, right: 500, bottom: 400, width: 400, height: 300 }) as DOMRect;
+        sendMessage.mockClear();
+
+        // Drag the bottom-right grip (the anchored corner); pivot = top-left (100,100).
+        const br = document.querySelector(".kb-grip-br") as HTMLElement;
+        br.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+        // dist from pivot (100,100) to (700,550) = hypot(600,450) = 750; start = 500.
+        br.dispatchEvent(new MouseEvent("pointermove", { bubbles: true, clientX: 700, clientY: 550 }));
+        br.dispatchEvent(new MouseEvent("pointerup", { bubbles: true, button: 0 }));
+
+        // Origin unchanged (still anchored bottom-right), position updated.
+        expect(el.style.right).not.toBe("");
+        expect(el.style.bottom).not.toBe("");
+        expect(el.style.left).toBe("");
+        expect(el.style.top).toBe("");
+        expect(persistedKeyUnit()).toBeCloseTo((32 * Math.hypot(600, 450)) / 500, 0);
+    });
+
     it("does not resize while collapsed", () => {
         const controller = new OnScreenKeyboardController(() => {});
         const el = sized();

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
@@ -70,9 +70,18 @@ export class OnScreenKeyboardController {
     // rendered smaller when the viewport can't fit it (clamped in placeKeyboard),
     // but the intended size is kept so it's restored when there's room again.
     private _keyUnit = DEFAULT_KEY_UNIT_PX;
-    // Drag-resize state, captured at pointer-down on the grip.
-    private _resize?: { anchorX: number; anchorY: number; startDist: number; startUnit: number; pointerId: number };
-    private _resizeGrip?: HTMLDivElement;
+    // Drag-resize state, captured at pointer-down on a corner grip. The pivot is
+    // the corner opposite the dragged one; it stays fixed while the keyboard
+    // scales, and the anchor offset is updated to keep it there.
+    private _resize?: {
+        pivotX: number;
+        pivotY: number;
+        pivotIsLeft: boolean;
+        pivotIsTop: boolean;
+        startDist: number;
+        startUnit: number;
+        pointerId: number;
+    };
 
     private _mode = KoreanKeyboardMode.English;
     // `undefined` until the first state update, so the first call to
@@ -334,10 +343,6 @@ export class OnScreenKeyboardController {
             placement.originX = originX;
             placement.originY = originY;
         }
-
-        // Keep the resize grip on the free corner (diagonally opposite the
-        // anchor), so dragging it grows the keyboard from the pinned corner.
-        this.positionResizeGrip(originX, originY);
     }
 
     // Set --key-unit to the intended size, then shrink it just enough that the
@@ -365,17 +370,31 @@ export class OnScreenKeyboardController {
         }
     }
 
-    private positionResizeGrip(originX: "left" | "right", originY: "top" | "bottom") {
-        const grip = this._resizeGrip;
-        if (!grip) {
+    // Resize the keyboard around the drag's fixed pivot corner: scale to the new
+    // key size, then update the anchor offset so the pivot stays put. The anchor
+    // origin is unchanged — only its distance from the origin edges moves.
+    private applyResize(keyUnit: number) {
+        const resize = this._resize;
+        if (!resize) {
             return;
         }
-        // The free corner (opposite the anchor) — the corner class carries the
-        // offsets and the matching resize cursor (see the SCSS).
-        grip.classList.toggle("kb-grip-tl", originX === "right" && originY === "bottom");
-        grip.classList.toggle("kb-grip-tr", originX === "left" && originY === "bottom");
-        grip.classList.toggle("kb-grip-bl", originX === "right" && originY === "top");
-        grip.classList.toggle("kb-grip-br", originX === "left" && originY === "top");
+
+        this._keyUnit = clamp(keyUnit, MIN_KEY_UNIT_PX, MAX_KEY_UNIT_PX);
+
+        const el = this._keyboardElement;
+        el.style.setProperty("--key-unit", `${this._keyUnit}px`);
+        const width = el.offsetWidth;
+        const height = el.offsetHeight;
+
+        // Place the box so the pivot corner stays at its captured viewport point.
+        const left = resize.pivotIsLeft ? resize.pivotX : resize.pivotX - width;
+        const top = resize.pivotIsTop ? resize.pivotY : resize.pivotY - height;
+
+        const placement = this._keyboardPlacement;
+        placement.x = placement.originX === "left" ? left : window.innerWidth - (left + width);
+        placement.y = placement.originY === "bottom" ? window.innerHeight - (top + height) : top;
+
+        this.placeKeyboard();
     }
 
     private createKeyboard() {
@@ -506,23 +525,27 @@ export class OnScreenKeyboardController {
         window.addEventListener("resize", reclampToViewport);
         window.visualViewport?.addEventListener("resize", reclampToViewport);
 
-        keyboardElement.appendChild(this.createResizeGrip());
+        for (const corner of ["tl", "tr", "bl", "br"] as const) {
+            keyboardElement.appendChild(this.createResizeGrip(corner));
+        }
         this.createGuides();
 
         return keyboardElement;
     }
 
-    // A corner grip for drag-resizing the keyboard. It scales --key-unit live
-    // (pointer capture during the drag), persists the size on release, and resets
-    // to the default size on double-click. Positioned at the free corner by
-    // positionResizeGrip so the anchored corner stays pinned as it grows.
-    private createResizeGrip(): HTMLDivElement {
+    // A corner grip for drag-resizing the keyboard. Any of the four corners works:
+    // the dragged corner tracks the cursor while the opposite (pivot) corner stays
+    // put; applyResize updates the anchor offset to keep it there. Scales
+    // --key-unit live (pointer capture during the drag), persists on release, and
+    // resets to the default size on double-click.
+    private createResizeGrip(corner: "tl" | "tr" | "bl" | "br"): HTMLDivElement {
         const grip = document.createElement("div");
-        grip.className = "kb-resize-grip";
-        this._resizeGrip = grip;
+        grip.className = `kb-resize-grip kb-grip-${corner}`;
+        const cornerIsLeft = corner === "tl" || corner === "bl";
+        const cornerIsTop = corner === "tl" || corner === "tr";
 
         grip.addEventListener("pointerdown", (e) => {
-            // No resizing while collapsed (the grip is also hidden via CSS then).
+            // No resizing while collapsed (the grips are also hidden via CSS then).
             if (e.button !== 0 || this._keyboardElement.classList.contains("collapsed")) {
                 return;
             }
@@ -530,13 +553,12 @@ export class OnScreenKeyboardController {
             e.stopPropagation();
 
             const rect = this._keyboardElement.getBoundingClientRect();
-            const { originX, originY } = this._keyboardPlacement;
-            // Pin the anchored corner; the grip (free corner) tracks the cursor.
-            const anchorX = originX === "right" ? rect.right : rect.left;
-            const anchorY = originY === "bottom" ? rect.bottom : rect.top;
+            // The pivot is the corner opposite the one being dragged; it stays put.
             this._resize = {
-                anchorX,
-                anchorY,
+                pivotX: cornerIsLeft ? rect.right : rect.left,
+                pivotY: cornerIsTop ? rect.bottom : rect.top,
+                pivotIsLeft: !cornerIsLeft,
+                pivotIsTop: !cornerIsTop,
                 startDist: Math.hypot(rect.width, rect.height) || 1,
                 startUnit: this._keyUnit,
                 pointerId: e.pointerId,
@@ -555,10 +577,10 @@ export class OnScreenKeyboardController {
             if (!resize) {
                 return;
             }
-            // Scale the key size by how far the cursor moved from the anchor,
-            // relative to where the free corner started. Aspect ratio is intrinsic.
-            const dist = Math.hypot(e.clientX - resize.anchorX, e.clientY - resize.anchorY);
-            this.setKeyUnit((resize.startUnit * dist) / resize.startDist, false);
+            // Scale the key size by how far the cursor is from the pivot, relative
+            // to where the dragged corner started. Aspect ratio is intrinsic.
+            const dist = Math.hypot(e.clientX - resize.pivotX, e.clientY - resize.pivotY);
+            this.applyResize((resize.startUnit * dist) / resize.startDist);
         });
 
         const endResize = (e: PointerEvent) => {

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
@@ -370,11 +370,8 @@ export class OnScreenKeyboardController {
         if (!grip) {
             return;
         }
-        // Free corner = opposite the anchor.
-        grip.style.left = originX === "right" ? "0" : "";
-        grip.style.right = originX === "right" ? "" : "0";
-        grip.style.top = originY === "bottom" ? "0" : "";
-        grip.style.bottom = originY === "bottom" ? "" : "0";
+        // The free corner (opposite the anchor) — the corner class carries the
+        // offsets and the matching resize cursor (see the SCSS).
         grip.classList.toggle("kb-grip-tl", originX === "right" && originY === "bottom");
         grip.classList.toggle("kb-grip-tr", originX === "left" && originY === "bottom");
         grip.classList.toggle("kb-grip-bl", originX === "right" && originY === "top");
@@ -522,11 +519,11 @@ export class OnScreenKeyboardController {
     private createResizeGrip(): HTMLDivElement {
         const grip = document.createElement("div");
         grip.className = "kb-resize-grip";
-        grip.title = api.i18n.getMessage("keyboard_resize");
         this._resizeGrip = grip;
 
         grip.addEventListener("pointerdown", (e) => {
-            if (e.button !== 0) {
+            // No resizing while collapsed (the grip is also hidden via CSS then).
+            if (e.button !== 0 || this._keyboardElement.classList.contains("collapsed")) {
                 return;
             }
             e.preventDefault();
@@ -581,8 +578,11 @@ export class OnScreenKeyboardController {
         grip.addEventListener("pointerup", endResize);
         grip.addEventListener("pointercancel", endResize);
 
-        // Double-click resets to the default size.
+        // Double-click resets to the default size (not while collapsed).
         grip.addEventListener("dblclick", (e) => {
+            if (this._keyboardElement.classList.contains("collapsed")) {
+                return;
+            }
             e.preventDefault();
             e.stopPropagation();
             this.setKeyUnit(DEFAULT_KEY_UNIT_PX, true);

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
@@ -3,11 +3,21 @@ import { KeyCode, KeyRecord, keyMap } from "../../keyboard/korean-keyboard-map";
 import { KeyboardLayout, LayoutKey, LayoutId, layouts, defaultLayoutId } from "./layouts";
 import { SupportedCompositionFeatures } from "../../composition/composition-adapters/composition-adapter-interface";
 import "./on-screen-keyboard.scss";
-import { ContentScriptRequestAction, ContentScriptRequestMessage } from "../../messaging/content-to-service-messages";
+import {
+    ContentScriptRequestAction,
+    ContentScriptRequestMessage,
+    PersistOnScreenKeyboardLayoutMessage,
+} from "../../messaging/content-to-service-messages";
 import { debugLog } from "../../debug-log";
 import { api } from "../../platform/browser-api";
 import { modeIconHangul, modeIconEnglish } from "./mode-icons";
-import { KeyboardPlacement, OnScreenKeyboardLayout } from "../../extension-state/osk-layout";
+import {
+    KeyboardPlacement,
+    OnScreenKeyboardLayout,
+    DEFAULT_KEY_UNIT_PX,
+    MIN_KEY_UNIT_PX,
+    MAX_KEY_UNIT_PX,
+} from "../../extension-state/osk-layout";
 import { currentOskSite } from "../osk-site";
 
 /**
@@ -32,6 +42,11 @@ const GUIDE_EDGE_THICKNESS = `${GUIDE_EDGE_THICKNESS_MM}mm`;
 // running them the whole way to the viewport edge.
 const GUIDE_EDGE_THICKNESS_PX = (GUIDE_EDGE_THICKNESS_MM * 96) / 25.4;
 
+/** Slack kept between the keyboard and the viewport edge when clamping its size. */
+const VIEWPORT_MARGIN_PX = 8;
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
 export class OnScreenKeyboardController {
     private _keyboardElement: HTMLDivElement;
     private _keyboardPlacement: KeyboardPlacement = {
@@ -50,6 +65,14 @@ export class OnScreenKeyboardController {
     // Whether the keyboard actually moved during the current drag, so a drop
     // persists the new position only after a real move (not a bare header click).
     private _movedDuringDrag = false;
+
+    // The user's intended key size (px); the board scales from it. May be
+    // rendered smaller when the viewport can't fit it (clamped in placeKeyboard),
+    // but the intended size is kept so it's restored when there's room again.
+    private _keyUnit = DEFAULT_KEY_UNIT_PX;
+    // Drag-resize state, captured at pointer-down on the grip.
+    private _resize?: { anchorX: number; anchorY: number; startDist: number; startUnit: number; pointerId: number };
+    private _resizeGrip?: HTMLDivElement;
 
     private _mode = KoreanKeyboardMode.English;
     // `undefined` until the first state update, so the first call to
@@ -178,25 +201,47 @@ export class OnScreenKeyboardController {
         if (layout.position) {
             this._keyboardPlacement = { ...layout.position };
         }
+        if (layout.keyUnit !== undefined) {
+            this._keyUnit = clamp(layout.keyUnit, MIN_KEY_UNIT_PX, MAX_KEY_UNIT_PX);
+        }
         this.setCollapsed(layout.collapsed);
     }
 
-    // Ask the service worker to persist whichever layout fields changed. A
-    // position needs a site key; the collapsed state is global. Failures are
-    // logged, not surfaced — persistence is best-effort.
-    private persistLayout(update: { position?: KeyboardPlacement; collapsed?: boolean }) {
-        const data: { site?: string; position?: KeyboardPlacement; collapsed?: boolean } = {
-            collapsed: update.collapsed,
-        };
+    /** Set the intended key size (px), re-render at the new size, and persist it. */
+    private setKeyUnit(keyUnit: number, persist: boolean) {
+        this._keyUnit = clamp(keyUnit, MIN_KEY_UNIT_PX, MAX_KEY_UNIT_PX);
 
+        if (this._keyboardElement.style.display !== "none") {
+            this.placeKeyboard(); // applies the size and re-clamps on-screen
+        }
+
+        if (persist) {
+            this.persistLayout({ keyUnit: this._keyUnit });
+        }
+    }
+
+    // Ask the service worker to persist whichever layout fields changed. A
+    // position needs a site key (skipped where there's none, e.g. file://); the
+    // collapsed state and key size are global. Best-effort — failures are ignored.
+    private persistLayout(update: { position?: KeyboardPlacement; collapsed?: boolean; keyUnit?: number }) {
+        const data: PersistOnScreenKeyboardLayoutMessage["data"] = {};
+
+        if (update.collapsed !== undefined) {
+            data.collapsed = update.collapsed;
+        }
+        if (update.keyUnit !== undefined) {
+            data.keyUnit = update.keyUnit;
+        }
         if (update.position) {
             const site = currentOskSite();
-            // Nothing meaningful to key a position on (e.g. file://) — skip it.
-            if (!site) {
-                return;
+            if (site) {
+                data.site = site;
+                data.position = update.position;
             }
-            data.site = site;
-            data.position = update.position;
+        }
+
+        if (Object.keys(data).length === 0) {
+            return;
         }
 
         api.runtime.sendMessage<ContentScriptRequestMessage>({
@@ -216,6 +261,10 @@ export class OnScreenKeyboardController {
     }
 
     private placeKeyboard(reanchor = false) {
+        // Apply the intended key size, shrinking it if the viewport can't fit it,
+        // before reading offsetWidth/Height below.
+        this.applyKeyUnit();
+
         // get x,y coordinates of keyboard based on an origin of Top Left
         const placement = this._keyboardPlacement;
         const width = this._keyboardElement.offsetWidth;
@@ -285,6 +334,51 @@ export class OnScreenKeyboardController {
             placement.originX = originX;
             placement.originY = originY;
         }
+
+        // Keep the resize grip on the free corner (diagonally opposite the
+        // anchor), so dragging it grows the keyboard from the pinned corner.
+        this.positionResizeGrip(originX, originY);
+    }
+
+    // Set --key-unit to the intended size, then shrink it just enough that the
+    // rendered keyboard fits the viewport (the intended size is kept for restore).
+    private applyKeyUnit() {
+        const el = this._keyboardElement;
+        el.style.setProperty("--key-unit", `${this._keyUnit}px`);
+
+        if (el.style.display === "none") {
+            return; // hidden: offsetWidth is 0, nothing meaningful to clamp
+        }
+
+        const availWidth = window.innerWidth - VIEWPORT_MARGIN_PX;
+        const availHeight = window.innerHeight - VIEWPORT_MARGIN_PX;
+
+        // offsetWidth includes fixed chrome (borders/padding/gaps), so the unit
+        // isn't perfectly proportional to it; a couple of passes converge.
+        for (let i = 0; i < 3; i++) {
+            const scale = Math.min(1, availWidth / el.offsetWidth, availHeight / el.offsetHeight);
+            if (scale >= 1) {
+                break;
+            }
+            const current = parseFloat(getComputedStyle(el).getPropertyValue("--key-unit")) || this._keyUnit;
+            el.style.setProperty("--key-unit", `${Math.max(MIN_KEY_UNIT_PX, current * scale)}px`);
+        }
+    }
+
+    private positionResizeGrip(originX: "left" | "right", originY: "top" | "bottom") {
+        const grip = this._resizeGrip;
+        if (!grip) {
+            return;
+        }
+        // Free corner = opposite the anchor.
+        grip.style.left = originX === "right" ? "0" : "";
+        grip.style.right = originX === "right" ? "" : "0";
+        grip.style.top = originY === "bottom" ? "0" : "";
+        grip.style.bottom = originY === "bottom" ? "" : "0";
+        grip.classList.toggle("kb-grip-tl", originX === "right" && originY === "bottom");
+        grip.classList.toggle("kb-grip-tr", originX === "left" && originY === "bottom");
+        grip.classList.toggle("kb-grip-bl", originX === "right" && originY === "top");
+        grip.classList.toggle("kb-grip-br", originX === "left" && originY === "top");
     }
 
     private createKeyboard() {
@@ -415,9 +509,86 @@ export class OnScreenKeyboardController {
         window.addEventListener("resize", reclampToViewport);
         window.visualViewport?.addEventListener("resize", reclampToViewport);
 
+        keyboardElement.appendChild(this.createResizeGrip());
         this.createGuides();
 
         return keyboardElement;
+    }
+
+    // A corner grip for drag-resizing the keyboard. It scales --key-unit live
+    // (pointer capture during the drag), persists the size on release, and resets
+    // to the default size on double-click. Positioned at the free corner by
+    // positionResizeGrip so the anchored corner stays pinned as it grows.
+    private createResizeGrip(): HTMLDivElement {
+        const grip = document.createElement("div");
+        grip.className = "kb-resize-grip";
+        grip.title = api.i18n.getMessage("keyboard_resize");
+        this._resizeGrip = grip;
+
+        grip.addEventListener("pointerdown", (e) => {
+            if (e.button !== 0) {
+                return;
+            }
+            e.preventDefault();
+            e.stopPropagation();
+
+            const rect = this._keyboardElement.getBoundingClientRect();
+            const { originX, originY } = this._keyboardPlacement;
+            // Pin the anchored corner; the grip (free corner) tracks the cursor.
+            const anchorX = originX === "right" ? rect.right : rect.left;
+            const anchorY = originY === "bottom" ? rect.bottom : rect.top;
+            this._resize = {
+                anchorX,
+                anchorY,
+                startDist: Math.hypot(rect.width, rect.height) || 1,
+                startUnit: this._keyUnit,
+                pointerId: e.pointerId,
+            };
+            // Capture so the drag keeps tracking even if the cursor leaves the
+            // grip. Not critical (and absent in jsdom), so tolerate failure.
+            try {
+                grip.setPointerCapture(e.pointerId);
+            } catch {
+                /* pointer capture unavailable */
+            }
+        });
+
+        grip.addEventListener("pointermove", (e) => {
+            const resize = this._resize;
+            if (!resize) {
+                return;
+            }
+            // Scale the key size by how far the cursor moved from the anchor,
+            // relative to where the free corner started. Aspect ratio is intrinsic.
+            const dist = Math.hypot(e.clientX - resize.anchorX, e.clientY - resize.anchorY);
+            this.setKeyUnit((resize.startUnit * dist) / resize.startDist, false);
+        });
+
+        const endResize = (e: PointerEvent) => {
+            if (!this._resize) {
+                return;
+            }
+            this._resize = undefined;
+            try {
+                if (grip.hasPointerCapture(e.pointerId)) {
+                    grip.releasePointerCapture(e.pointerId);
+                }
+            } catch {
+                /* pointer capture unavailable */
+            }
+            this.persistLayout({ keyUnit: this._keyUnit });
+        };
+        grip.addEventListener("pointerup", endResize);
+        grip.addEventListener("pointercancel", endResize);
+
+        // Double-click resets to the default size.
+        grip.addEventListener("dblclick", (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            this.setKeyUnit(DEFAULT_KEY_UNIT_PX, true);
+        });
+
+        return grip;
     }
 
     // Builds the anchor-guide overlay: two dotted lines pinned to the viewport

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard.scss
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard.scss
@@ -258,6 +258,48 @@
             display: none;
         }
     }
+
+    // Corner grip for drag-resizing. Sits on the free corner (set inline by
+    // positionResizeGrip), scales with the keyboard, and is hatched so it reads
+    // as a grip distinct from the keys and the header drag area.
+    .kb-resize-grip {
+        position: absolute;
+        z-index: 1;
+        width: calc(var(--key-unit) * 0.45);
+        height: calc(var(--key-unit) * 0.45);
+        min-width: 10px;
+        min-height: 10px;
+        opacity: 0.55;
+        background: repeating-linear-gradient(
+            -45deg,
+            var(--key-color) 0,
+            var(--key-color) 1px,
+            transparent 1px,
+            transparent 3px
+        );
+        // Let the grip receive pointer events / capture during a drag.
+        touch-action: none;
+
+        &:hover {
+            opacity: 1;
+        }
+    }
+
+    // Diagonal resize cursor matching the free corner being dragged.
+    .kb-grip-tl,
+    .kb-grip-br {
+        cursor: nwse-resize;
+    }
+    .kb-grip-tr,
+    .kb-grip-bl {
+        cursor: nesw-resize;
+    }
+
+    // The hidden collapsed body still leaves the grip on the header corner; keep
+    // it from overlapping the header controls by tucking it to the very corner.
+    &.collapsed .kb-resize-grip {
+        opacity: 0.35;
+    }
 }
 
 // Anchor guides: dotted lines along the two viewport edges the keyboard is

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard.scss
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard.scss
@@ -6,6 +6,10 @@
     // units is N*--key-unit wide plus the --key-gap gaps it bridges.
     --key-unit: 32px;
     --key-gap: 4px;
+    // Rounded keyboard corners, and how far the (invisible) corner resize
+    // hit-area reaches beyond the edge — a discoverable border zone.
+    --kb-radius: 8px;
+    --kb-grip-reach: 5px;
 
     --background-color: #444;
     --border-color: #000;
@@ -38,6 +42,7 @@
         width: fit-content;
         position: relative;
         box-sizing: border-box;
+        border-radius: var(--kb-radius);
     }
 
     .kb-header {
@@ -47,6 +52,14 @@
         background-color: var(--key-background-color);
         border-bottom: 1px solid var(--border-color);
         cursor: move;
+        // Round to match the keyboard's top corners (the header's own background
+        // would otherwise square them off).
+        border-radius: var(--kb-radius) var(--kb-radius) 0 0;
+    }
+
+    // Collapsed, the header is the whole keyboard, so round all of its corners.
+    &.collapsed .kb-header {
+        border-radius: var(--kb-radius);
     }
 
     .kb-mode {
@@ -259,46 +272,45 @@
         }
     }
 
-    // Corner grip for drag-resizing. Sits on the free corner (set inline by
-    // positionResizeGrip), scales with the keyboard, and is hatched so it reads
-    // as a grip distinct from the keys and the header drag area.
+    // Corner grip for drag-resizing: an invisible hit-area hugging the rounded
+    // free corner and reaching --kb-grip-reach beyond the edge (Apple-style
+    // discoverable border), so it doesn't cover any keys. The cursor is the only
+    // hint. The corner class (set by positionResizeGrip) places it on the free
+    // corner and picks the matching diagonal cursor.
     .kb-resize-grip {
         position: absolute;
         z-index: 1;
-        width: calc(var(--key-unit) * 0.45);
-        height: calc(var(--key-unit) * 0.45);
-        min-width: 10px;
-        min-height: 10px;
-        opacity: 0.55;
-        background: repeating-linear-gradient(
-            -45deg,
-            var(--key-color) 0,
-            var(--key-color) 1px,
-            transparent 1px,
-            transparent 3px
-        );
-        // Let the grip receive pointer events / capture during a drag.
+        width: calc(var(--kb-radius) + var(--kb-grip-reach));
+        height: calc(var(--kb-radius) + var(--kb-grip-reach));
+        background: transparent;
+        // Receive pointer events / capture during a drag.
         touch-action: none;
-
-        &:hover {
-            opacity: 1;
-        }
     }
 
-    // Diagonal resize cursor matching the free corner being dragged.
-    .kb-grip-tl,
-    .kb-grip-br {
+    .kb-grip-tl {
+        top: calc(-1 * var(--kb-grip-reach));
+        left: calc(-1 * var(--kb-grip-reach));
         cursor: nwse-resize;
     }
-    .kb-grip-tr,
+    .kb-grip-br {
+        bottom: calc(-1 * var(--kb-grip-reach));
+        right: calc(-1 * var(--kb-grip-reach));
+        cursor: nwse-resize;
+    }
+    .kb-grip-tr {
+        top: calc(-1 * var(--kb-grip-reach));
+        right: calc(-1 * var(--kb-grip-reach));
+        cursor: nesw-resize;
+    }
     .kb-grip-bl {
+        bottom: calc(-1 * var(--kb-grip-reach));
+        left: calc(-1 * var(--kb-grip-reach));
         cursor: nesw-resize;
     }
 
-    // The hidden collapsed body still leaves the grip on the header corner; keep
-    // it from overlapping the header controls by tucking it to the very corner.
+    // No resizing while collapsed — hide the grip so there's no hit-area or cursor.
     &.collapsed .kb-resize-grip {
-        opacity: 0.35;
+        display: none;
     }
 }
 

--- a/src/extension-state/osk-layout.ts
+++ b/src/extension-state/osk-layout.ts
@@ -36,4 +36,11 @@ export type OnScreenKeyboardLayout = {
     position?: KeyboardPlacement;
     /** Global minimised/maximised state. */
     collapsed: boolean;
+    /** Global key size in px (the `--key-unit` the board scales from); absent if unset. */
+    keyUnit?: number;
 };
+
+/** The key size (`--key-unit`, px) the keyboard scales from, and its drag bounds. */
+export const DEFAULT_KEY_UNIT_PX = 32;
+export const MIN_KEY_UNIT_PX = 18;
+export const MAX_KEY_UNIT_PX = 64;

--- a/src/messaging/content-to-service-messages.ts
+++ b/src/messaging/content-to-service-messages.ts
@@ -34,7 +34,7 @@ export type RequestOnScreenKeyboardLayoutMessage = {
 export type PersistOnScreenKeyboardLayoutMessage = {
     type: "contentScriptRequest";
     action: ContentScriptRequestAction.PersistOnScreenKeyboardLayout;
-    data: { site?: string; position?: KeyboardPlacement; collapsed?: boolean };
+    data: { site?: string; position?: KeyboardPlacement; collapsed?: boolean; keyUnit?: number };
 };
 
 export type ContentScriptRequestMessage =

--- a/src/service-worker/osk-layout-store.test.ts
+++ b/src/service-worker/osk-layout-store.test.ts
@@ -11,7 +11,10 @@ describe("osk-layout-store", () => {
                 runtime: { onMessage: {} },
                 storage: {
                     local: {
-                        get: jest.fn(async (key: string) => ({ [key]: store[key] })),
+                        get: jest.fn(async (keys: string | string[]) => {
+                            const wanted = Array.isArray(keys) ? keys : [keys];
+                            return Object.fromEntries(wanted.map((k) => [k, store[k]]));
+                        }),
                         set: jest.fn(async (obj: Record<string, unknown>) => {
                             Object.assign(store, obj);
                         }),
@@ -43,6 +46,14 @@ describe("osk-layout-store", () => {
 
         expect((await getOnScreenKeyboardLayout("anything.com")).collapsed).toBe(true);
         expect((await getOnScreenKeyboardLayout(undefined)).collapsed).toBe(true);
+    });
+
+    it("persists the key size globally and ignores a non-numeric stored value", async () => {
+        await saveOnScreenKeyboardLayout({ keyUnit: 40 });
+        expect((await getOnScreenKeyboardLayout(undefined)).keyUnit).toBe(40);
+
+        store["oskKeyUnit"] = "huge";
+        expect((await getOnScreenKeyboardLayout(undefined)).keyUnit).toBeUndefined();
     });
 
     it("returns no position for an unknown or undefined site", async () => {

--- a/src/service-worker/osk-layout-store.ts
+++ b/src/service-worker/osk-layout-store.ts
@@ -12,6 +12,7 @@ import { api } from "../platform/browser-api";
  */
 const POSITIONS_KEY = "oskPositions";
 const COLLAPSED_KEY = "oskCollapsed";
+const KEY_UNIT_KEY = "oskKeyUnit";
 
 type PositionsMap = Record<string, KeyboardPlacement>;
 
@@ -44,18 +45,23 @@ async function getPositions(): Promise<PositionsMap> {
     return result;
 }
 
-/** The layout to restore for a site: its saved position (if any) + the global collapsed state. */
+/** The layout to restore for a site: its saved position (if any) + the global collapsed state and key size. */
 export async function getOnScreenKeyboardLayout(site?: string): Promise<OnScreenKeyboardLayout> {
-    const collapsed = (await api.storage.local.get(COLLAPSED_KEY))[COLLAPSED_KEY] === true;
+    const stored = await api.storage.local.get([COLLAPSED_KEY, KEY_UNIT_KEY]);
+    const collapsed = stored[COLLAPSED_KEY] === true;
+    const rawKeyUnit = stored[KEY_UNIT_KEY];
+    const keyUnit =
+        typeof rawKeyUnit === "number" && Number.isFinite(rawKeyUnit) && rawKeyUnit > 0 ? rawKeyUnit : undefined;
     const position = site ? (await getPositions())[site] : undefined;
-    return { position, collapsed };
+    return { position, collapsed, keyUnit };
 }
 
-/** Persist whichever fields are present: the per-site position and/or the global collapsed state. */
+/** Persist whichever fields are present: the per-site position and/or the global collapsed state / key size. */
 export async function saveOnScreenKeyboardLayout(update: {
     site?: string;
     position?: KeyboardPlacement;
     collapsed?: boolean;
+    keyUnit?: number;
 }): Promise<void> {
     if (update.position && update.site) {
         const positions = await getPositions();
@@ -65,5 +71,9 @@ export async function saveOnScreenKeyboardLayout(update: {
 
     if (update.collapsed !== undefined) {
         await api.storage.local.set({ [COLLAPSED_KEY]: update.collapsed });
+    }
+
+    if (update.keyUnit !== undefined) {
+        await api.storage.local.set({ [KEY_UNIT_KEY]: update.keyUnit });
     }
 }


### PR DESCRIPTION
Closes #76.

Adds drag-resizing of the on-screen keyboard via a corner grip, scaling the keyboard's `--key-unit` so the whole board (including labels) resizes while keeping its aspect ratio.

- Invisible grip on each corner
- Size is clamped to a min/max and to the viewport (intended size kept and restored when there's room), persisted globally in `chrome.storage.local` via the existing layout message, and double-click resets to the default.
- No new permissions or settings UI.

Per the design discussion the persisted "size" is the key size (`--key-unit`, default 32px), the post-#86 equivalent of the issue's original width-based wording.
