### PR TITLE
Add an in-keyboard layout drop-down to the OSK

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -62,6 +62,9 @@
     "keyboard_resize": {
         "message": "Drag to resize; double-click to reset"
     },
+    "keyboard_layout": {
+        "message": "Keyboard layout"
+    },
     "options_title": {
         "message": "Korean IME Options"
     },

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -62,6 +62,9 @@
     "keyboard_resize": {
         "message": "Arrastre para cambiar el tamaño; doble clic para restablecer"
     },
+    "keyboard_layout": {
+        "message": "Distribución del teclado"
+    },
     "options_title": {
         "message": "Opciones de IME coreano"
     },

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -62,6 +62,9 @@
     "keyboard_resize": {
         "message": "드래그하여 크기 조절, 더블클릭하여 기본값으로"
     },
+    "keyboard_layout": {
+        "message": "키보드 레이아웃"
+    },
     "options_title": {
         "message": "한글 입력기 설정"
     },

--- a/src/content-script/content-script-controller.ts
+++ b/src/content-script/content-script-controller.ts
@@ -17,7 +17,8 @@ import {
 import { api } from "../platform/browser-api";
 import { routeByAction } from "../messaging/route-message";
 import { currentOskSite } from "./osk-site";
-import { loadSettings } from "../settings/settings-store";
+import { loadSettings, saveSettings } from "../settings/settings-store";
+import { LayoutId } from "../extension-state/osk-layout";
 
 export class ContentScriptController {
     private isHanYongEnabled = false;
@@ -32,16 +33,19 @@ export class ContentScriptController {
 
     public initialize(isTopWindow: boolean) {
         this.keyboardController = isTopWindow
-            ? new OnScreenKeyboardController((key, keyCode) => {
-                  const handled = this.textInputManager.enterCharacter(key, keyCode);
-                  if (!handled) {
-                      api.runtime.sendMessage<ContentScriptRequestMessage>({
-                          type: "contentScriptRequest",
-                          action: ContentScriptRequestAction.SendKey,
-                          data: { key, keyCode },
-                      });
-                  }
-              })
+            ? new OnScreenKeyboardController(
+                  (key, keyCode) => {
+                      const handled = this.textInputManager.enterCharacter(key, keyCode);
+                      if (!handled) {
+                          api.runtime.sendMessage<ContentScriptRequestMessage>({
+                              type: "contentScriptRequest",
+                              action: ContentScriptRequestAction.SendKey,
+                              data: { key, keyCode },
+                          });
+                      }
+                  },
+                  (layoutId) => void this.saveLayoutSetting(layoutId)
+              )
             : undefined;
 
         this.setupMessageListener();
@@ -69,6 +73,14 @@ export class ContentScriptController {
     private async applyLayoutSetting() {
         const settings = await loadSettings();
         this.keyboardController?.setLayout(settings.onScreenKeyboard.layout);
+    }
+
+    /** Persist the layout chosen from the keyboard's drop-down (the synced setting,
+     *  shared with the options page; the storage.onChanged watcher re-applies it). */
+    private async saveLayoutSetting(layoutId: LayoutId) {
+        const settings = await loadSettings();
+        settings.onScreenKeyboard.layout = layoutId;
+        await saveSettings(settings);
     }
 
     /** Re-apply the layout when the setting changes (the options page writes it). */

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
@@ -755,3 +755,61 @@ describe("OnScreenKeyboardController resize", () => {
         expect(persistedKeyUnit()).toBe(32);
     });
 });
+
+describe("OnScreenKeyboardController layout drop-down", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        Object.assign(globalThis, {
+            chrome: { runtime: { sendMessage: jest.fn() }, i18n: { getMessage: () => "" } },
+        });
+    });
+
+    const host = () => document.querySelector("[id^='kb-']") as HTMLElement;
+    const options = () => Array.from(host().querySelectorAll(".kb-layout-option")) as HTMLButtonElement[];
+    const menu = () => host().querySelector(".kb-layout-menu") as HTMLElement;
+    const trigger = () => host().querySelector(".kb-layout-trigger") as HTMLButtonElement;
+
+    it("lists the three layouts and marks the current one", () => {
+        new OnScreenKeyboardController(() => {});
+
+        // Order matches LAYOUT_OPTIONS: minimal, full US, full Korean.
+        expect(options()).toHaveLength(3);
+        // Default layout is full US (index 1).
+        expect(options()[1].classList.contains("selected")).toBe(true);
+        expect(options()[0].classList.contains("selected")).toBe(false);
+    });
+
+    it("toggles the menu open and closed from the trigger", () => {
+        new OnScreenKeyboardController(() => {});
+
+        expect(menu().classList.contains("open")).toBe(false);
+        trigger().click();
+        expect(menu().classList.contains("open")).toBe(true);
+        trigger().click();
+        expect(menu().classList.contains("open")).toBe(false);
+    });
+
+    it("applies the picked layout, reports the change, and closes the menu", () => {
+        const onLayoutChange = jest.fn();
+        new OnScreenKeyboardController(() => {}, onLayoutChange);
+        const el = host();
+
+        trigger().click();
+        options()[0].click(); // minimal
+
+        expect(onLayoutChange).toHaveBeenCalledWith("minimal");
+        expect(menu().classList.contains("open")).toBe(false);
+        // Switched to minimal (no number row) and reflected as selected.
+        expect(el.querySelector("kbd.Digit1")).toBeNull();
+        expect(options()[0].classList.contains("selected")).toBe(true);
+    });
+
+    it("reflects an externally-set layout (e.g. from the options page)", () => {
+        const controller = new OnScreenKeyboardController(() => {});
+
+        controller.setLayout(LayoutId.FullKorean);
+
+        expect(options()[2].classList.contains("selected")).toBe(true);
+        expect(options()[1].classList.contains("selected")).toBe(false);
+    });
+});

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
@@ -47,6 +47,13 @@ const VIEWPORT_MARGIN_PX = 8;
 
 const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
 
+/** Layouts shown in the in-header drop-down, with their i18n label keys. */
+const LAYOUT_OPTIONS: { id: LayoutId; messageKey: string }[] = [
+    { id: LayoutId.Minimal, messageKey: "options_onScreenKeyboard_layout_minimal" },
+    { id: LayoutId.FullUs, messageKey: "options_onScreenKeyboard_layout_fullUs" },
+    { id: LayoutId.FullKorean, messageKey: "options_onScreenKeyboard_layout_fullKorean" },
+];
+
 export class OnScreenKeyboardController {
     private _keyboardElement: HTMLDivElement;
     private _keyboardPlacement: KeyboardPlacement = {
@@ -94,6 +101,10 @@ export class OnScreenKeyboardController {
     private _layoutId: LayoutId = defaultLayoutId;
     private _collapseButton?: HTMLButtonElement;
     private _modeIndicator?: HTMLImageElement;
+    // In-header layout drop-down: a custom (focus-preserving) menu of layouts.
+    private _layoutMenu?: HTMLDivElement;
+    private _layoutMenuOpen = false;
+    private _layoutOptionButtons = new Map<LayoutId, HTMLButtonElement>();
     // Dotted overlays marking how the keyboard is anchored, shown only while it's
     // being moved (see GUIDE_LINGER_MS): two full-edge lines along the anchored
     // viewport edges (_guideH/_guideV), plus two connectors running from the
@@ -105,9 +116,17 @@ export class OnScreenKeyboardController {
     private _connectorY?: HTMLDivElement;
     private _guideHideTimer?: ReturnType<typeof setTimeout>;
     private _onSendKey: (key: string, keyCode: KeyCode) => void;
+    // Called when the user picks a layout from the in-header drop-down, so the
+    // (synced) layout setting can be updated — keeping it in step with the
+    // options page.
+    private _onLayoutChange: (layoutId: LayoutId) => void;
 
-    constructor(onSendKey: (key: string, keyCode: KeyCode) => void) {
+    constructor(
+        onSendKey: (key: string, keyCode: KeyCode) => void,
+        onLayoutChange: (layoutId: LayoutId) => void = () => {}
+    ) {
         this._onSendKey = onSendKey;
+        this._onLayoutChange = onLayoutChange;
         this._keyboardElement = this.createKeyboard();
         this.setMode(this._mode);
     }
@@ -430,8 +449,13 @@ export class OnScreenKeyboardController {
                 return;
             }
 
-            // Drag only from the header bar, and not from its buttons.
-            if (e.target.closest(".kb-header") && !e.target.closest("button") && !e.target.closest(".kb-mode")) {
+            // Drag only from the header bar, and not from its controls.
+            if (
+                e.target.closest(".kb-header") &&
+                !e.target.closest("button") &&
+                !e.target.closest(".kb-mode") &&
+                !e.target.closest(".kb-layout")
+            ) {
                 this._keyboardMovement.mouse.down = true;
                 this._movedDuringDrag = false;
                 // clientX/Y (CSS px, viewport-relative), not screenX/Y (device px):
@@ -758,6 +782,8 @@ export class OnScreenKeyboardController {
         this._modeIndicator.addEventListener("click", () => this.toggleHanYong());
         header.appendChild(this._modeIndicator);
 
+        header.appendChild(this.createLayoutControl());
+
         // A flex-grow grab area that also pushes the buttons to the right.
         const handle = document.createElement("div");
         handle.className = "kb-handle";
@@ -790,6 +816,82 @@ export class OnScreenKeyboardController {
         button.setAttribute("aria-label", label);
         button.addEventListener("click", onClick);
         return button;
+    }
+
+    // The in-header layout drop-down. Built from buttons (not a native <select>),
+    // so the keyboard's mousedown-preventDefault keeps page focus — a <select>
+    // would steal it and break typing into the focused field.
+    private createLayoutControl(): HTMLDivElement {
+        const control = document.createElement("div");
+        control.className = "kb-layout";
+
+        const trigger = this.createHeaderButton("kb-layout-trigger", "\u{2328}", "keyboard_layout", () =>
+            this.toggleLayoutMenu()
+        );
+        trigger.setAttribute("aria-haspopup", "true");
+        control.appendChild(trigger);
+
+        const menu = document.createElement("div");
+        menu.className = "kb-layout-menu";
+        this._layoutMenu = menu;
+        this._layoutOptionButtons.clear();
+
+        for (const option of LAYOUT_OPTIONS) {
+            const item = document.createElement("button");
+            item.type = "button";
+            item.className = "kb-layout-option";
+            item.textContent = api.i18n.getMessage(option.messageKey);
+            item.addEventListener("click", () => this.selectLayout(option.id));
+            this._layoutOptionButtons.set(option.id, item);
+            menu.appendChild(item);
+        }
+
+        control.appendChild(menu);
+        this.updateLayoutControl();
+
+        // Close the menu when interacting anywhere outside the control (clicks on
+        // the keyboard's keys/handle are stopPropagated, so this catches the page;
+        // the keyboard mousedown handler closes it for in-keyboard clicks).
+        document.addEventListener("pointerdown", (e) => {
+            if (this._layoutMenuOpen && !(e.target instanceof Element && e.target.closest(".kb-layout"))) {
+                this.closeLayoutMenu();
+            }
+        });
+
+        return control;
+    }
+
+    private toggleLayoutMenu() {
+        if (this._layoutMenuOpen) {
+            this.closeLayoutMenu();
+        } else {
+            this.openLayoutMenu();
+        }
+    }
+
+    private openLayoutMenu() {
+        this._layoutMenuOpen = true;
+        this._layoutMenu?.classList.add("open");
+    }
+
+    private closeLayoutMenu() {
+        this._layoutMenuOpen = false;
+        this._layoutMenu?.classList.remove("open");
+    }
+
+    private selectLayout(layoutId: LayoutId) {
+        this.closeLayoutMenu();
+        this.setLayout(layoutId); // apply immediately
+        this._onLayoutChange(layoutId); // persist the (synced) setting
+    }
+
+    // Reflect the current layout in the drop-down (selected option + trigger title).
+    private updateLayoutControl() {
+        for (const [id, button] of this._layoutOptionButtons) {
+            const selected = id === this._layoutId;
+            button.classList.toggle("selected", selected);
+            button.setAttribute("aria-checked", String(selected));
+        }
     }
 
     private toggleCollapsed() {
@@ -1012,6 +1114,7 @@ export class OnScreenKeyboardController {
         this.renderKeyboard(this._keyboardBody, layout);
         // Re-apply state that the freshly rendered keys need to reflect.
         this.updateKeyVisibility();
+        this.updateLayoutControl();
         // The keyboard's size changed, so re-clamp it (only while shown — hidden,
         // offsetWidth is 0 and showKeyboard re-places it on show).
         if (this._keyboardElement.style.display !== "none") {

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard.scss
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard.scss
@@ -97,6 +97,55 @@
         background-color: #a00000;
     }
 
+    // In-header layout drop-down: a trigger button + an absolutely-positioned
+    // menu that drops below the header over the keys.
+    .kb-layout {
+        position: relative;
+        flex: 0 0 auto;
+        display: flex;
+        align-items: stretch;
+    }
+
+    .kb-layout-menu {
+        display: none;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        z-index: 3; // above the keys and resize grips
+        min-width: max-content;
+        background-color: var(--key-background-color);
+        border: 1px solid var(--border-color);
+
+        &.open {
+            display: block;
+        }
+    }
+
+    .kb-layout-option {
+        display: block;
+        width: 100%;
+        padding: 4px 10px;
+        border: none;
+        background: transparent;
+        color: var(--key-color);
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 13px;
+        line-height: 1.4;
+        text-align: left;
+        white-space: nowrap;
+        cursor: pointer;
+
+        &:hover {
+            background-color: var(--key-hover-background-color);
+        }
+
+        // Mark the active layout.
+        &.selected {
+            background-color: var(--key-active-background-color);
+            font-weight: bold;
+        }
+    }
+
     .kb-body {
         padding: var(--key-gap) 0;
     }


### PR DESCRIPTION
Closes #91.

Adds a layout drop-down to the on-screen keyboard's header, so the layout can be switched in place without opening the options page.

- Writes the same synced `onScreenKeyboard.layout` setting, so it round-trips with the options page (the content script's `storage.onChanged` watcher re-applies the layout, and the options dropdown reads the same value).
- Built from buttons rather than a native `<select>` so the keyboard's existing `mousedown`-preventDefault keeps page focus — a focusable `<select>` would steal focus and break typing into the active field.
- Excluded from the header drag area; reuses the existing layout labels; reflects the current layout and works while collapsed/expanded.
