### PR TITLE
Fix Firefox "element.matches is not a function" on focus

### DIFF
--- a/src/content-script/content-script-controller.ts
+++ b/src/content-script/content-script-controller.ts
@@ -229,14 +229,13 @@ export class ContentScriptController {
         document.addEventListener(
             "focus",
             (e) => {
-                const element = e.target as HTMLElement;
-                this.setActiveElement(element);
+                this.setActiveElement(e.target);
             },
             true
         );
     }
 
-    private setActiveElement(element: HTMLElement) {
+    private setActiveElement(element: EventTarget | null) {
         const compositionFeatures = this.textInputManager.setActiveElement(element);
 
         if (!compositionFeatures) {

--- a/src/content-script/text-input-manager.test.ts
+++ b/src/content-script/text-input-manager.test.ts
@@ -55,6 +55,35 @@ describe("TextInputManager DOM-removal cleanup", () => {
     });
 });
 
+describe("TextInputManager.setActiveElement", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+        document.body.innerHTML = "";
+    });
+
+    // Firefox delivers focus events whose target is the `document` (or other
+    // non-Element nodes) when focus enters the page/frame; those have no
+    // `.matches`, so setActiveElement must not call it blindly. Regression for
+    // "TypeError: element.matches is not a function".
+    it.each([
+        ["document", document],
+        ["null", null],
+    ])("returns undefined for a non-element focus target (%s)", (_label, target) => {
+        const manager = new TextInputManager();
+
+        expect(() => manager.setActiveElement(target)).not.toThrow();
+        expect(manager.setActiveElement(target)).toBeUndefined();
+    });
+
+    it("returns undefined for a focused element that is not a text input", () => {
+        const manager = new TextInputManager();
+        const button = element("<button></button>");
+        document.body.appendChild(button);
+
+        expect(manager.setActiveElement(button)).toBeUndefined();
+    });
+});
+
 describe("TextInputManager.enterCharacter", () => {
     afterEach(() => {
         jest.restoreAllMocks();

--- a/src/content-script/text-input-manager.ts
+++ b/src/content-script/text-input-manager.ts
@@ -30,9 +30,8 @@ export class TextInputManager {
         }
     }
 
-    public setActiveElement(element: HTMLElement): SupportedCompositionFeatures | undefined {
-        // check if element matches the selector `textInputElementsSelector`
-        if (element.matches(textInputElementsSelector)) {
+    public setActiveElement(element: EventTarget | null): SupportedCompositionFeatures | undefined {
+        if (element instanceof HTMLElement && element.matches(textInputElementsSelector)) {
             return this.ensureController(element).getCompositionFeatures();
         }
         return;


### PR DESCRIPTION
EventTarget isn't necessarily an HTML element, guard it. Closes #141 