### PR TITLE
Fix some issues with styling

### DIFF
--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.test.ts
@@ -20,6 +20,20 @@ jest.mock(
     { virtual: true }
 );
 
+// The controller reads its viewport from the OSK container's clientWidth/clientHeight
+// (deliberately, so the scrollbar is excluded). jsdom performs no layout, so those are
+// 0 — point them at window.inner*, which the tests stub, so placement and clamping math
+// runs as it would in a real browser. Call after the controller (and so the container)
+// exists; the getters track later window.inner* changes (e.g. resize tests).
+function mirrorViewportToContainer() {
+    const container = document.querySelector("[id^='osk-container-']");
+    if (!container) {
+        throw new Error("OSK container not found; create the controller first");
+    }
+    Object.defineProperty(container, "clientWidth", { configurable: true, get: () => window.innerWidth });
+    Object.defineProperty(container, "clientHeight", { configurable: true, get: () => window.innerHeight });
+}
+
 describe("OnScreenKeyboardController han/yong key", () => {
     let sendMessage: jest.Mock;
     let onSendKey: jest.Mock;
@@ -168,6 +182,7 @@ describe("OnScreenKeyboardController resize handling", () => {
         };
 
         const controller = new OnScreenKeyboardController(() => {});
+        mirrorViewportToContainer();
         const el = document.querySelector("[id^='kb-']") as HTMLElement;
         Object.defineProperty(el, "offsetWidth", { configurable: true, value: 480 });
         Object.defineProperty(el, "offsetHeight", { configurable: true, value: 250 });
@@ -223,6 +238,7 @@ describe("OnScreenKeyboardController resize handling", () => {
         Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
 
         const controller = new OnScreenKeyboardController(() => {});
+        mirrorViewportToContainer();
         const el = document.querySelector("[id^='kb-']") as HTMLElement;
         Object.defineProperty(el, "offsetWidth", { configurable: true, value: 480 });
         Object.defineProperty(el, "offsetHeight", { configurable: true, value: 250 });
@@ -343,6 +359,7 @@ describe("OnScreenKeyboardController header controls", () => {
 
     it("drags only from the header, not from the keys", () => {
         const controller = new OnScreenKeyboardController(() => {});
+        mirrorViewportToContainer();
         const el = host();
         controller.showKeyboard();
         const place = jest.spyOn(
@@ -419,6 +436,7 @@ describe("OnScreenKeyboardController anchor guides", () => {
         Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
 
         const controller = new OnScreenKeyboardController(() => {});
+        mirrorViewportToContainer();
         const el = document.querySelector("[id^='kb-']") as HTMLElement;
         // A keyboard sitting in from the bottom-right corner, with a known rect.
         setPlacement(controller, "right", "bottom");
@@ -576,6 +594,7 @@ describe("OnScreenKeyboardController persisted layout", () => {
 
     it("applies a restored position and collapsed state, used on the next show", () => {
         const controller = new OnScreenKeyboardController(() => {});
+        mirrorViewportToContainer();
         const el = sizedKeyboard();
 
         controller.applyPersistedLayout({
@@ -682,6 +701,7 @@ describe("OnScreenKeyboardController resize", () => {
 
     it("restores a persisted key size, clamped to the allowed range", () => {
         const controller = new OnScreenKeyboardController(() => {});
+        mirrorViewportToContainer();
         const el = sized();
 
         controller.applyPersistedLayout({ collapsed: false, keyUnit: 999 });
@@ -753,6 +773,7 @@ describe("OnScreenKeyboardController resize", () => {
 
     it("resets to the default size on double-clicking the grip", () => {
         const controller = new OnScreenKeyboardController(() => {});
+        mirrorViewportToContainer();
         const el = sized();
         controller.applyPersistedLayout({ collapsed: false, keyUnit: 50 });
         controller.showKeyboard();

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard-controller.ts
@@ -43,7 +43,7 @@ const GUIDE_EDGE_THICKNESS = `${GUIDE_EDGE_THICKNESS_MM}mm`;
 const GUIDE_EDGE_THICKNESS_PX = (GUIDE_EDGE_THICKNESS_MM * 96) / 25.4;
 
 /** Slack kept between the keyboard and the viewport edge when clamping its size. */
-const VIEWPORT_MARGIN_PX = 8;
+const VIEWPORT_MARGIN_PX = 0;
 
 const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
 
@@ -55,6 +55,7 @@ const LAYOUT_OPTIONS: { id: LayoutId; messageKey: string }[] = [
 ];
 
 export class OnScreenKeyboardController {
+    private _keyboardContainer: HTMLDivElement;
     private _keyboardElement: HTMLDivElement;
     private _keyboardPlacement: KeyboardPlacement = {
         originX: "right",
@@ -127,7 +128,17 @@ export class OnScreenKeyboardController {
     ) {
         this._onSendKey = onSendKey;
         this._onLayoutChange = onLayoutChange;
+        this._keyboardContainer = document.createElement("div");
+        this._keyboardContainer.id = "osk-container-67064f11-f376-47ac-abac-ce5e08ed5f45";
         this._keyboardElement = this.createKeyboard();
+
+        // insert the keyboard as the last child of the BODY tag
+        const body = document.getElementsByTagName("body")[0];
+        body.appendChild(this._keyboardContainer);
+        this._keyboardContainer.appendChild(this._keyboardElement);
+        const guides = this.createGuides();
+        this._keyboardContainer.appendChild(guides);
+
         this.setMode(this._mode);
     }
 
@@ -298,26 +309,27 @@ export class OnScreenKeyboardController {
         const width = this._keyboardElement.offsetWidth;
         const height = this._keyboardElement.offsetHeight;
 
-        let x = placement.originX === "right" ? window.innerWidth - width - placement.x : placement.x;
+        let x = placement.originX === "right" ? this._keyboardContainer.clientWidth - width - placement.x : placement.x;
 
-        let y = placement.originY === "bottom" ? window.innerHeight - height - placement.y : placement.y;
+        let y =
+            placement.originY === "bottom" ? this._keyboardContainer.clientHeight - height - placement.y : placement.y;
 
         // Keep the keyboard within the viewport. When it is larger than the
         // viewport it cannot fit either way, so keep the anchored edge on-screen
         // (overflowing off the opposite edge) rather than pinning the far edge and
         // pushing the anchored one off.
-        if (width > window.innerWidth) {
-            x = placement.originX === "right" ? window.innerWidth - width : 0;
+        if (width > this._keyboardContainer.clientWidth) {
+            x = placement.originX === "right" ? this._keyboardContainer.clientWidth - width : 0;
         } else {
             if (x < 0) x = 0;
-            if (x + width > window.innerWidth) x = window.innerWidth - width;
+            if (x + width > this._keyboardContainer.clientWidth) x = this._keyboardContainer.clientWidth - width;
         }
 
-        if (height > window.innerHeight) {
-            y = placement.originY === "bottom" ? window.innerHeight - height : 0;
+        if (height > this._keyboardContainer.clientHeight) {
+            y = placement.originY === "bottom" ? this._keyboardContainer.clientHeight - height : 0;
         } else {
             if (y < 0) y = 0;
-            if (y + height > window.innerHeight) y = window.innerHeight - height;
+            if (y + height > this._keyboardContainer.clientHeight) y = this._keyboardContainer.clientHeight - height;
         }
 
         // Re-derive the anchor corner from the keyboard's quadrant only when the
@@ -329,14 +341,14 @@ export class OnScreenKeyboardController {
         if (reanchor) {
             const cx = ~~(x + width / 2);
             const cy = ~~(y + height / 2);
-            originX = cx > window.innerWidth / 2 ? "right" : "left";
-            originY = cy > window.innerHeight / 2 ? "bottom" : "top";
+            originX = cx > this._keyboardContainer.clientWidth / 2 ? "right" : "left";
+            originY = cy > this._keyboardContainer.clientHeight / 2 ? "bottom" : "top";
         }
 
         // set x and y based on new origin
         const keyboardElement = this._keyboardElement;
         if (originX === "right") {
-            x = window.innerWidth - x - width;
+            x = this._keyboardContainer.clientWidth - x - width;
             keyboardElement.style.left = "";
             keyboardElement.style.right = `${x}px`;
         } else {
@@ -345,7 +357,7 @@ export class OnScreenKeyboardController {
         }
 
         if (originY === "bottom") {
-            y = window.innerHeight - y - height;
+            y = this._keyboardContainer.clientHeight - y - height;
             keyboardElement.style.top = "";
             keyboardElement.style.bottom = `${y}px`;
         } else {
@@ -374,8 +386,8 @@ export class OnScreenKeyboardController {
             return; // hidden: offsetWidth is 0, nothing meaningful to clamp
         }
 
-        const availWidth = window.innerWidth - VIEWPORT_MARGIN_PX;
-        const availHeight = window.innerHeight - VIEWPORT_MARGIN_PX;
+        const availWidth = this._keyboardContainer.clientWidth - VIEWPORT_MARGIN_PX;
+        const availHeight = this._keyboardContainer.clientHeight - VIEWPORT_MARGIN_PX;
 
         // offsetWidth includes fixed chrome (borders/padding/gaps), so the unit
         // isn't perfectly proportional to it; a couple of passes converge.
@@ -410,8 +422,8 @@ export class OnScreenKeyboardController {
         const top = resize.pivotIsTop ? resize.pivotY : resize.pivotY - height;
 
         const placement = this._keyboardPlacement;
-        placement.x = placement.originX === "left" ? left : window.innerWidth - (left + width);
-        placement.y = placement.originY === "bottom" ? window.innerHeight - (top + height) : top;
+        placement.x = placement.originX === "left" ? left : this._keyboardContainer.clientWidth - (left + width);
+        placement.y = placement.originY === "bottom" ? this._keyboardContainer.clientHeight - (top + height) : top;
 
         this.placeKeyboard();
     }
@@ -421,16 +433,11 @@ export class OnScreenKeyboardController {
 
         keyboardElement.id = "kb-73ce1520-9c19-48ad-bf12-f7ec206ab11f";
 
-        keyboardElement.style.position = "fixed";
+        keyboardElement.style.position = "absolute";
         keyboardElement.style.bottom = "0";
         keyboardElement.style.right = "0";
         keyboardElement.style.display = "none";
         keyboardElement.style.border = "none";
-        keyboardElement.style.zIndex = "2147483647"; // max int
-
-        // insert the keyboard as the last child of the BODY tag
-        const body = document.getElementsByTagName("body")[0];
-        body.appendChild(keyboardElement);
 
         // Header bar (drag handle + collapse/close controls); the keys live in a
         // body wrapper so the header can collapse them away.
@@ -552,7 +559,6 @@ export class OnScreenKeyboardController {
         for (const corner of ["tl", "tr", "bl", "br"] as const) {
             keyboardElement.appendChild(this.createResizeGrip(corner));
         }
-        this.createGuides();
 
         return keyboardElement;
     }
@@ -638,10 +644,8 @@ export class OnScreenKeyboardController {
     }
 
     // Builds the anchor-guide overlay: two dotted lines pinned to the viewport
-    // edges, hidden until a drag shows them (see showGuides). Appended after the
-    // keyboard so the keyboard stays the body's first child (tests and the
-    // initial insert rely on that ordering).
-    private createGuides() {
+    // edges, hidden until a drag shows them (see showGuides).
+    private createGuides(): HTMLDivElement {
         const guides = document.createElement("div");
         guides.id = "kb-guides-3f2a9c7e-7b1d-4e8a-9c2f-1a6b5d4e3c20";
 
@@ -668,13 +672,13 @@ export class OnScreenKeyboardController {
         connectorY.className = "kb-connector kb-connector-y";
 
         guides.append(horizontal, vertical, connectorX, connectorY);
-        document.getElementsByTagName("body")[0].appendChild(guides);
 
         this._guidesElement = guides;
         this._guideH = horizontal;
         this._guideV = vertical;
         this._connectorX = connectorX;
         this._connectorY = connectorY;
+        return guides;
     }
 
     // Points the guides at the keyboard's current anchor: the full-edge lines mark
@@ -720,7 +724,7 @@ export class OnScreenKeyboardController {
         connectorY.style.left = `${centerX}px`;
         if (originY === "bottom") {
             connectorY.style.top = `${rect.bottom}px`;
-            connectorY.style.height = `${Math.max(0, window.innerHeight - rect.bottom - GUIDE_EDGE_THICKNESS_PX)}px`;
+            connectorY.style.height = `${Math.max(0, this._keyboardContainer.clientHeight - rect.bottom - GUIDE_EDGE_THICKNESS_PX)}px`;
         } else {
             connectorY.style.top = `${GUIDE_EDGE_THICKNESS_PX}px`;
             connectorY.style.height = `${Math.max(0, rect.top - GUIDE_EDGE_THICKNESS_PX)}px`;
@@ -731,7 +735,7 @@ export class OnScreenKeyboardController {
         connectorX.style.top = `${centerY}px`;
         if (originX === "right") {
             connectorX.style.left = `${rect.right}px`;
-            connectorX.style.width = `${Math.max(0, window.innerWidth - rect.right - GUIDE_EDGE_THICKNESS_PX)}px`;
+            connectorX.style.width = `${Math.max(0, this._keyboardContainer.clientWidth - rect.right - GUIDE_EDGE_THICKNESS_PX)}px`;
         } else {
             connectorX.style.left = `${GUIDE_EDGE_THICKNESS_PX}px`;
             connectorX.style.width = `${Math.max(0, rect.left - GUIDE_EDGE_THICKNESS_PX)}px`;

--- a/src/content-script/on-screen-keyboard/on-screen-keyboard.scss
+++ b/src/content-script/on-screen-keyboard/on-screen-keyboard.scss
@@ -1,3 +1,20 @@
+#osk-container-67064f11-f376-47ac-abac-ce5e08ed5f45 {
+    &,
+    * {
+        all: unset;
+        user-select: none;
+    }
+
+    display: block;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 2147483647;
+    pointer-events: none;
+}
+
 #kb-73ce1520-9c19-48ad-bf12-f7ec206ab11f {
     // The size of one standard (1-unit) square key. Everything scales from this,
     // so resizing the keyboard is just changing this one value. A key spanning N
@@ -5,7 +22,6 @@
     --key-unit: 32px;
     --key-gap: calc(var(--key-unit) * 0.125);
     --text-distance: calc(var(--key-unit) * 0.05);
-    --jamo-distance: 0;
 
     // Rounded keyboard corners, and how far the (invisible) corner resize
     // hit-area reaches beyond the edge — a discoverable border zone.
@@ -27,11 +43,6 @@
     --key-mode-inactive-font-size: calc(var(--key-unit) * 0.38);
     --key-mode-active-font-size: calc(var(--key-mode-inactive-font-size) * 1.15);
 
-    &,
-    * {
-        user-select: none;
-    }
-
     & {
         border: 1px solid var(--border-color);
         margin-left: auto;
@@ -44,6 +55,7 @@
         position: relative;
         box-sizing: border-box;
         border-radius: var(--kb-radius);
+        pointer-events: auto; // the container lets clicks through, but the keyboard itself should receive them
     }
 
     .kb-header {
@@ -148,6 +160,7 @@
     }
 
     .kb-body {
+        display: block;
         padding: var(--key-gap) 0;
     }
 
@@ -225,22 +238,23 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            top: var(--text-distance);
+            top: 0;
         }
 
         .full,
         .base {
-            bottom: var(--text-distance);
-            &.jamo {
-                bottom: var(--jamo-distance);
-            }
+            bottom: 0;
         }
 
         .shift {
-            top: var(--text-distance);
-            &.jamo {
-                top: var(--jamo-distance);
-            }
+            top: 0;
+        }
+
+        .base,.shift {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 50%;
         }
 
         .full,
@@ -276,11 +290,7 @@
         }
 
         kbd .shift {
-            top: 0;
-            bottom: 0;
-            display: flex;
-            align-items: center;
-            justify-content: center;
+            height: 100%;
         }
 
         kbd.ShiftLeft,
@@ -385,8 +395,6 @@
     // Never intercept clicks or page interaction — the keyboard's drag relies on
     // document-level mousemove, and the page underneath must stay usable.
     pointer-events: none;
-    // Same as the keyboard (which sits at max int).
-    z-index: 2147483647;
     opacity: 0;
     transition: opacity 250ms ease-out;
 


### PR DESCRIPTION
Put keyboard + guides into same container.
Reset all CSS within keyboard.
Fixed issue with scrollbar causing incorrect calculations due to clientWidth and window.innerWidth being different.
Got Claude to fix the tests.