### PR TITLE
Auto-load the dev extension over CDP; use a throwaway profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ has the feature branch around, can look merged when it isn't (or vice versa).
 | `npm run build:firefox` | Firefox build to `dist-firefox/` (see Firefox build note below) |
 | `npm run lint:firefox` | `web-ext lint` the Firefox build in `dist-firefox/` |
 | `npm run build-dev:chrome` | Unoptimized dev Chrome build to `dist-chrome-dev/` |
-| `npm run dev:chrome` | One-off dev build + launch Chrome on a persistent dev profile + test page (no watcher; re-run to rebuild — see `scripts/dev.mjs`). Add `--watch` for a live-reloading Parcel watcher. |
+| `npm run dev:chrome` | One-off dev build + launch Chrome on a fresh throwaway profile, auto-load the extension over CDP, open a test page (no watcher; re-run to rebuild — see `scripts/dev.mjs`). Add `--watch` for a live-reloading Parcel watcher. |
 | `npm run check` | Type-check only (`tsc --noEmit`) |
 | `npm run lint` / `lint:fix` | ESLint (flat config in `eslint.config.mjs`) |
 | `npm test` | Jest unit tests (ts-jest + jsdom) |
@@ -108,12 +108,16 @@ Core domain logic (mostly pure, well unit-tested):
   (`npm run dev:chrome -- --enable-word`). Don't waste time trying to drive Docs with
   synthetic events; that door is closed (Google Input Tools only works via a
   private main-world bridge into Docs' internal `kix` editor).
-- **`--load-extension` is dead in current Chrome.** Chrome 137+ removed the
-  command-line switch (anti-malware), and by Chrome 148 the
-  `--disable-features=DisableLoadExtensionCommandLineSwitch` opt-out no longer
-  works either. So `npm run dev:chrome` can't auto-load into a throwaway profile
-  — it uses a persistent `.chrome-profile/` where you "Load unpacked" once (from
-  `dist-chrome-dev/`; dev builds are kept out of the production `dist-chrome/`).
+- **`--load-extension` is dead in current Chrome, so `dev:chrome` loads over
+  CDP.** Chrome 137+ removed the command-line switch (anti-malware), and by Chrome
+  148 the `--disable-features=DisableLoadExtensionCommandLineSwitch` opt-out no
+  longer works either. So `npm run dev:chrome` instead launches Chrome on a
+  *fresh throwaway profile* with `--enable-unsafe-extension-debugging` and loads
+  `dist-chrome-dev/` over the DevTools Protocol (`Extensions.loadUnpacked`, after
+  `Extensions.uninstall`-ing anything already loaded). No manual "Load unpacked"
+  step. Needs a recent Chrome (we assume the latest). The temp profile is removed
+  on shutdown; `.chrome-profile/` now only holds the stop-dev session file. Dev
+  builds stay out of the production `dist-chrome/`.
 - ESLint uses **flat config** (`eslint.config.mjs`). There is no `.eslintrc`.
 - `tsc` is type-check only (`--noEmit`); Parcel does the actual bundling.
 - A **husky pre-commit hook** (`.husky/pre-commit`, installed via the `prepare`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,12 +112,15 @@ Core domain logic (mostly pure, well unit-tested):
   CDP.** Chrome 137+ removed the command-line switch (anti-malware), and by Chrome
   148 the `--disable-features=DisableLoadExtensionCommandLineSwitch` opt-out no
   longer works either. So `npm run dev:chrome` instead launches Chrome on a
-  *fresh throwaway profile* with `--enable-unsafe-extension-debugging` and loads
-  `dist-chrome-dev/` over the DevTools Protocol (`Extensions.loadUnpacked`, after
-  `Extensions.uninstall`-ing anything already loaded). No manual "Load unpacked"
-  step. Needs a recent Chrome (we assume the latest). The temp profile is removed
-  on shutdown; `.chrome-profile/` now only holds the stop-dev session file. Dev
-  builds stay out of the production `dist-chrome/`.
+  *fresh throwaway profile* with `--enable-unsafe-extension-debugging` +
+  `--remote-debugging-pipe` and loads `dist-chrome-dev/` over the DevTools
+  Protocol (`Extensions.loadUnpacked`). The Extensions domain is gated to the
+  **pipe** transport (fd 3/4) — over `--remote-debugging-port` it returns "Method
+  not available", so the port is kept only for VS Code debugging + `/json`
+  polling. No manual "Load unpacked" step, and the throwaway profile means no
+  stale extension to uninstall. Needs a recent Chrome (we assume the latest). The
+  temp profile is removed on shutdown; `.chrome-profile/` now only holds the
+  stop-dev session file. Dev builds stay out of the production `dist-chrome/`.
 - ESLint uses **flat config** (`eslint.config.mjs`). There is no `.eslintrc`.
 - `tsc` is type-check only (`--noEmit`); Parcel does the actual bundling.
 - A **husky pre-commit hook** (`.husky/pre-commit`, installed via the `prepare`

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install
 | `npm run build:firefox` | Production Firefox build to `/dist-firefox` |
 | `npm run build-dev:chrome` | Development Chrome build to `/dist-chrome-dev` (no optimisation) |
 | `npm run start:chrome` | Watch mode (to `/dist-chrome-dev`) — rebuilds on file changes |
-| `npm run dev:chrome` | Watch + launch Chrome (persistent dev profile) on a test page; load unpacked once |
+| `npm run dev:chrome` | Build + launch Chrome (fresh throwaway profile), auto-load the extension over CDP, open a test page (add `--watch` for live reload) |
 | `npm run check` | Type-check without emitting output |
 | `npm run lint` | Lint with ESLint (`npm run lint:fix` to auto-fix) |
 | `npm test` | Run unit tests |
@@ -72,7 +72,7 @@ Launch the dev Chrome in a specific UI language to check the `chrome.i18n` strin
 npm run dev:chrome -- --locale=ko
 ```
 
-This passes `--lang=ko` to Chrome. Because Chrome caches the UI language in a profile, the change is most reliable on a fresh profile — delete `.chrome-profile/` if a locale switch doesn't take effect.
+This passes `--lang=ko` to Chrome. Every `dev:chrome` run uses a fresh throwaway profile, so a locale change always takes effect.
 
 #### Debugging in VS Code
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -20,11 +20,9 @@
 // profile, --remote-debugging-pipe and --enable-unsafe-extension-debugging, then
 // call Extensions.loadUnpacked over the pipe to load dist-chrome-dev/ (rebuilt on
 // each run). The Extensions domain is gated to the pipe transport — it returns
-// "Method not available" over --remote-debugging-port. Existing unpacked
-// extensions are uninstalled first via Extensions.uninstall — with a throwaway
-// profile that's a no-op, but it keeps the load idempotent. No manual "Load
-// unpacked" step, and no persistent profile to carry stale state between runs.
-// Requires a recent Chrome (we assume developers run the latest).
+// "Method not available" over --remote-debugging-port. No manual "Load unpacked"
+// step, and the fresh profile carries no stale state (so no uninstall needed)
+// between runs. Requires a recent Chrome (we assume developers run the latest).
 //
 // chrome-launcher is used only to locate the Chrome binary. Close the Chrome
 // window or press Ctrl+C to stop everything.
@@ -161,25 +159,6 @@ function connectCdpPipe(chromeProc) {
             }
         },
     };
-}
-
-// Find any already-loaded extensions by scanning the debug targets for
-// chrome-extension:// origins. On a fresh throwaway profile this is empty; it
-// only matters if a previous session left extensions behind.
-async function discoverLoadedExtensionIds(port) {
-    try {
-        const response = await fetch(`http://127.0.0.1:${port}/json/list`);
-        if (!response.ok) return [];
-        const targets = await response.json();
-        const ids = new Set();
-        for (const target of targets ?? []) {
-            const match = /^chrome-extension:\/\/([a-p]{32})\//.exec(target?.url ?? "");
-            if (match) ids.add(match[1]);
-        }
-        return [...ids];
-    } catch {
-        return [];
-    }
 }
 
 // The Chrome user-data-dir is now a fresh throwaway dir per run (created at
@@ -412,19 +391,6 @@ chrome.on("exit", () => {
 // 4. Load the extension over the DevTools Protocol pipe, then open the test page.
 const cdp = connectCdpPipe(chrome);
 try {
-    // Uninstall any extensions already loaded before loading ours. On a fresh
-    // throwaway profile the only matches are Chrome's built-in component
-    // extensions, which can't be uninstalled — those failures are expected and
-    // swallowed. This only removes anything on a reused profile.
-    for (const id of await discoverLoadedExtensionIds(chromeDebugPort)) {
-        try {
-            await cdp.send("Extensions.uninstall", { id });
-            console.log(`[dev] Uninstalled existing extension: ${id}`);
-        } catch {
-            /* component extensions can't be uninstalled — expected */
-        }
-    }
-
     const { id } = await cdp.send("Extensions.loadUnpacked", { path: distDir });
     console.log(`[dev] Loaded unpacked extension: ${id}`);
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -15,20 +15,25 @@
 // NOTE on loading the extension: Chrome 137+ removed the --load-extension
 // command-line switch (anti-malware hardening), and by Chrome 148 even the
 // --disable-features=DisableLoadExtensionCommandLineSwitch opt-out no longer
-// works. So we can't auto-load into a throwaway profile any more. Instead we use
-// a *persistent* dev profile: you "Load unpacked" once, and every later run
-// reuses the profile with the extension still installed. The unpacked extension
-// is read from dist-chrome-dev/ on each launch, which this script rebuilds, so a
-// fresh `npm run dev:chrome` is current (use the extension's reload button, or
-// reload the page, to pick it up if Chrome was already open).
+// works. So we can't load via the command line any more. Instead we drive the
+// DevTools Protocol's Extensions domain: launch Chrome with a fresh throwaway
+// profile, --remote-debugging-pipe and --enable-unsafe-extension-debugging, then
+// call Extensions.loadUnpacked over the pipe to load dist-chrome-dev/ (rebuilt on
+// each run). The Extensions domain is gated to the pipe transport — it returns
+// "Method not available" over --remote-debugging-port. Existing unpacked
+// extensions are uninstalled first via Extensions.uninstall — with a throwaway
+// profile that's a no-op, but it keeps the load idempotent. No manual "Load
+// unpacked" step, and no persistent profile to carry stale state between runs.
+// Requires a recent Chrome (we assume developers run the latest).
 //
 // chrome-launcher is used only to locate the Chrome binary. Close the Chrome
 // window or press Ctrl+C to stop everything.
 
 import { spawn, spawnSync } from "node:child_process";
 import { createServer } from "node:http";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import * as ChromeLauncher from "chrome-launcher";
 
 const root = process.cwd();
@@ -106,9 +111,86 @@ async function waitForChromePageTarget(port, url, timeout = 10000) {
     throw new Error(`[dev] Timed out waiting for a Chrome page target at ${endpoint}.`);
 }
 
-const profileDir = resolve(root, ".chrome-profile");
-const sessionFile = resolve(profileDir, "dev-session.json");
+// A minimal CDP client over the DevTools *pipe* (not the WebSocket port). The
+// Extensions domain (loadUnpacked/uninstall) is gated to the pipe transport plus
+// --enable-unsafe-extension-debugging; it returns "Method not available" over
+// --remote-debugging-port. With --remote-debugging-pipe, Chrome reads commands
+// from fd 3 and writes replies/events to fd 4, each message NUL-terminated. We
+// spawn Chrome with those fds piped (see the stdio array at launch).
+function connectCdpPipe(chromeProc) {
+    const writeStream = chromeProc.stdio[3]; // commands → browser (fd 3)
+    const readStream = chromeProc.stdio[4]; // replies/events ← browser (fd 4)
+    const pending = new Map();
+    let nextId = 1;
+    let buffer = Buffer.alloc(0);
+
+    readStream.on("data", (chunk) => {
+        buffer = Buffer.concat([buffer, chunk]);
+        let end;
+        while ((end = buffer.indexOf(0)) !== -1) {
+            const raw = buffer.subarray(0, end).toString("utf8");
+            buffer = buffer.subarray(end + 1);
+            let msg;
+            try {
+                msg = JSON.parse(raw);
+            } catch {
+                continue;
+            }
+            if (msg.id && pending.has(msg.id)) {
+                const { resolve: res, reject: rej } = pending.get(msg.id);
+                pending.delete(msg.id);
+                if (msg.error) rej(new Error(msg.error.message ?? "CDP error"));
+                else res(msg.result);
+            }
+        }
+    });
+
+    return {
+        send(method, params = {}) {
+            const id = nextId++;
+            return new Promise((res, rej) => {
+                pending.set(id, { resolve: res, reject: rej });
+                writeStream.write(`${JSON.stringify({ id, method, params })}\0`);
+            });
+        },
+        close() {
+            try {
+                writeStream.end();
+            } catch {
+                /* already closed */
+            }
+        },
+    };
+}
+
+// Find any already-loaded extensions by scanning the debug targets for
+// chrome-extension:// origins. On a fresh throwaway profile this is empty; it
+// only matters if a previous session left extensions behind.
+async function discoverLoadedExtensionIds(port) {
+    try {
+        const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+        if (!response.ok) return [];
+        const targets = await response.json();
+        const ids = new Set();
+        for (const target of targets ?? []) {
+            const match = /^chrome-extension:\/\/([a-p]{32})\//.exec(target?.url ?? "");
+            if (match) ids.add(match[1]);
+        }
+        return [...ids];
+    } catch {
+        return [];
+    }
+}
+
+// The Chrome user-data-dir is now a fresh throwaway dir per run (created at
+// launch, removed on shutdown) — see profileDir below. The session file, which
+// scripts/stop-dev.mjs (the "Stop Dev Chrome" task) reads to find and kill this
+// session, lives in a stable repo-local dir instead so it can be found without
+// knowing the temp path.
+const sessionDir = resolve(root, ".chrome-profile");
+const sessionFile = resolve(sessionDir, "dev-session.json");
 const chromeDebugPort = getChromeDebugPort();
+let profileDir; // assigned to a fresh temp dir just before launch
 
 const TEST_PAGE = `<!DOCTYPE html>
 <html lang="en">
@@ -165,6 +247,7 @@ function writeSessionFile(chromePid) {
                 devPid: process.pid,
                 chromePid,
                 debugPort: chromeDebugPort,
+                profileDir,
                 startedAt: new Date().toISOString(),
                 testUrl,
             },
@@ -198,6 +281,15 @@ function shutdown(code = 0) {
     killTree(chrome);
     killTree(watch);
     server?.close();
+    // Throwaway profile: drop it so runs don't accumulate temp dirs. Chrome may
+    // still hold a lock for a moment after kill, so this is best-effort.
+    if (profileDir) {
+        try {
+            rmSync(profileDir, { recursive: true, force: true });
+        } catch {
+            /* Chrome may not have fully released the profile yet */
+        }
+    }
     process.exit(code);
 }
 
@@ -267,37 +359,45 @@ if (watchMode) {
     }
 }
 
-// 3. Launch Chrome on the persistent dev profile.
+// 3. Launch Chrome on a fresh throwaway profile.
 const chromePath = process.env.CHROME_PATH || ChromeLauncher.Launcher.getFirstInstallation();
 if (!chromePath) {
     console.error("[dev] Could not find Chrome. Set CHROME_PATH to the chrome executable.");
     shutdown(1);
 }
 
-const firstRun = !existsSync(profileDir);
-mkdirSync(profileDir, { recursive: true });
+mkdirSync(sessionDir, { recursive: true });
 removeSessionFile();
+// A new throwaway user-data-dir per run: no stale state, and nothing to "Load
+// unpacked" by hand since we load over CDP below. Cleaned up on shutdown.
+profileDir = mkdtempSync(join(tmpdir(), "kime-dev-"));
 
-// On first run, also open the extensions page so the one-time load is easy.
-const urls = firstRun ? ["chrome://extensions", testUrl] : [testUrl];
 const locale = requestedLocale();
 const args = [
     `--user-data-dir=${profileDir}`,
+    // The port is kept for VS Code debugging and /json polling; the *pipe* (fd
+    // 3/4) is what the Extensions CDP domain requires (the port rejects
+    // loadUnpacked with "Method not available"). --enable-unsafe-extension-debugging
+    // unlocks loadUnpacked/uninstall.
     `--remote-debugging-port=${chromeDebugPort}`,
+    "--remote-debugging-pipe",
+    "--enable-unsafe-extension-debugging",
     "--no-first-run",
     "--no-default-browser-check",
-    // --lang sets the UI locale chrome.i18n resolves against. Note: Chrome
-    // caches the UI language in an existing profile, so a locale change is most
-    // reliable on a fresh .chrome-profile/ (delete it to force a re-read).
+    // --lang sets the UI locale chrome.i18n resolves against. Every run uses a
+    // fresh profile, so a locale change always takes effect.
     ...(locale ? [`--lang=${locale}`] : []),
-    ...urls,
+    // Open a blank page; the test page is opened over CDP after the extension is
+    // loaded, so its content script injects on load.
+    "about:blank",
 ];
 
 if (locale) {
-    console.log(`[dev] UI locale: ${locale} (delete .chrome-profile/ if it doesn't take effect)`);
+    console.log(`[dev] UI locale: ${locale}`);
 }
 
-chrome = spawn(chromePath, args, { stdio: "ignore" });
+// fd 0-2 ignored; fd 3/4 are the CDP pipe (--remote-debugging-pipe).
+chrome = spawn(chromePath, args, { stdio: ["ignore", "ignore", "ignore", "pipe", "pipe"] });
 writeSessionFile(chrome.pid ?? null);
 const launchedAt = Date.now();
 
@@ -309,20 +409,37 @@ chrome.on("exit", () => {
     shutdown(0);
 });
 
+// 4. Load the extension over the DevTools Protocol pipe, then open the test page.
+const cdp = connectCdpPipe(chrome);
 try {
+    // Uninstall any extensions already loaded before loading ours. On a fresh
+    // throwaway profile the only matches are Chrome's built-in component
+    // extensions, which can't be uninstalled — those failures are expected and
+    // swallowed. This only removes anything on a reused profile.
+    for (const id of await discoverLoadedExtensionIds(chromeDebugPort)) {
+        try {
+            await cdp.send("Extensions.uninstall", { id });
+            console.log(`[dev] Uninstalled existing extension: ${id}`);
+        } catch {
+            /* component extensions can't be uninstalled — expected */
+        }
+    }
+
+    const { id } = await cdp.send("Extensions.loadUnpacked", { path: distDir });
+    console.log(`[dev] Loaded unpacked extension: ${id}`);
+
+    // Open the test page after the extension is loaded so its content script
+    // injects on load.
+    await cdp.send("Target.createTarget", { url: testUrl });
+
     await waitForChromePageTarget(chromeDebugPort, testUrl);
 } catch (err) {
-    console.error(err instanceof Error ? err.message : err);
+    console.error(`[dev] ${err instanceof Error ? err.message : err}`);
+    console.error("[dev] Loading the extension over CDP failed. Make sure you're on a recent Chrome");
+    console.error("[dev] (the Extensions DevTools domain + --enable-unsafe-extension-debugging are required).");
     shutdown(1);
 }
 
-if (firstRun) {
-    console.log("\n[dev] First run on this dev profile — load the extension once:");
-    console.log('[dev]   1. On the chrome://extensions tab, turn on "Developer mode" (top right).');
-    console.log('[dev]   2. Click "Load unpacked" and select:');
-    console.log(`[dev]        ${distDir}`);
-    console.log("[dev]   It stays loaded for future `npm run dev:chrome` runs (each run rebuilds it).");
-}
 console.log(`\n[dev] Dev profile:  ${profileDir}`);
 console.log(`[dev] Extension:    ${distDir}`);
 console.log(`[dev] Debug port:   ${chromeDebugPort}`);

--- a/scripts/stop-dev.mjs
+++ b/scripts/stop-dev.mjs
@@ -54,4 +54,15 @@ if (!(await waitForSessionFileToClear())) {
 }
 
 rmSync(sessionFile, { force: true });
+
+// dev.mjs uses a throwaway profile dir and normally removes it on shutdown, but
+// if we had to hard-kill it the dir can be left behind. Best-effort cleanup.
+if (typeof session.profileDir === "string" && session.profileDir) {
+    try {
+        rmSync(session.profileDir, { recursive: true, force: true });
+    } catch {
+        /* Chrome may still hold a lock briefly after kill */
+    }
+}
+
 console.log("[stop-dev] Dev session stopped.");


### PR DESCRIPTION
@
Closes #100.

`npm run dev:chrome` now loads the extension automatically over the DevTools
Protocol (`Extensions.loadUnpacked`) on a fresh throwaway profile — no manual
"Load unpacked" step, no persistent `.chrome-profile/`. Verified locally: the
extension loads enabled (service worker live) and the test page injects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@