### PR TITLE
Hanja conversion step 1 (Right-Ctrl, KIME_ENABLE_HANJA flag)

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -41,6 +41,18 @@ const DEFAULT_CHROME_DEBUG_PORT = 9222;
 // this in sync with the --dist-dir in the "start:chrome" npm script.
 const distDir = resolve(root, "dist-chrome-dev");
 
+// The Hanja feature (#150) is gated behind a build-time flag, off by default.
+// Turn it on for this dev session with `npm run dev:chrome -- --enable-hanja`
+// (flag reaches argv) or `npm run dev:chrome --enable-hanja` (npm exposes it as
+// npm_config_enable_hanja). The build reads KIME_ENABLE_HANJA, which we set on the
+// spawned Parcel process below; Parcel inlines it at build time.
+function hanjaFeatureRequested() {
+    if (process.argv.slice(2).includes("--enable-hanja")) return true;
+    const cfg = process.env.npm_config_enable_hanja;
+    if (cfg !== undefined && cfg !== "false" && cfg !== "0") return true;
+    return process.env.KIME_ENABLE_HANJA === "true";
+}
+
 function getChromeDebugPort() {
     const rawPort = process.env.KIME_CHROME_DEBUG_PORT ?? process.env.CHROME_DEBUG_PORT;
     if (rawPort === undefined || rawPort.trim() === "") return DEFAULT_CHROME_DEBUG_PORT;
@@ -199,7 +211,9 @@ const { server, testUrl } = await startTestPageServer();
 // 2. Build the extension. Default: a one-off build. With --watch: start Parcel
 //    in watch mode (auto-rebuild + hot reload) and wait for the first build.
 const watchMode = watchRequested();
-const buildEnv = { ...process.env, NODE_ENV: "development" };
+const enableHanja = hanjaFeatureRequested();
+console.log(`[dev] Hanja conversion (Right-Ctrl): ${enableHanja ? "enabled" : "disabled"}`);
+const buildEnv = { ...process.env, NODE_ENV: "development", KIME_ENABLE_HANJA: enableHanja ? "true" : "" };
 
 console.log("[dev] Starting...");
 if (watchMode) {

--- a/src/composition/hangul-ime-controller.test.ts
+++ b/src/composition/hangul-ime-controller.test.ts
@@ -400,3 +400,67 @@ describe("HangulImeController intercepts Shift+Backspace in the capture phase", 
         expect(reachedBodyCapture).toBe(true);
     });
 });
+
+describe("HangulImeController Hanja conversion (Right-Ctrl, KIME_ENABLE_HANJA)", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+        delete process.env.KIME_ENABLE_HANJA;
+    });
+
+    // Drive composition state in jsdom by stubbing the adapter's DOM mutations, then
+    // type the jamo for a syllable so the compositor is genuinely mid-composition.
+    function composingController() {
+        jest.spyOn(InputAdapter.prototype, "beginComposition").mockImplementation(() => {});
+        jest.spyOn(InputAdapter.prototype, "updateComposition").mockImplementation(() => {});
+        const endComposition = jest.spyOn(InputAdapter.prototype, "endComposition").mockImplementation(() => {});
+
+        const element = document.createElement("textarea");
+        const controller = makeController(element);
+        controller.activate();
+        return { element, endComposition };
+    }
+
+    function composeHan(element: HTMLElement) {
+        dispatchKeydown(element, "KeyG", "g"); // ㅎ
+        dispatchKeydown(element, "KeyK", "k"); // ㅏ → 하
+        dispatchKeydown(element, "KeyS", "s"); // ㄴ → 한
+    }
+
+    function pressRightCtrl(element: HTMLElement) {
+        return dispatchKeydown(element, "ControlRight", "Control");
+    }
+
+    it("converts a composing 한 to 韓 and swallows the key when the flag is on", () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element, endComposition } = composingController();
+        composeHan(element);
+
+        const ctrl = pressRightCtrl(element);
+
+        expect(endComposition).toHaveBeenCalledWith("韓");
+        expect(ctrl.defaultPrevented).toBe(true);
+    });
+
+    it("does nothing when the flag is off (Right-Ctrl is just a modifier)", () => {
+        const { element, endComposition } = composingController(); // flag unset
+        composeHan(element);
+
+        const ctrl = pressRightCtrl(element);
+
+        expect(endComposition).not.toHaveBeenCalled();
+        expect(ctrl.defaultPrevented).toBe(false);
+    });
+
+    it("leaves a composing syllable that isn't in the dictionary alone, even with the flag on", () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element, endComposition } = composingController();
+        dispatchKeydown(element, "KeyR", "r"); // ㄱ
+        dispatchKeydown(element, "KeyM", "m"); // ㅡ → 그
+        dispatchKeydown(element, "KeyF", "f"); // ㄹ → 글
+
+        const ctrl = pressRightCtrl(element);
+
+        expect(endComposition).not.toHaveBeenCalled();
+        expect(ctrl.defaultPrevented).toBe(false);
+    });
+});

--- a/src/composition/hangul-ime-controller.ts
+++ b/src/composition/hangul-ime-controller.ts
@@ -3,6 +3,7 @@ import { isAltKey, isModifierKey, KeyCode, keyMap } from "../keyboard/korean-key
 import { HangulCompositor } from "./hangul-compositor";
 import { CompositionAdapterFactory } from "./composition-adapter-factory";
 import { CompositionAdapter } from "./composition-adapters/composition-adapter";
+import { convertHangulToHanja } from "./hanja/hanja-converter";
 
 /**
  * Controls the Hangul IME for a given element.
@@ -113,6 +114,28 @@ export class HangulImeController {
             }
 
             const code = event.code as KeyCode;
+
+            // Hanja conversion (Right-Ctrl) — gated behind a build-time flag, off by
+            // default. Parcel inlines process.env.KIME_ENABLE_HANJA at build time, so
+            // with the flag unset this condition folds to a constant false and the whole
+            // branch is dropped: the feature never runs and is inert (dark) in
+            // production. (Parcel still bundles the small hanja/ module — its
+            // symbol-level tree-shaking doesn't drop the now-dead import — but it's
+            // unreachable, so the only cost is a few bytes.) Temporary scaffolding for
+            // #150; graduates to a Settings toggle when the feature ships. The trigger is
+            // Right-Ctrl (the 한자 key on a US layout); the Korean keyboard's dedicated
+            // Lang2/한자 key is the natural equivalent to wire up later. Sits ahead of the
+            // modifier-key early-return below because ControlRight is a modifier and
+            // would otherwise be ignored.
+            if (process.env.KIME_ENABLE_HANJA === "true" && code === KeyCode.ControlRight) {
+                if (convertHangulToHanja(this.compositor, this.compositionAdapter)) {
+                    this.notifyOnEntry();
+                    event.preventDefault();
+                    event.stopPropagation();
+                    event.stopImmediatePropagation();
+                }
+                return;
+            }
 
             // record which alt was down last, so we know if the "han/yong" key is down
             if (isAltKey(code)) {

--- a/src/composition/hangul-ime-controller.ts
+++ b/src/composition/hangul-ime-controller.ts
@@ -115,18 +115,7 @@ export class HangulImeController {
 
             const code = event.code as KeyCode;
 
-            // Hanja conversion (Right-Ctrl) — gated behind a build-time flag, off by
-            // default. Parcel inlines process.env.KIME_ENABLE_HANJA at build time, so
-            // with the flag unset this condition folds to a constant false and the whole
-            // branch is dropped: the feature never runs and is inert (dark) in
-            // production. (Parcel still bundles the small hanja/ module — its
-            // symbol-level tree-shaking doesn't drop the now-dead import — but it's
-            // unreachable, so the only cost is a few bytes.) Temporary scaffolding for
-            // #150; graduates to a Settings toggle when the feature ships. The trigger is
-            // Right-Ctrl (the 한자 key on a US layout); the Korean keyboard's dedicated
-            // Lang2/한자 key is the natural equivalent to wire up later. Sits ahead of the
-            // modifier-key early-return below because ControlRight is a modifier and
-            // would otherwise be ignored.
+            // Temporary scaffolding for Issue 150; graduates to a Settings toggle when the feature ships.
             if (process.env.KIME_ENABLE_HANJA === "true" && code === KeyCode.ControlRight) {
                 if (convertHangulToHanja(this.compositor, this.compositionAdapter)) {
                     this.notifyOnEntry();

--- a/src/composition/hanja/hanja-converter.test.ts
+++ b/src/composition/hanja/hanja-converter.test.ts
@@ -1,0 +1,84 @@
+import { convertHangulToHanja } from "./hanja-converter";
+import { HangulCompositor } from "../hangul-compositor";
+import { CompositionAdapter } from "../composition-adapters/composition-adapter";
+
+// A minimal stand-in for the bits of the adapter the converter touches. supportsMethods
+// defaults to true (the input/contenteditable/CKEditor adapters all support these).
+function fakeAdapter(
+    overrides: Partial<{
+        supportsMethods: jest.Mock;
+        getPreviousCharacter: jest.Mock;
+        deleteContentBackwards: jest.Mock;
+        inputCharacter: jest.Mock;
+        endComposition: jest.Mock;
+    }> = {}
+) {
+    return {
+        supportsMethods: jest.fn().mockReturnValue(true),
+        getPreviousCharacter: jest.fn(),
+        deleteContentBackwards: jest.fn(),
+        inputCharacter: jest.fn(),
+        endComposition: jest.fn(),
+        ...overrides,
+    };
+}
+
+function asAdapter(fake: ReturnType<typeof fakeAdapter>): CompositionAdapter {
+    return fake as unknown as CompositionAdapter;
+}
+
+describe("convertHangulToHanja", () => {
+    describe("mid-composition", () => {
+        it("commits the Hanja in place of the in-progress block and clears composition", () => {
+            const compositor = new HangulCompositor();
+            compositor.setCharacter("한");
+            const adapter = fakeAdapter();
+
+            expect(convertHangulToHanja(compositor, asAdapter(adapter))).toBe(true);
+            expect(adapter.endComposition).toHaveBeenCalledWith("韓");
+            expect(compositor.isCompositing()).toBe(false);
+        });
+
+        it("leaves an unknown composing block untouched and reports nothing converted", () => {
+            const compositor = new HangulCompositor();
+            compositor.setCharacter("글"); // not in the dictionary
+            const adapter = fakeAdapter();
+
+            expect(convertHangulToHanja(compositor, asAdapter(adapter))).toBe(false);
+            expect(adapter.endComposition).not.toHaveBeenCalled();
+            expect(compositor.isCompositing()).toBe(true); // composition preserved
+        });
+    });
+
+    describe("after a committed syllable", () => {
+        it("replaces the preceding syllable with its Hanja", () => {
+            const adapter = fakeAdapter({ getPreviousCharacter: jest.fn().mockReturnValue("한") });
+
+            expect(convertHangulToHanja(new HangulCompositor(), asAdapter(adapter))).toBe(true);
+            expect(adapter.deleteContentBackwards).toHaveBeenCalled();
+            expect(adapter.inputCharacter).toHaveBeenCalledWith("韓", expect.anything());
+        });
+
+        it("does nothing when the preceding syllable isn't in the dictionary", () => {
+            const adapter = fakeAdapter({ getPreviousCharacter: jest.fn().mockReturnValue("글") });
+
+            expect(convertHangulToHanja(new HangulCompositor(), asAdapter(adapter))).toBe(false);
+            expect(adapter.deleteContentBackwards).not.toHaveBeenCalled();
+            expect(adapter.inputCharacter).not.toHaveBeenCalled();
+        });
+
+        it("does nothing when there is no preceding character", () => {
+            const adapter = fakeAdapter({ getPreviousCharacter: jest.fn().mockReturnValue(undefined) });
+
+            expect(convertHangulToHanja(new HangulCompositor(), asAdapter(adapter))).toBe(false);
+            expect(adapter.inputCharacter).not.toHaveBeenCalled();
+        });
+
+        it("bails out (without reading the document) on an adapter that can't replace the previous char", () => {
+            const adapter = fakeAdapter({ supportsMethods: jest.fn().mockReturnValue(false) });
+
+            expect(convertHangulToHanja(new HangulCompositor(), asAdapter(adapter))).toBe(false);
+            expect(adapter.getPreviousCharacter).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/composition/hanja/hanja-converter.ts
+++ b/src/composition/hanja/hanja-converter.ts
@@ -1,0 +1,52 @@
+import { KeyCode } from "../../keyboard/korean-keyboard-map";
+import { CompositionAdapter } from "../composition-adapters/composition-adapter";
+import { HangulCompositor } from "../hangul-compositor";
+import { lookUpHanja } from "./hanja-dictionary";
+
+/**
+ * Hanja conversion — the distinct phase that turns an already-composed Hangul
+ * syllable into Hanja. It deliberately sits *alongside* the compositor rather than
+ * inside it: jamo assembly is already done by the time this runs.
+ *
+ * Step 1 (#150): one-entry dictionary, single candidate, no candidate UI — the
+ * sole candidate is committed immediately. Two entry points, mirroring how a real
+ * IME's Hanja key behaves:
+ *
+ *   1. mid-composition — the block (e.g. 한) is still being composed; or
+ *   2. after a committed syllable — the caret sits immediately after it.
+ *
+ * Returns true when a conversion happened (so the caller can swallow the key),
+ * and false when there was nothing to convert: an unknown reading, no preceding
+ * syllable, or an adapter that can't read/replace the previous character.
+ */
+export function convertHangulToHanja(compositor: HangulCompositor, adapter: CompositionAdapter): boolean {
+    if (compositor.isCompositing()) {
+        const hanja = firstCandidate(compositor.getCurrentChar());
+        if (!hanja) {
+            return false;
+        }
+
+        // Commit the Hanja in place of the in-progress block.
+        adapter.endComposition(hanja);
+        compositor.reset();
+        return true;
+    }
+
+    if (!adapter.supportsMethods("getPreviousCharacter", "deleteContentBackwards", "inputCharacter")) {
+        return false;
+    }
+
+    const hanja = firstCandidate(adapter.getPreviousCharacter());
+    if (!hanja) {
+        return false;
+    }
+
+    // Replace the committed syllable before the caret with its Hanja.
+    adapter.deleteContentBackwards();
+    adapter.inputCharacter(hanja, KeyCode.ControlRight);
+    return true;
+}
+
+function firstCandidate(reading: string | undefined): string | undefined {
+    return reading ? lookUpHanja(reading)[0] : undefined;
+}

--- a/src/composition/hanja/hanja-dictionary.test.ts
+++ b/src/composition/hanja/hanja-dictionary.test.ts
@@ -1,0 +1,12 @@
+import { lookUpHanja } from "./hanja-dictionary";
+
+describe("lookUpHanja (step-1 bootstrap dictionary)", () => {
+    it("returns the candidate list for the one known reading", () => {
+        expect(lookUpHanja("한")).toEqual(["韓"]);
+    });
+
+    it("returns an empty list for a reading that isn't in the dictionary", () => {
+        expect(lookUpHanja("글")).toEqual([]);
+        expect(lookUpHanja("")).toEqual([]);
+    });
+});

--- a/src/composition/hanja/hanja-dictionary.ts
+++ b/src/composition/hanja/hanja-dictionary.ts
@@ -1,0 +1,18 @@
+/**
+ * Step-1 bootstrap Hanja dictionary (#150).
+ *
+ * A single hard-coded entry — just enough to prove the conversion pipeline end to
+ * end. It maps a composed Hangul reading to its ordered list of Hanja candidates
+ * (one candidate, for now). This is throwaway scaffolding: a later phase swaps it
+ * for the libhangul-derived data (see the Hanja Feature design doc on the wiki).
+ * Keep the shape (reading → candidate[]) so that swap stays mechanical.
+ */
+const hanjaDictionary: ReadonlyMap<string, readonly string[]> = new Map([["한", ["韓"]]]);
+
+/**
+ * Ordered Hanja candidates for a composed Hangul reading, or an empty array when
+ * the reading isn't in the dictionary.
+ */
+export function lookUpHanja(reading: string): readonly string[] {
+    return hanjaDictionary.get(reading) ?? [];
+}


### PR DESCRIPTION
Closes #150

Adds the first slice of Hanja conversion behind the build-time `KIME_ENABLE_HANJA` flag (off by default, inert in production): pressing Right-Ctrl converts a composing or just-committed 한 into 韓 via a one-entry dictionary. Conversion lives alongside `HangulCompositor` as its own phase; `npm run dev:chrome -- --enable-hanja` turns it on for development.