### PR TITLE
Improve options understandibility

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -86,6 +86,12 @@
     "options_hanYong_keyboardKeyEnabled_description": {
         "message": "Applies to the physical keyboard key. On Korean keyboards, this is the dedicated Han/Yong key to the right of the spacebar."
     },
+    "options_hanYong_syncAcrossTabs_label": {
+        "message": "Sync mode across tabs"
+    },
+    "options_hanYong_syncAcrossTabs_description": {
+        "message": "Switch between Hangul and English in one tab and every tab follows. When off, each tab keeps its own mode."
+    },
     "options_hanYong_hint": {
         "message": "Switches between Hangul and Latin input."
     },
@@ -113,6 +119,12 @@
     "options_onScreenKeyboard_layout_fullKorean": {
         "message": "Full - Korean Dubeolsik (두벌식)"
     },
+    "options_onScreenKeyboard_syncAcrossTabs_label": {
+        "message": "Sync visibility across tabs"
+    },
+    "options_onScreenKeyboard_syncAcrossTabs_description": {
+        "message": "Show or hide the on-screen keyboard in one tab and every tab follows. When off, each tab controls its own."
+    },
     "options_hanYong_startOff": {
         "message": "Start in English"
     },
@@ -121,14 +133,5 @@
     },
     "options_hanYong_restore": {
         "message": "Restore last mode"
-    },
-    "options_general_heading": {
-        "message": "General"
-    },
-    "options_shareAcrossTabs_label": {
-        "message": "Share status across tabs"
-    },
-    "options_shareAcrossTabs_description": {
-        "message": "When you turn the on-screen keyboard or Han/Yong mode on or off, apply it to every tab at once, not just the focused one."
     }
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -86,6 +86,12 @@
     "options_hanYong_keyboardKeyEnabled_description": {
         "message": "Se aplica a la tecla física del teclado. En los teclados coreanos, es la tecla dedicada Han/Yong a la derecha de la barra espaciadora."
     },
+    "options_hanYong_syncAcrossTabs_label": {
+        "message": "Sincronizar el modo entre pestañas"
+    },
+    "options_hanYong_syncAcrossTabs_description": {
+        "message": "Cambie entre hangul e inglés en una pestaña y todas las pestañas seguirán el cambio. Si está desactivado, cada pestaña mantiene su propio modo."
+    },
     "options_hanYong_hint": {
         "message": "Alterna entre la entrada de hangul y la latina."
     },
@@ -113,6 +119,12 @@
     "options_onScreenKeyboard_layout_fullKorean": {
         "message": "Completa - Dubeolsik coreano (두벌식)"
     },
+    "options_onScreenKeyboard_syncAcrossTabs_label": {
+        "message": "Sincronizar la visibilidad entre pestañas"
+    },
+    "options_onScreenKeyboard_syncAcrossTabs_description": {
+        "message": "Muestre u oculte el teclado en pantalla en una pestaña y todas las pestañas seguirán el cambio. Si está desactivado, cada pestaña lo controla por separado."
+    },
     "options_hanYong_startOff": {
         "message": "Iniciar en inglés"
     },
@@ -121,14 +133,5 @@
     },
     "options_hanYong_restore": {
         "message": "Restaurar el último modo"
-    },
-    "options_general_heading": {
-        "message": "General"
-    },
-    "options_shareAcrossTabs_label": {
-        "message": "Compartir el estado entre pestañas"
-    },
-    "options_shareAcrossTabs_description": {
-        "message": "Cuando active o desactive el teclado en pantalla o el modo Han/Yong, se aplicará a todas las pestañas a la vez, no solo a la activa."
     }
 }

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -86,6 +86,12 @@
     "options_hanYong_keyboardKeyEnabled_description": {
         "message": "실제 키보드 키에 적용됩니다. 한국어 키보드에서는 스페이스바 오른쪽의 전용 한/영 키가 이에 해당합니다."
     },
+    "options_hanYong_syncAcrossTabs_label": {
+        "message": "모든 탭에서 모드 동기화"
+    },
+    "options_hanYong_syncAcrossTabs_description": {
+        "message": "한 탭에서 한글과 영문을 전환하면 모든 탭에 적용됩니다. 끄면 각 탭이 자체 모드를 유지합니다."
+    },
     "options_hanYong_hint": {
         "message": "한글과 로마자 입력을 전환합니다."
     },
@@ -113,6 +119,12 @@
     "options_onScreenKeyboard_layout_fullKorean": {
         "message": "전체 - 한국어 두벌식"
     },
+    "options_onScreenKeyboard_syncAcrossTabs_label": {
+        "message": "모든 탭에서 표시 동기화"
+    },
+    "options_onScreenKeyboard_syncAcrossTabs_description": {
+        "message": "한 탭에서 화면 키보드를 표시하거나 숨기면 모든 탭에 적용됩니다. 끄면 각 탭이 자체적으로 제어합니다."
+    },
     "options_hanYong_startOff": {
         "message": "영문으로 시작"
     },
@@ -121,14 +133,5 @@
     },
     "options_hanYong_restore": {
         "message": "마지막 모드 유지"
-    },
-    "options_general_heading": {
-        "message": "일반"
-    },
-    "options_shareAcrossTabs_label": {
-        "message": "모든 탭에서 상태 공유"
-    },
-    "options_shareAcrossTabs_description": {
-        "message": "화면 키보드나 한/영 모드를 켜거나 끄면 현재 탭뿐만 아니라 모든 탭에 동시에 적용됩니다."
     }
 }

--- a/src/options-app/HanYongSection.vue
+++ b/src/options-app/HanYongSection.vue
@@ -4,6 +4,7 @@ import { Persistence } from "../settings/settings";
 import { t } from "./i18n";
 import PersistenceSelect from "./PersistenceSelect.vue";
 import LabeledCheckbox from "./LabeledCheckbox.vue";
+import ToggleSwitch from "./ToggleSwitch.vue";
 
 const optionLabels: Record<Persistence, string> = {
     [Persistence.AlwaysOff]: t("options_hanYong_startOff"),
@@ -14,17 +15,21 @@ const optionLabels: Record<Persistence, string> = {
 
 <template>
     <section>
-        <h2>{{ t("options_hanYong_heading") }}</h2>
-        <LabeledCheckbox
-            v-model="settings.hanYong.enabled"
-            :label="t('options_hanYong_enabled_label')"
-        />
+        <div class="section-header">
+            <ToggleSwitch v-model="settings.hanYong.enabled" :aria-label="t('options_hanYong_heading')" />
+            <h2>{{ t("options_hanYong_heading") }}</h2>
+        </div>
         <template v-if="settings.hanYong.enabled">
             <p class="description section-hint">{{ t("options_hanYong_hint") }}</p>
             <LabeledCheckbox
                 v-model="settings.hanYong.keyboardKeyEnabled"
                 :label="t('options_hanYong_keyboardKeyEnabled_label')"
                 :description="t('options_hanYong_keyboardKeyEnabled_description')"
+            />
+            <LabeledCheckbox
+                v-model="settings.hanYong.syncAcrossTabs"
+                :label="t('options_hanYong_syncAcrossTabs_label')"
+                :description="t('options_hanYong_syncAcrossTabs_description')"
             />
             <PersistenceSelect
                 v-model="settings.hanYong.persistence"
@@ -37,6 +42,18 @@ const optionLabels: Record<Persistence, string> = {
 </template>
 
 <style scoped>
+.section-header {
+    display: flex;
+    align-items: center;
+    gap: 0.6em;
+    margin-bottom: 0.75em;
+}
+
+/* The header row owns the spacing below the heading (see section-header). */
+.section-header h2 {
+    margin: 0;
+}
+
 .section-hint {
     margin-top: -0.25em;
     margin-bottom: 0.75em;

--- a/src/options-app/OnScreenKeyboardSection.vue
+++ b/src/options-app/OnScreenKeyboardSection.vue
@@ -4,6 +4,7 @@ import { Persistence } from "../settings/settings";
 import { LayoutId } from "../extension-state/osk-layout";
 import { t } from "./i18n";
 import PersistenceSelect from "./PersistenceSelect.vue";
+import LabeledCheckbox from "./LabeledCheckbox.vue";
 
 const optionLabels: Record<Persistence, string> = {
     [Persistence.AlwaysOff]: t("options_onScreenKeyboard_startOff"),
@@ -25,6 +26,11 @@ const layoutOptions: { value: LayoutId; name: string }[] = [
             v-model="settings.onScreenKeyboard.persistence"
             :label="t('options_persistence_label')"
             :option-labels="optionLabels"
+        />
+        <LabeledCheckbox
+            v-model="settings.onScreenKeyboard.syncAcrossTabs"
+            :label="t('options_onScreenKeyboard_syncAcrossTabs_label')"
+            :description="t('options_onScreenKeyboard_syncAcrossTabs_description')"
         />
         <label class="select">
             <span class="label">{{ t("options_onScreenKeyboard_layout_label") }}</span>

--- a/src/options-app/ToggleSwitch.vue
+++ b/src/options-app/ToggleSwitch.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+defineProps<{
+    ariaLabel: string;
+}>();
+
+const model = defineModel<boolean>({ required: true });
+</script>
+
+<template>
+    <label class="switch">
+        <input v-model="model" type="checkbox" :aria-label="ariaLabel" />
+        <span class="slider" aria-hidden="true"></span>
+    </label>
+</template>
+
+<style scoped>
+.switch {
+    display: inline-flex;
+    flex: 0 0 auto;
+    cursor: pointer;
+}
+
+/* Visually hidden but still focusable and accessible: the styled .slider is the
+   visible control, the native checkbox drives state and keyboard interaction. */
+.switch input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    overflow: hidden;
+    white-space: nowrap;
+}
+
+.slider {
+    position: relative;
+    display: block;
+    width: 2.5em;
+    height: 1.4em;
+    border-radius: 1em;
+    background-color: var(--toggle-off-bg);
+    transition: background-color 0.15s ease;
+}
+
+.slider::before {
+    content: "";
+    position: absolute;
+    top: 0.2em;
+    left: 0.2em;
+    width: 1em;
+    height: 1em;
+    border-radius: 50%;
+    background-color: #fff;
+    transition: transform 0.15s ease;
+}
+
+.switch input:checked + .slider {
+    background-color: var(--toggle-on-bg);
+}
+
+.switch input:checked + .slider::before {
+    transform: translateX(1.1em);
+}
+
+.switch input:focus-visible + .slider {
+    outline: 2px solid var(--toggle-on-bg);
+    outline-offset: 2px;
+}
+</style>

--- a/src/options-app/options-page.vue
+++ b/src/options-app/options-page.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { onMounted } from "vue";
-import { initSettings, settings } from "./use-settings";
+import { initSettings } from "./use-settings";
 import { t } from "./i18n";
 import OnScreenKeyboardSection from "./OnScreenKeyboardSection.vue";
 import HanYongSection from "./HanYongSection.vue";
-import LabeledCheckbox from "./LabeledCheckbox.vue";
 
 onMounted(initSettings);
 </script>
@@ -12,16 +11,8 @@ onMounted(initSettings);
 <template>
     <main>
         <h1>{{ t("options_title") }}</h1>
-        <OnScreenKeyboardSection />
         <HanYongSection />
-        <section>
-            <h2>{{ t("options_general_heading") }}</h2>
-            <LabeledCheckbox
-                v-model="settings.shareAcrossTabs"
-                :label="t('options_shareAcrossTabs_label')"
-                :description="t('options_shareAcrossTabs_description')"
-            />
-        </section>
+        <OnScreenKeyboardSection />
     </main>
 </template>
 
@@ -35,6 +26,9 @@ onMounted(initSettings);
     --section-bg: light-dark(#f9f9f9, #1e1e1e);
     --section-border: light-dark(#ddd, #333);
     --description-color: light-dark(#666, #999);
+
+    --toggle-off-bg: light-dark(#ccc, #555);
+    --toggle-on-bg: light-dark(#2563eb, #3b82f6);
 }
 
 body {

--- a/src/service-worker/state-manager.test.ts
+++ b/src/service-worker/state-manager.test.ts
@@ -295,9 +295,9 @@ describe("KeepLastState persistence", () => {
     });
 });
 
-describe("share across tabs", () => {
-    it("fans a toggle out to every open tab", async () => {
-        withSettings({ shareAcrossTabs: true });
+describe("sync across tabs", () => {
+    it("fans a keyboard-visibility toggle out to every open tab when OSK sync is on", async () => {
+        withSettings({ onScreenKeyboard: { syncAcrossTabs: true } });
         tabs = [{ id: 1, active: true }, { id: 2 }, { id: 3 }];
         const manager = new StateManager();
 
@@ -308,8 +308,48 @@ describe("share across tabs", () => {
         expect(lastSentTo(3)?.isOnScreenKeyboardEnabled).toBe(true);
     });
 
-    it("a tab opened later adopts the shared value", async () => {
-        withSettings({ shareAcrossTabs: true });
+    it("fans a Han/Yong mode toggle out to every open tab when mode sync is on", async () => {
+        withSettings({ hanYong: { syncAcrossTabs: true } });
+        tabs = [{ id: 1, active: true }, { id: 2 }, { id: 3 }];
+        const manager = new StateManager();
+
+        await manager.toggleHanYongMode(1);
+
+        expect(lastSentTo(1)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
+        expect(lastSentTo(2)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
+        expect(lastSentTo(3)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
+    });
+
+    it("syncing visibility leaves each tab's Han/Yong mode untouched", async () => {
+        withSettings({ onScreenKeyboard: { syncAcrossTabs: true } }); // mode sync off
+        tabs = [{ id: 1, active: true }, { id: 2 }];
+        session["tabState-1"] = { koreanKeyboardMode: KoreanKeyboardMode.English, isOnScreenKeyboardEnabled: false };
+        session["tabState-2"] = { koreanKeyboardMode: KoreanKeyboardMode.Hangul, isOnScreenKeyboardEnabled: false };
+        const manager = new StateManager();
+
+        await manager.toggleOnScreenKeyboard(1);
+
+        // Tab 2 adopts the shared visibility but keeps its own Hangul mode.
+        expect(lastSentTo(2)?.isOnScreenKeyboardEnabled).toBe(true);
+        expect(lastSentTo(2)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
+    });
+
+    it("syncing Han/Yong mode leaves each tab's keyboard visibility untouched", async () => {
+        withSettings({ hanYong: { syncAcrossTabs: true } }); // visibility sync off
+        tabs = [{ id: 1, active: true }, { id: 2 }];
+        session["tabState-1"] = { koreanKeyboardMode: KoreanKeyboardMode.English, isOnScreenKeyboardEnabled: false };
+        session["tabState-2"] = { koreanKeyboardMode: KoreanKeyboardMode.English, isOnScreenKeyboardEnabled: true };
+        const manager = new StateManager();
+
+        await manager.toggleHanYongMode(1);
+
+        // Tab 2 adopts the shared mode but keeps its own (visible) keyboard.
+        expect(lastSentTo(2)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
+        expect(lastSentTo(2)?.isOnScreenKeyboardEnabled).toBe(true);
+    });
+
+    it("a tab opened later adopts the synced value", async () => {
+        withSettings({ onScreenKeyboard: { syncAcrossTabs: true } });
         const manager = new StateManager();
         await manager.toggleOnScreenKeyboard(1);
 
@@ -319,8 +359,8 @@ describe("share across tabs", () => {
         expect(lastSentTo(9)?.isOnScreenKeyboardEnabled).toBe(true);
     });
 
-    it("does not fan out when sharing is off", async () => {
-        withSettings({ shareAcrossTabs: false });
+    it("does not fan out when sync is off", async () => {
+        withSettings({}); // both syncAcrossTabs flags default off
         tabs = [{ id: 1, active: true }, { id: 2 }];
         const manager = new StateManager();
 
@@ -331,7 +371,7 @@ describe("share across tabs", () => {
     });
 
     it("pushes disabled Han/Yong state to open tabs immediately", async () => {
-        withSettings({ shareAcrossTabs: false, hanYong: { persistence: Persistence.AlwaysOn } });
+        withSettings({ hanYong: { persistence: Persistence.AlwaysOn } });
         tabs = [{ id: 1, active: true }, { id: 2 }];
         session["tabState-1"] = {
             koreanKeyboardMode: KoreanKeyboardMode.Hangul,
@@ -343,7 +383,7 @@ describe("share across tabs", () => {
         };
         const manager = new StateManager();
 
-        withSettings({ shareAcrossTabs: false, hanYong: { enabled: false, persistence: Persistence.AlwaysOn } });
+        withSettings({ hanYong: { enabled: false, persistence: Persistence.AlwaysOn } });
         await manager.onSettingsChanged();
 
         expect(lastSentTo(1)?.isHanYongEnabled).toBe(false);
@@ -354,7 +394,7 @@ describe("share across tabs", () => {
     });
 
     it("pushes disabled physical-key state to open tabs immediately without changing Hangul mode", async () => {
-        withSettings({ shareAcrossTabs: false, hanYong: { persistence: Persistence.AlwaysOn } });
+        withSettings({ hanYong: { persistence: Persistence.AlwaysOn } });
         tabs = [{ id: 1, active: true }, { id: 2 }];
         session["tabState-1"] = {
             koreanKeyboardMode: KoreanKeyboardMode.Hangul,
@@ -367,7 +407,6 @@ describe("share across tabs", () => {
         const manager = new StateManager();
 
         withSettings({
-            shareAcrossTabs: false,
             hanYong: { enabled: true, keyboardKeyEnabled: false, persistence: Persistence.AlwaysOn },
         });
         await manager.onSettingsChanged();

--- a/src/service-worker/state-manager.ts
+++ b/src/service-worker/state-manager.ts
@@ -20,8 +20,8 @@ import { api } from "../platform/browser-api";
 
 /**
  * Global current live state (browser-session-lived). New tabs inherit it, and
- * in "share across tabs" mode every tab is kept equal to it. Updated whenever a
- * tab's state changes or a tab becomes active.
+ * any field with `syncAcrossTabs` on is kept equal to it across every open tab.
+ * Updated whenever a tab's state changes or a tab becomes active.
  */
 const LIVE_STATE_KEY = "liveState";
 /** Persisted (survives restart) last state, source for KeepLastState seeding. */
@@ -34,9 +34,8 @@ const englishActionIcons = { 16: icon16a, 24: icon24a, 32: icon32a };
  *
  * Live per-tab state lives in `storage.session` (`tabState-<id>`). Two globals
  * connect it to the user's settings (#26):
- *  - `storage.session[liveState]` — the current value new tabs inherit (and
- *    that all tabs share when "share across tabs" is on). Tracks the last
- *    active tab.
+ *  - `storage.session[liveState]` — the current value new tabs inherit (and the
+ *    source for any field synced across tabs). Tracks the last active tab.
  *  - `storage.local[lastState]` — the value remembered across a browser
  *    restart, used to seed `KeepLastState` features on a fresh session.
  *
@@ -184,13 +183,12 @@ export class StateManager {
      *  - Enabling/disabling Hangul typing (or the Right Alt / Han-Yong key)
      *    is re-derived for every tab by `hydrateTabState`, so each open tab is
      *    re-sent its state to reflect the change.
-     *  - Enabling "share across tabs" converges the currently-open tabs onto
-     *    the shared live value.
+     *  - Turning on a feature's `syncAcrossTabs` converges the currently-open
+     *    tabs onto the shared live value for that feature's field.
      *
      * Persistence changes remain restart-only (they only seed a fresh session),
-     * so re-sending state is a harmless no-op for them. When not sharing, each
-     * tab is pushed its own re-hydrated state; when sharing, the single shared
-     * value is broadcast instead.
+     * so re-sending state is a harmless no-op for them. Each tab is pushed its
+     * own re-hydrated state, with any synced field overlaid from the live value.
      */
     public async onSettingsChanged(): Promise<void> {
         const settings = await loadSettings();
@@ -199,38 +197,32 @@ export class StateManager {
             await this.setLiveState(live);
         }
 
-        if (!settings.shareAcrossTabs) {
-            const tabs = await api.tabs.query({});
-            await Promise.all(
-                tabs.map(async (tab) => {
-                    if (tab.id === undefined) {
-                        return;
-                    }
-                    await this.sendStateToTab(tab.id, settings);
-                })
-            );
-            return;
-        }
-
-        let shared = live;
-        if (!shared) {
-            const [active] = await api.tabs.query({ active: true, lastFocusedWindow: true });
-            shared =
-                active?.id !== undefined
-                    ? await this.getTabState(active.id, settings)
-                    : await this.deriveInitialState(settings);
-            await this.setLiveState(shared);
-        }
-        await this.broadcastState(shared);
+        // Re-send every open tab its own re-hydrated state, overlaying any field
+        // that's now synced so the open tabs converge onto the shared live value
+        // (e.g. when a syncAcrossTabs flag was just turned on).
+        const shared = this.syncedFields(live, settings);
+        const tabs = await api.tabs.query({});
+        await Promise.all(
+            tabs.map(async (tab) => {
+                if (tab.id === undefined) {
+                    return;
+                }
+                const own = await this.anchorTabState(tab.id, settings);
+                const merged = this.hydrateTabState({ ...own, ...shared }, settings);
+                await api.storage.session.set({ [this.tabStateKey(tab.id)]: merged });
+                await this.pushState(tab.id, merged);
+                await this.updatePresentation(tab.id, merged);
+            })
+        );
     }
 
     /**
      * Updates a tab's state and propagates it. Returns the new state.
      *
      * Always updates the global live value (so new tabs inherit it) and, for any
-     * `KeepLastState` feature, the persisted `storage.local` value. When "share
-     * across tabs" is on, mirrors the new state to every open tab instead of
-     * just this one.
+     * `KeepLastState` feature, the persisted `storage.local` value. Any field
+     * whose `syncAcrossTabs` flag is on is also mirrored to every other open tab
+     * (see {@link shareToOtherTabs}).
      * @param tabId The ID of the tab for which to update the state
      * @param updateFn function that takes the current tab state and returns the new tab state
      */
@@ -240,6 +232,9 @@ export class StateManager {
         settings?: Settings
     ): Promise<TabState> {
         const currentSettings = settings ?? (await loadSettings());
+        // Captured before we move the live value, so tabs that are still tracking
+        // it (no own state yet) keep their current un-synced fields below.
+        const previousLive = await this.getLiveState(currentSettings);
         const currentTabState = await this.anchorTabState(tabId, currentSettings);
         const newTabState = this.hydrateTabState(updateFn(currentTabState), currentSettings);
 
@@ -247,14 +242,65 @@ export class StateManager {
         await this.persistLastState(currentSettings, newTabState);
         await this.setLiveState(newTabState);
 
-        if (currentSettings.shareAcrossTabs) {
-            await this.broadcastState(newTabState);
-        } else {
-            await this.pushState(tabId, newTabState);
-            await this.updatePresentation(tabId, newTabState);
-        }
+        await this.pushState(tabId, newTabState);
+        await this.updatePresentation(tabId, newTabState);
+        await this.shareToOtherTabs(tabId, newTabState, previousLive, currentSettings);
 
         return newTabState;
+    }
+
+    /**
+     * Fan the synced fields of one tab's new state out to every *other* open tab.
+     * Only the fields whose `syncAcrossTabs` flag is on are applied; each target
+     * tab keeps its own value for the rest (e.g. syncing keyboard visibility must
+     * not disturb another tab's Han/Yong mode). A tab with no state of its own is
+     * still tracking the previous live value, so that's the base we preserve.
+     */
+    private async shareToOtherTabs(
+        sourceTabId: number,
+        sourceState: TabState,
+        previousLive: TabState | undefined,
+        settings: Settings
+    ): Promise<void> {
+        const shared = this.syncedFields(sourceState, settings);
+        if (Object.keys(shared).length === 0) {
+            return;
+        }
+
+        const tabs = await api.tabs.query({});
+        await Promise.all(
+            tabs.map(async (tab) => {
+                if (tab.id === undefined || tab.id === sourceTabId) {
+                    return;
+                }
+                const key = this.tabStateKey(tab.id);
+                const own = (await api.storage.session.get(key))[key] as Partial<TabState> | undefined;
+                const base = own ?? previousLive ?? sourceState;
+                const merged = this.hydrateTabState({ ...base, ...shared }, settings);
+                await api.storage.session.set({ [key]: merged });
+                await this.pushState(tab.id, merged);
+                await this.updatePresentation(tab.id, merged);
+            })
+        );
+    }
+
+    /**
+     * The subset of a state's live fields that are currently synced across tabs,
+     * per each feature's `syncAcrossTabs` flag. Returns {} when `source` is
+     * undefined (no live value yet) or nothing is synced.
+     */
+    private syncedFields(source: TabState | undefined, settings: Settings): Partial<TabState> {
+        const fields: Partial<TabState> = {};
+        if (!source) {
+            return fields;
+        }
+        if (settings.onScreenKeyboard.syncAcrossTabs) {
+            fields.isOnScreenKeyboardEnabled = source.isOnScreenKeyboardEnabled;
+        }
+        if (settings.hanYong.syncAcrossTabs) {
+            fields.koreanKeyboardMode = source.koreanKeyboardMode;
+        }
+        return fields;
     }
 
     /** Push a tab's current state to it and refresh its icon / menu presentation. */
@@ -273,21 +319,6 @@ export class StateManager {
             action: ServiceScriptMessageAction.UpdateState,
             data: state,
         });
-    }
-
-    /** Apply one state to every open tab (used in "share across tabs" mode). */
-    private async broadcastState(state: TabState) {
-        const tabs = await api.tabs.query({});
-        await Promise.all(
-            tabs.map(async (tab) => {
-                if (tab.id === undefined) {
-                    return;
-                }
-                await api.storage.session.set({ [this.tabStateKey(tab.id)]: state });
-                await this.pushState(tab.id, state);
-                await this.updatePresentation(tab.id, state);
-            })
-        );
     }
 
     /**

--- a/src/settings/settings-store.test.ts
+++ b/src/settings/settings-store.test.ts
@@ -39,23 +39,41 @@ describe("loadSettings", () => {
 
     it("overlays stored values, keeping defaults for untouched keys", async () => {
         stored({
-            shareAcrossTabs: true,
-            hanYong: { persistence: Persistence.KeepLastState },
+            hanYong: { persistence: Persistence.KeepLastState, syncAcrossTabs: true },
         });
 
         const settings = await loadSettings();
 
-        expect(settings.shareAcrossTabs).toBe(true);
         expect(settings.hanYong.persistence).toBe(Persistence.KeepLastState);
+        expect(settings.hanYong.syncAcrossTabs).toBe(true);
         expect(settings.hanYong.enabled).toBe(true);
         expect(settings.hanYong.keyboardKeyEnabled).toBe(true);
         expect(settings.onScreenKeyboard.persistence).toBe(Persistence.AlwaysOff);
     });
 
     it("keeps the default when a stored value has the wrong type", async () => {
-        stored({ shareAcrossTabs: "yes please" });
+        stored({ hanYong: { syncAcrossTabs: "yes please" } });
 
-        expect((await loadSettings()).shareAcrossTabs).toBe(false);
+        expect((await loadSettings()).hanYong.syncAcrossTabs).toBe(false);
+    });
+
+    it("migrates the legacy top-level shareAcrossTabs onto both feature flags", async () => {
+        stored({ shareAcrossTabs: true });
+
+        const settings = await loadSettings();
+
+        expect(settings.hanYong.syncAcrossTabs).toBe(true);
+        expect(settings.onScreenKeyboard.syncAcrossTabs).toBe(true);
+        expect(settings).not.toHaveProperty("shareAcrossTabs");
+    });
+
+    it("lets an explicit feature sync flag win over the legacy shareAcrossTabs", async () => {
+        stored({ shareAcrossTabs: true, hanYong: { syncAcrossTabs: false } });
+
+        const settings = await loadSettings();
+
+        expect(settings.hanYong.syncAcrossTabs).toBe(false);
+        expect(settings.onScreenKeyboard.syncAcrossTabs).toBe(true);
     });
 
     it("ignores keys that are not part of the settings", async () => {
@@ -90,7 +108,8 @@ describe("loadSettings", () => {
 
 describe("saveSettings", () => {
     it("writes the whole settings object to storage.sync", async () => {
-        const settings: Settings = { ...defaultSettings, shareAcrossTabs: true };
+        const settings: Settings = structuredClone(defaultSettings);
+        settings.hanYong.syncAcrossTabs = true;
 
         await saveSettings(settings);
 

--- a/src/settings/settings-store.ts
+++ b/src/settings/settings-store.ts
@@ -12,7 +12,30 @@ export async function loadSettings(): Promise<Settings> {
     const stored = (await api.storage.sync.get(null)) as Record<string, unknown>;
     const result = structuredClone(defaultSettings);
     overlayStored(result as unknown as Record<string, unknown>, stored);
+    migrateLegacyShareAcrossTabs(result, stored);
     return result;
+}
+
+/**
+ * The single top-level `shareAcrossTabs` was split into per-feature
+ * `onScreenKeyboard.syncAcrossTabs` and `hanYong.syncAcrossTabs`. If a user had
+ * the old flag on and hasn't written either new flag yet, carry it onto both so
+ * the behavior is preserved across the upgrade.
+ */
+function migrateLegacyShareAcrossTabs(result: Settings, stored: Record<string, unknown>): void {
+    if (stored.shareAcrossTabs !== true) {
+        return;
+    }
+
+    const oskStored = isPlainObject(stored.onScreenKeyboard) ? stored.onScreenKeyboard : {};
+    const hanYongStored = isPlainObject(stored.hanYong) ? stored.hanYong : {};
+
+    if (!("syncAcrossTabs" in oskStored)) {
+        result.onScreenKeyboard.syncAcrossTabs = true;
+    }
+    if (!("syncAcrossTabs" in hanYongStored)) {
+        result.hanYong.syncAcrossTabs = true;
+    }
 }
 
 export async function saveSettings(settings: Settings): Promise<void> {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -10,6 +10,12 @@ export enum Persistence {
 export interface FeatureSettings {
     /** The feature's state when the browser starts (see {@link Persistence}). */
     persistence: Persistence;
+    /**
+     * Keep this feature's live on/off value the same in every tab: toggling it in
+     * one tab fans the change out to all of them. When false, each tab is
+     * independent. Governs only this feature's live state — not layout/size/etc.
+     */
+    syncAcrossTabs: boolean;
 }
 
 export interface OnScreenKeyboardSettings extends FeatureSettings {
@@ -33,21 +39,20 @@ export interface HanYongSettings extends FeatureSettings {
 export interface Settings {
     onScreenKeyboard: OnScreenKeyboardSettings;
     hanYong: HanYongSettings;
-    /** Apply changes to every tab at once, not just the focused one. */
-    shareAcrossTabs: boolean;
 }
 
 export const defaultSettings: Settings = {
     onScreenKeyboard: {
         persistence: Persistence.AlwaysOff,
+        syncAcrossTabs: false,
         layout: defaultLayoutId,
     },
     hanYong: {
         enabled: true,
         keyboardKeyEnabled: true,
         persistence: Persistence.AlwaysOff,
+        syncAcrossTabs: false,
     },
-    shareAcrossTabs: false,
 };
 
 /**


### PR DESCRIPTION
* Split shareAcrossTabs into two syncAcrossTabs settings.
* Han/yong is now enabled with a toggle instead of checkbox.

Closes #97 