### PR TITLE
Reduce Firefox web-ext lint warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,10 +96,14 @@ Core domain logic (mostly pure, well unit-tested):
   webextension transformer *only* accepts `service_worker` and rejects a manifest
   with both keys. So `build:firefox` generates a `service_worker` manifest (what
   Parcel allows), lets Parcel bundle, then `scripts/patch-firefox-manifest.mjs`
-  adds `background.scripts` to the *emitted* `dist-firefox/manifest.json` — the
-  dual-key form Mozilla recommends, assembled after Parcel because it won't pass
-  it through pre-build. `lint:firefox` (`web-ext lint`) validates the result;
-  `BACKGROUND_SERVICE_WORKER_IGNORED` is the expected, correct warning. In
+  rewrites the *emitted* `dist-firefox/manifest.json`, swapping `service_worker`
+  for `background.scripts` (dropping the `service_worker` key Firefox ignores),
+  assembled after Parcel because it won't pass `scripts` through pre-build. We
+  swap rather than keep both keys because this manifest is Firefox-only — Mozilla's
+  dual-key form only helps a single manifest shared across browsers, and keeping
+  `service_worker` here would just earn a `BACKGROUND_SERVICE_WORKER_IGNORED`
+  warning from `web-ext lint` for no benefit. `lint:firefox` (`web-ext lint`)
+  validates the result. In
   `dev:firefox --watch` this patch must re-run after *every* Parcel rebuild
   (Parcel re-emits the `service_worker`-only manifest each time), and the Firefox
   reload must fire only after the patch — `scripts/dev-firefox.mjs` drives that

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "korean-ime",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "korean-ime",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "MIT",
-      "dependencies": {
-        "reflect-metadata": "^0.2.0"
-      },
       "devDependencies": {
         "@babel/types": "^7.29.0",
         "@eslint/js": "^10.0.0",
@@ -12025,12 +12022,6 @@
       "engines": {
         "node": ">= 12.13.0"
       }
-    },
-    "node_modules/reflect-metadata": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -79,8 +79,5 @@
     "typescript-eslint": "^8.60.0",
     "vue": "^3.5.33",
     "web-ext": "^10.3.0"
-  },
-  "dependencies": {
-    "reflect-metadata": "^0.2.0"
   }
 }

--- a/scripts/build-manifest.mjs
+++ b/scripts/build-manifest.mjs
@@ -59,10 +59,9 @@ const modeIconRenderSizes = [16, 24, 32, 48];
 // Both targets use `background.service_worker` here because Parcel's
 // webextension transformer only accepts the service_worker form — it rejects
 // `background.scripts`, and rejects a manifest containing both. Firefox doesn't
-// support service_worker, so the Firefox build adds `background.scripts` to the
-// *emitted* manifest afterwards (scripts/patch-firefox-manifest.mjs) — the
-// dual-key form Mozilla recommends, assembled post-Parcel because Parcel won't
-// pass it through.
+// support service_worker, so the Firefox build rewrites the *emitted* manifest
+// afterwards (scripts/patch-firefox-manifest.mjs), swapping service_worker for
+// `background.scripts` — done post-Parcel because Parcel won't pass scripts through.
 const targets = {
     chrome: {
         minimum_chrome_version: "102",
@@ -75,11 +74,19 @@ const targets = {
         browser_specific_settings: {
             gecko: {
                 id: "korean-ime@vmcnabb",
-                // storage.session (used heavily) requires Firefox 115+.
-                strict_min_version: "115.0",
+                // 140 is where data_collection_permissions (below) is first
+                // honoured on desktop, and it's the current ESR — so it's the
+                // honest floor for this manifest. (storage.session, used heavily,
+                // only needs 115, so it's comfortably covered.) There's no
+                // installed base on older Firefox to keep the floor low for.
+                strict_min_version: "140.0",
                 // AMO requires a data-collection declaration. This extension
                 // collects/transmits no personal data — all storage is local
                 // config/state, and there are no network calls — so "none".
+                // Honoured on FF desktop 140+ / Android 142+; web-ext still warns
+                // about the Android gap (KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION)
+                // since we ship desktop-only and don't set gecko_android — that
+                // warning is expected and accepted.
                 data_collection_permissions: { required: ["none"] },
             },
         },

--- a/scripts/patch-firefox-manifest.mjs
+++ b/scripts/patch-firefox-manifest.mjs
@@ -2,10 +2,17 @@
 //
 // Parcel only emits `background.service_worker` (it rejects `background.scripts`
 // and rejects both keys together), but Firefox doesn't support service workers —
-// it needs `background.scripts`. Mozilla's recommended cross-browser form is to
-// declare BOTH keys pointing at the same background file; Chrome uses
-// service_worker, Firefox uses scripts. We can't express that pre-build (Parcel
-// won't pass it through), so we add `scripts` to the already-emitted manifest.
+// it needs `background.scripts`. Since this is a Firefox-only manifest (Chrome
+// gets its own build), we swap the keys outright: drop the `service_worker` key
+// Firefox would ignore and point `scripts` at the same emitted file. We can't
+// express `scripts` pre-build (Parcel won't pass it through), so we rewrite the
+// already-emitted manifest here.
+//
+// Mozilla's dual-key form — declaring BOTH keys in one manifest — only helps when
+// a single manifest is shared across browsers (Chrome reads service_worker,
+// Firefox reads scripts). We ship per-browser manifests, so keeping service_worker
+// here would just earn web-ext's BACKGROUND_SERVICE_WORKER_IGNORED warning for no
+// benefit.
 //
 // Parcel inlines the background into a single self-contained classic script, so
 // pointing `scripts` at the same emitted file is exactly what Firefox wants.
@@ -27,11 +34,10 @@ if (!serviceWorker) {
     process.exit(1);
 }
 
-manifest.background = {
-    ...manifest.background,
-    // Firefox loads this; Chrome ignores it in favour of service_worker.
-    scripts: [serviceWorker],
-};
+// Firefox-only manifest: swap service_worker -> scripts, preserving any other
+// background keys (e.g. `type`).
+delete manifest.background.service_worker;
+manifest.background.scripts = [serviceWorker];
 
 writeFileSync(manifestPath, JSON.stringify(manifest, null, 4) + "\n");
-console.log(`[patch-firefox-manifest] added background.scripts -> ${serviceWorker}`);
+console.log(`[patch-firefox-manifest] background.scripts -> ${serviceWorker} (dropped service_worker)`);

--- a/src/decorators/method-not-supported.test.ts
+++ b/src/decorators/method-not-supported.test.ts
@@ -1,0 +1,39 @@
+import { isMethodSupported, methodNotSupported } from "./method-not-supported";
+
+class Base {
+    supported(): string {
+        return "ok";
+    }
+
+    @methodNotSupported
+    unsupported(): string {
+        return "never reached";
+    }
+}
+
+class Derived extends Base {
+    @methodNotSupported
+    alsoUnsupported(): void {}
+}
+
+describe("methodNotSupported", () => {
+    it("replaces the decorated method with one that throws", () => {
+        const instance = new Base();
+        expect(() => instance.unsupported()).toThrow('Method "unsupported" is not supported.');
+    });
+
+    it("reports a decorated method as unsupported", () => {
+        expect(isMethodSupported(new Base(), "unsupported")).toBe(false);
+    });
+
+    it("reports a non-decorated method as supported", () => {
+        expect(isMethodSupported(new Base(), "supported")).toBe(true);
+    });
+
+    it("resolves through the prototype chain — decorator on a base class, query on a subclass instance", () => {
+        const instance = new Derived();
+        expect(isMethodSupported(instance, "unsupported")).toBe(false);
+        expect(isMethodSupported(instance, "alsoUnsupported")).toBe(false);
+        expect(isMethodSupported(instance, "supported")).toBe(true);
+    });
+});

--- a/src/decorators/method-not-supported.ts
+++ b/src/decorators/method-not-supported.ts
@@ -1,6 +1,10 @@
-import "reflect-metadata";
-
-const notSupportedMetadataKey = Symbol("notSupported");
+// Tracks which (prototype, method) pairs are marked unsupported. This used to be
+// reflect-metadata, but its globalThis shim (`Function("return this")()` /
+// `(0,eval)(...)`) tripped web-ext's DANGEROUS_EVAL lint. The decorator stores
+// against a class prototype while the query runs against an instance, so we walk
+// the prototype chain on lookup — the same resolution reflect-metadata's
+// getMetadata did, minus the eval.
+const notSupportedMethods = new WeakMap<object, Set<PropertyKey>>();
 
 /**
  * Decorator that marks a method as not supported and causes it to throw an error when called.
@@ -10,7 +14,11 @@ export const methodNotSupported: MethodDecorator = <Function>(
     propertyKey: string | symbol,
     descriptor: TypedPropertyDescriptor<Function>
 ) => {
-    Reflect.defineMetadata(notSupportedMetadataKey, true, target, propertyKey);
+    let marked = notSupportedMethods.get(target);
+    if (!marked) {
+        notSupportedMethods.set(target, (marked = new Set()));
+    }
+    marked.add(propertyKey);
 
     // Replace the original method with a new one that throws an error
     descriptor.value = function (): void {
@@ -19,5 +27,10 @@ export const methodNotSupported: MethodDecorator = <Function>(
 };
 
 export function isMethodSupported<T extends object>(target: T, propertyKey: keyof T & (string | symbol)): boolean {
-    return !Reflect.getMetadata(notSupportedMetadataKey, target, propertyKey);
+    for (let obj: object | null = target; obj; obj = Object.getPrototypeOf(obj)) {
+        if (notSupportedMethods.get(obj)?.has(propertyKey)) {
+            return false;
+        }
+    }
+    return true;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,6 @@
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "experimentalDecorators": true,
-        "emitDecoratorMetadata": true,
         "sourceMap": true,
         "forceConsistentCasingInFileNames": true,
         "rootDir": "./src",


### PR DESCRIPTION
Closes #148

Cuts `npm run lint:firefox` from 8 warnings to 2 (the remaining two are intentional and documented in the issue):

- Swap the Firefox-only manifest's dual-key background for `scripts`-only — kills `BACKGROUND_SERVICE_WORKER_IGNORED`.
- Raise the Firefox floor 115 → 140 — kills the desktop `data_collection_permissions` min-version warning.
- Replace `reflect-metadata` with a WeakMap so `eval`/`Function` no longer ship in the bundles — kills 4× `DANGEROUS_EVAL` (and shrinks `popup-converter.js` ~341 kB → ~219 kB).
