### PR TITLE
Draw the composing-Hangul box in inputs & textareas; track scroll

### DIFF
--- a/src/composition/composition-adapters/compositing-box.test.ts
+++ b/src/composition/composition-adapters/compositing-box.test.ts
@@ -1,0 +1,75 @@
+import { CompositingBox, GlyphRect } from "./compositing-box";
+
+// jsdom has no layout, so the real measurement (getBoundingClientRect) returns
+// zeros in the adapters. Here we stub the measure callback with a concrete rect so
+// the box's lifecycle, styling, positioning, and scroll-tracking are observable.
+describe("CompositingBox", () => {
+    const rect: GlyphRect = { left: 10, top: 20, width: 16, height: 18 };
+    let host: HTMLElement;
+
+    beforeEach(() => {
+        host = document.createElement("div");
+        document.body.appendChild(host);
+        // Run rAF callbacks synchronously so a dispatched scroll repositions at once.
+        jest.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
+            cb(0);
+            return 0;
+        });
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+        jest.restoreAllMocks();
+    });
+
+    it("draws a positioned overlay carrying the composing text", () => {
+        new CompositingBox(host, () => rect).show("한");
+
+        const overlay = document.body.lastElementChild as HTMLElement;
+        expect(overlay.textContent).toBe("한");
+        expect(overlay.style.position).toBe("absolute");
+        expect(overlay.style.zIndex).toBe("2147483647");
+        expect(overlay.style.pointerEvents).toBe("none");
+        // left/top = rect + scroll(0) - border(1); width/height = rect
+        expect(overlay.style.left).toBe("9px");
+        expect(overlay.style.top).toBe("19px");
+        expect(overlay.style.width).toBe("16px");
+        expect(overlay.style.height).toBe("18px");
+    });
+
+    it("draws nothing when the glyph can't be measured", () => {
+        const before = document.body.childElementCount;
+        new CompositingBox(host, () => undefined).show("한");
+        expect(document.body.childElementCount).toBe(before);
+    });
+
+    it("updates the text and re-measures on update", () => {
+        const measure = jest.fn(() => rect);
+        const box = new CompositingBox(host, measure);
+        box.show("ㅎ");
+        measure.mockClear();
+
+        box.update("한");
+
+        expect((document.body.lastElementChild as HTMLElement).textContent).toBe("한");
+        expect(measure).toHaveBeenCalled();
+    });
+
+    it("re-aligns on scroll while shown, and stops once removed", () => {
+        const measure = jest.fn(() => rect);
+        const box = new CompositingBox(host, measure);
+        box.show("한");
+        const overlay = document.body.lastElementChild as HTMLElement;
+        measure.mockClear();
+
+        window.dispatchEvent(new Event("scroll"));
+        expect(measure).toHaveBeenCalledTimes(1); // repositioned
+
+        box.remove();
+        expect(document.body.contains(overlay)).toBe(false); // overlay gone
+        measure.mockClear();
+
+        window.dispatchEvent(new Event("scroll"));
+        expect(measure).not.toHaveBeenCalled(); // listener detached
+    });
+});

--- a/src/composition/composition-adapters/compositing-box.ts
+++ b/src/composition/composition-adapters/compositing-box.ts
@@ -113,7 +113,7 @@ export class CompositingBox {
 
     private buildStyle(): Partial<CSSStyleDeclaration> {
         return {
-            ...getAssignableStyles(this.host),
+            ...getTextStyles(this.host),
             color: window.getComputedStyle(this.host).color,
             backgroundColor: resolveOpaqueBackground(this.host),
             backgroundImage: `linear-gradient(rgba(${ACCENT}, 0.18), rgba(${ACCENT}, 0.18))`,
@@ -133,59 +133,32 @@ export class CompositingBox {
     }
 }
 
-/**
- * Copy the font/text-appearance styles from the editor so the box's text matches
- * the page's, skipping anything that would interfere with the overlay's own box
- * model (background/border/layout) and anything still at its document default.
- */
-function getAssignableStyles(source: Element): Partial<CSSStyleDeclaration> {
-    const computedStyles = window.getComputedStyle(source);
-    const styles: Record<CSSStringKey, string> = {} as Record<CSSStringKey, string>;
+const COPIED_TEXT_STYLES: CSSStringKey[] = [
+    "fontFamily",
+    "fontSize",
+    "fontStyle",
+    "fontWeight",
+    "fontVariant",
+    "fontStretch",
+    "fontSizeAdjust",
+    "fontFeatureSettings",
+    "fontKerning",
+    "fontVariationSettings",
+    "letterSpacing",
+    "wordSpacing",
+    "textTransform",
+    "textRendering",
+    "direction",
+];
 
-    const testElement = document.createElement("div");
-    testElement.textContent = "test";
-    document.body.appendChild(testElement);
-    const defaultStyles = window.getComputedStyle(testElement);
-
-    for (let i = 0; i < computedStyles.length; i++) {
-        const styleName = computedStyles[i] as CSSStringKey;
-        if (shouldExclude(styleName, computedStyles, defaultStyles)) {
-            continue;
-        }
-        styles[styleName] = computedStyles.getPropertyValue(styleName);
+/** Copy just the text-appearance styles so the box's glyph matches the page's. */
+function getTextStyles(source: Element): Partial<CSSStyleDeclaration> {
+    const computed = window.getComputedStyle(source);
+    const styles: Partial<CSSStyleDeclaration> = {};
+    for (const property of COPIED_TEXT_STYLES) {
+        styles[property] = computed[property];
     }
-
-    testElement.remove();
     return styles;
-
-    function shouldExclude(styleName: string, computed: CSSStyleDeclaration, defaults: CSSStyleDeclaration) {
-        // The box owns these — never inherit them from the editor (they'd shift or
-        // hide the overlay). `inset`/`width`/`height`/`margin`/`padding` are set
-        // explicitly by the box; the rest would fight the absolute positioning.
-        const excludeStartWith = [
-            "background",
-            "border",
-            "outline",
-            "position",
-            "display",
-            "visibility",
-            "margin",
-            "padding",
-            "width",
-            "height",
-            "inset",
-            "top",
-            "left",
-            "right",
-            "bottom",
-        ];
-
-        if (excludeStartWith.some((prefix) => styleName.startsWith(prefix))) {
-            return true;
-        }
-
-        return computed.getPropertyValue(styleName) === defaults.getPropertyValue(styleName);
-    }
 }
 
 /**

--- a/src/composition/composition-adapters/compositing-box.ts
+++ b/src/composition/composition-adapters/compositing-box.ts
@@ -111,7 +111,6 @@ export class CompositingBox {
             height: `${rect.height}px`,
         };
         Object.assign(this.box.style, pageRect);
-        console.log("[KIME RECT]", pageRect);
     }
 
     private buildStyle(): Partial<CSSStyleDeclaration> {
@@ -121,6 +120,7 @@ export class CompositingBox {
             backgroundColor: resolveOpaqueBackground(this.host),
             backgroundImage: `linear-gradient(rgba(${ACCENT}, 0.18), rgba(${ACCENT}, 0.18))`,
             border: `${BORDER}px solid rgba(${ACCENT}, 0.9)`,
+            boxSizing: "content-box",
             margin: "0",
             padding: "0",
             overflow: "hidden",

--- a/src/composition/composition-adapters/compositing-box.ts
+++ b/src/composition/composition-adapters/compositing-box.ts
@@ -48,6 +48,7 @@ export class CompositingBox {
         const box = document.createElement("div");
         Object.assign(box.style, this.buildStyle());
         box.textContent = text;
+        box.style.lineHeight = `${rect.height}px`; // vertically center the glyph
         this.box = box;
         this.position(rect);
         document.body.appendChild(box);
@@ -103,12 +104,14 @@ export class CompositingBox {
         }
         // measure() returns viewport coordinates; the box is absolutely positioned
         // on document.body, so add the page scroll to convert to document space.
-        Object.assign(this.box.style, {
+        const pageRect = {
             left: `${rect.left + window.scrollX - BORDER}px`,
             top: `${rect.top + window.scrollY - BORDER}px`,
             width: `${rect.width}px`,
             height: `${rect.height}px`,
-        });
+        };
+        Object.assign(this.box.style, pageRect);
+        console.log("[KIME RECT]", pageRect);
     }
 
     private buildStyle(): Partial<CSSStyleDeclaration> {
@@ -118,9 +121,6 @@ export class CompositingBox {
             backgroundColor: resolveOpaqueBackground(this.host),
             backgroundImage: `linear-gradient(rgba(${ACCENT}, 0.18), rgba(${ACCENT}, 0.18))`,
             border: `${BORDER}px solid rgba(${ACCENT}, 0.9)`,
-            // Keep the overlay tight to the glyph and inert: no inherited box
-            // spacing, and never intercept pointer events meant for the editor.
-            boxSizing: "content-box",
             margin: "0",
             padding: "0",
             overflow: "hidden",
@@ -149,6 +149,10 @@ const COPIED_TEXT_STYLES: CSSStringKey[] = [
     "textTransform",
     "textRendering",
     "direction",
+    "lineHeight",
+    "textAlign",
+    "textIndent",
+    "tabSize",
 ];
 
 /** Copy just the text-appearance styles so the box's glyph matches the page's. */

--- a/src/composition/composition-adapters/compositing-box.ts
+++ b/src/composition/composition-adapters/compositing-box.ts
@@ -1,0 +1,226 @@
+/**
+ * The blue overlay drawn over the Hangul block that's currently being composed.
+ *
+ * Everything here is editor-agnostic: lifecycle (create/update/remove), styling,
+ * positioning, and — importantly — keeping the box aligned with the glyph while
+ * the page or the editor scrolls. Only *measuring* where the composing glyph sits
+ * on screen differs per editor, so the caller supplies that as a `measure`
+ * callback returning the glyph's viewport-relative rect (or `undefined` when it
+ * can't be measured, e.g. in jsdom, where the box simply isn't shown).
+ *
+ * Shared by `ContentEditableAdapter` and `InputAdapter` so the two stay visually
+ * identical and so scroll-tracking is implemented once (see #152 / #153).
+ */
+export interface GlyphRect {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+}
+
+// Translucent blue, used for the border and a faint tint so the box reads as an
+// active composition without depending on the page's color scheme.
+const ACCENT = "68, 136, 255";
+const BORDER = 1;
+
+export class CompositingBox {
+    private box?: HTMLElement;
+    private rafId?: number;
+
+    /**
+     * @param host    the editor element — used to derive the box's text colour,
+     *                background, and font so the composing text matches the page.
+     * @param measure returns the composing glyph's rect in *viewport* coordinates,
+     *                or `undefined` if it can't currently be measured.
+     */
+    constructor(
+        private readonly host: HTMLElement,
+        private readonly measure: () => GlyphRect | undefined
+    ) {}
+
+    /** Create the overlay and position it over the glyph. No-op if unmeasurable. */
+    show(text: string): void {
+        const rect = this.measure();
+        if (!rect) {
+            return;
+        }
+
+        const box = document.createElement("div");
+        Object.assign(box.style, this.buildStyle());
+        box.textContent = text;
+        this.box = box;
+        this.position(rect);
+        document.body.appendChild(box);
+
+        // scroll doesn't bubble, but a capture-phase listener on window still sees
+        // scrolling from any descendant scroll container (an internally-scrolled
+        // input/textarea or contentEditable), which is exactly the case that used
+        // to leave the box stranded.
+        window.addEventListener("scroll", this.reposition, true);
+        window.addEventListener("resize", this.reposition);
+    }
+
+    /** Update the composing text and re-align the box. */
+    update(text: string): void {
+        if (this.box) {
+            this.box.textContent = text;
+        }
+        const rect = this.measure();
+        if (rect) {
+            this.position(rect);
+        }
+    }
+
+    /** Remove the overlay and detach every listener it registered. */
+    remove(): void {
+        if (this.rafId !== undefined) {
+            cancelAnimationFrame(this.rafId);
+            this.rafId = undefined;
+        }
+        window.removeEventListener("scroll", this.reposition, true);
+        window.removeEventListener("resize", this.reposition);
+        this.box?.remove();
+        this.box = undefined;
+    }
+
+    // Coalesce a burst of scroll/resize events into one re-measure per frame.
+    private reposition = (): void => {
+        if (this.rafId !== undefined) {
+            return;
+        }
+        this.rafId = requestAnimationFrame(() => {
+            this.rafId = undefined;
+            const rect = this.measure();
+            if (rect && this.box) {
+                this.position(rect);
+            }
+        });
+    };
+
+    private position(rect: GlyphRect): void {
+        if (!this.box) {
+            return;
+        }
+        // measure() returns viewport coordinates; the box is absolutely positioned
+        // on document.body, so add the page scroll to convert to document space.
+        Object.assign(this.box.style, {
+            left: `${rect.left + window.scrollX - BORDER}px`,
+            top: `${rect.top + window.scrollY - BORDER}px`,
+            width: `${rect.width}px`,
+            height: `${rect.height}px`,
+        });
+    }
+
+    private buildStyle(): Partial<CSSStyleDeclaration> {
+        return {
+            ...getAssignableStyles(this.host),
+            color: window.getComputedStyle(this.host).color,
+            backgroundColor: resolveOpaqueBackground(this.host),
+            backgroundImage: `linear-gradient(rgba(${ACCENT}, 0.18), rgba(${ACCENT}, 0.18))`,
+            border: `${BORDER}px solid rgba(${ACCENT}, 0.9)`,
+            // Keep the overlay tight to the glyph and inert: no inherited box
+            // spacing, and never intercept pointer events meant for the editor.
+            boxSizing: "content-box",
+            margin: "0",
+            padding: "0",
+            overflow: "hidden",
+            whiteSpace: "pre",
+            pointerEvents: "none",
+            display: "inline-block",
+            position: "absolute",
+            zIndex: "2147483647",
+        };
+    }
+}
+
+/**
+ * Copy the font/text-appearance styles from the editor so the box's text matches
+ * the page's, skipping anything that would interfere with the overlay's own box
+ * model (background/border/layout) and anything still at its document default.
+ */
+function getAssignableStyles(source: Element): Partial<CSSStyleDeclaration> {
+    const computedStyles = window.getComputedStyle(source);
+    const styles: Record<CSSStringKey, string> = {} as Record<CSSStringKey, string>;
+
+    const testElement = document.createElement("div");
+    testElement.textContent = "test";
+    document.body.appendChild(testElement);
+    const defaultStyles = window.getComputedStyle(testElement);
+
+    for (let i = 0; i < computedStyles.length; i++) {
+        const styleName = computedStyles[i] as CSSStringKey;
+        if (shouldExclude(styleName, computedStyles, defaultStyles)) {
+            continue;
+        }
+        styles[styleName] = computedStyles.getPropertyValue(styleName);
+    }
+
+    testElement.remove();
+    return styles;
+
+    function shouldExclude(styleName: string, computed: CSSStyleDeclaration, defaults: CSSStyleDeclaration) {
+        // The box owns these — never inherit them from the editor (they'd shift or
+        // hide the overlay). `inset`/`width`/`height`/`margin`/`padding` are set
+        // explicitly by the box; the rest would fight the absolute positioning.
+        const excludeStartWith = [
+            "background",
+            "border",
+            "outline",
+            "position",
+            "display",
+            "visibility",
+            "margin",
+            "padding",
+            "width",
+            "height",
+            "inset",
+            "top",
+            "left",
+            "right",
+            "bottom",
+        ];
+
+        if (excludeStartWith.some((prefix) => styleName.startsWith(prefix))) {
+            return true;
+        }
+
+        return computed.getPropertyValue(styleName) === defaults.getPropertyValue(styleName);
+    }
+}
+
+/**
+ * The background the composing glyph actually sits on: the first opaque
+ * background-color found walking up from the editor. A translucent background
+ * can't occlude the underlying glyph on its own, so keep climbing; fall back to
+ * the `Canvas` system colour (which tracks the user's light/dark scheme).
+ */
+function resolveOpaqueBackground(element: Element): string {
+    let current: Element | null = element;
+    while (current) {
+        const backgroundColor = window.getComputedStyle(current).backgroundColor;
+        if (isOpaqueColor(backgroundColor)) {
+            return backgroundColor;
+        }
+        current = current.parentElement;
+    }
+    return "Canvas";
+}
+
+// True only for a fully opaque colour. getComputedStyle normalizes background-color
+// to "rgb(...)"/"rgba(...)", or "rgba(0, 0, 0, 0)"/"transparent" when unset; treat
+// anything with alpha < 1 (or unparseable) as see-through.
+function isOpaqueColor(color: string): boolean {
+    const channels = color.match(/^rgba?\(([^)]+)\)/);
+    if (!channels) {
+        return false;
+    }
+    const parts = channels[1].split(",");
+    const alpha = parts.length >= 4 ? parseFloat(parts[3]) : 1;
+    return alpha === 1;
+}
+
+type StringStyleKeys<T> = {
+    [K in keyof T]: T[K] extends string ? K : never;
+}[keyof T];
+
+type CSSStringKey = Extract<StringStyleKeys<CSSStyleDeclaration>, string>;

--- a/src/composition/composition-adapters/content-editable-adapter.test.ts
+++ b/src/composition/composition-adapters/content-editable-adapter.test.ts
@@ -1,0 +1,75 @@
+import { ContentEditableAdapter } from "./content-editable-adapter";
+import { KeyCode } from "../../keyboard/korean-keyboard-map";
+
+function makeContentEditable(): HTMLElement {
+    const element = document.createElement("div");
+    Object.defineProperty(element, "isContentEditable", { value: true });
+    document.body.appendChild(element);
+    return element;
+}
+
+function placeCaretAtEnd(element: HTMLElement) {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    range.collapse(false);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+}
+
+// The overlay box is the only element appended to <body> with the max z-index.
+function compositingBox(): HTMLElement | undefined {
+    return Array.from(document.body.children).find(
+        (element): element is HTMLElement => element instanceof HTMLElement && element.style.zIndex === "2147483647"
+    );
+}
+
+describe("ContentEditableAdapter compositing box", () => {
+    beforeEach(() => {
+        // jsdom has no layout: Range has no getBoundingClientRect at all, and the
+        // box bails on a zero-sized glyph. Define one with a real size to exercise
+        // the drawing path. After the block is inserted the caret lands in the
+        // *element*, not a text node — the case that regressed and drew nothing.
+        (Range.prototype as { getBoundingClientRect?: () => DOMRect }).getBoundingClientRect = () =>
+            ({
+                left: 5,
+                top: 6,
+                width: 10,
+                height: 12,
+                right: 15,
+                bottom: 18,
+                x: 5,
+                y: 6,
+                toJSON: () => ({}),
+            }) as DOMRect;
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+        window.getSelection()?.removeAllRanges();
+        delete (Range.prototype as { getBoundingClientRect?: () => DOMRect }).getBoundingClientRect;
+    });
+
+    it("draws the overlay box over the composing block", () => {
+        const element = makeContentEditable();
+        placeCaretAtEnd(element);
+        const adapter = new ContentEditableAdapter(element);
+
+        adapter.beginComposition("한", KeyCode.KeyR);
+
+        const box = compositingBox();
+        expect(box).toBeDefined();
+        expect(box?.textContent).toBe("한");
+    });
+
+    it("removes the overlay box when composition ends", () => {
+        const element = makeContentEditable();
+        placeCaretAtEnd(element);
+        const adapter = new ContentEditableAdapter(element);
+
+        adapter.beginComposition("한", KeyCode.KeyR);
+        adapter.endComposition("韓");
+
+        expect(compositingBox()).toBeUndefined();
+    });
+});

--- a/src/composition/composition-adapters/content-editable-adapter.ts
+++ b/src/composition/composition-adapters/content-editable-adapter.ts
@@ -239,14 +239,23 @@ export class ContentEditableAdapter extends CompositionAdapter {
         }
 
         const caret = selection.getRangeAt(0);
-        const node = caret.startContainer;
-        if (node.nodeType !== Node.TEXT_NODE || caret.startOffset < 1) {
+        if (caret.startOffset < 1) {
             return undefined;
         }
 
+        // Select the content immediately before the caret — the just-composed
+        // glyph. This works whether the caret sits inside the glyph's text node
+        // (offsets are character indices, so this spans one character) or in its
+        // parent element (offsets are child indices, so this spans the glyph's text
+        // node) — the latter is where the caret usually lands after the block is
+        // inserted, which is why guarding on a text-node container drew no box.
         const glyph = document.createRange();
-        glyph.setStart(node, caret.startOffset - 1);
-        glyph.setEnd(node, caret.startOffset);
+        try {
+            glyph.setStart(caret.startContainer, caret.startOffset - 1);
+            glyph.setEnd(caret.startContainer, caret.startOffset);
+        } catch {
+            return undefined;
+        }
         const rect = glyph.getBoundingClientRect();
 
         if (rect.width === 0 && rect.height === 0) {

--- a/src/composition/composition-adapters/content-editable-adapter.ts
+++ b/src/composition/composition-adapters/content-editable-adapter.ts
@@ -1,5 +1,6 @@
 import { KeyCode } from "../../keyboard/korean-keyboard-map";
 import { CompositionAdapter } from "./composition-adapter";
+import { CompositingBox, GlyphRect } from "./compositing-box";
 
 /**
  * Handles IME composition for contentEditable elements.
@@ -13,10 +14,8 @@ export class ContentEditableAdapter extends CompositionAdapter {
     private isCompositing = false;
     private _currentBlock = "";
 
-    /**
-     * Used to display or underline the current composition.
-     */
-    private compositingBox?: HTMLElement = undefined;
+    /** The overlay drawn over the composing block. */
+    private compositingBox?: CompositingBox = undefined;
 
     constructor(element: HTMLElement) {
         super(element);
@@ -28,9 +27,7 @@ export class ContentEditableAdapter extends CompositionAdapter {
 
     private set currentBlock(value: string) {
         this._currentBlock = value;
-        if (this.compositingBox) {
-            this.compositingBox.innerText = value;
-        }
+        this.compositingBox?.update(value);
     }
 
     deleteContentBackwards(): void {
@@ -111,7 +108,11 @@ export class ContentEditableAdapter extends CompositionAdapter {
             }
             document.dispatchEvent(new Event("selectionchange"));
         });
-        this.createCompositingBox();
+
+        // The glyph is now in the DOM with the caret just after it, so the box can
+        // measure it. (See measureCompositingRect.)
+        this.compositingBox = new CompositingBox(this.element, () => this.measureCompositingRect());
+        this.compositingBox.show(data);
 
         this.currentBlock = data;
         this.isCompositing = true;
@@ -184,7 +185,8 @@ export class ContentEditableAdapter extends CompositionAdapter {
         } finally {
             this.isCompositing = false;
             this.currentBlock = "";
-            this.removeCompositingBox();
+            this.compositingBox?.remove();
+            this.compositingBox = undefined;
         }
     }
 
@@ -226,172 +228,31 @@ export class ContentEditableAdapter extends CompositionAdapter {
     }
 
     /**
-     * Creates a box that is positioned at the current caret position. This box is used to indicate that the character
-     * shown is being composed.
+     * The composing glyph's viewport rect, measured directly from a Range over the
+     * character immediately before the caret (the just-composed block). No DOM
+     * mutation, so it's safe to re-run on every scroll frame as the box re-aligns.
      */
-    private createCompositingBox() {
-        if (this.compositingBox) {
-            this.removeCompositingBox();
-        }
-
+    private measureCompositingRect(): GlyphRect | undefined {
         const selection = window.getSelection();
-
         if (!selection || selection.rangeCount === 0) {
-            console.error("no selection!");
-            return;
+            return undefined;
         }
 
-        // find x/y coordinates of caret
-        const range = selection.getRangeAt(0);
-
-        // Create a temporary span element at the caret position to measure the height/width of the
-        // selection of a Hangul character as well as the x/y coordinates of the caret.
-        const span = document.createElement("span");
-        span.textContent = "아"; // same height/width as all Hangul characters
-        span.style.display = "inline-block";
-        range.insertNode(span);
-
-        const characterRect = span.getBoundingClientRect();
-        const selectionStyle = this.getAssignableStyles(span);
-        // Capture the effective text color at the caret while the span is still in
-        // the DOM, so the box reuses the page's own color-on-background pairing.
-        const textColor = window.getComputedStyle(span).color;
-
-        span.parentNode?.removeChild(span);
-
-        // Take the current scroll position into account
-        const scrollTop = window.scrollY;
-        const scrollLeft = window.scrollX;
-
-        const left =
-            characterRect.left -
-            characterRect.width + // we created the compositing box after already rendering the character
-            scrollLeft;
-        const top = characterRect.top + scrollTop;
-
-        const borderLeftWidth = 1;
-        const borderTopWidth = 1;
-
-        // The box is drawn on top of the already-inserted glyph, so it needs an
-        // opaque background to occlude it. Rather than hardcode one (which clashed
-        // with dark pages and could match the text color), reuse the page's own
-        // background + text color so the composing text is always as legible as the
-        // page's normal text, on light and dark alike. The blue stays as a
-        // scheme-agnostic accent: a translucent border plus a faint tint overlay
-        // (a 1px-wide solid-color gradient painted over the background) so the box
-        // still reads as an active composition.
-        const accent = "68, 136, 255";
-        const style: Partial<CSSStyleDeclaration> = {
-            ...selectionStyle,
-            color: textColor,
-            display: "inline-block",
-            position: "absolute",
-            top: `${top - borderTopWidth}px`,
-            left: `${left - borderLeftWidth}px`,
-            width: `${characterRect.width}px`,
-            height: `${characterRect.height}px`,
-            backgroundColor: this.resolveOpaqueBackground(),
-            backgroundImage: `linear-gradient(rgba(${accent}, 0.18), rgba(${accent}, 0.18))`,
-            zIndex: "2147483647",
-            borderLeft: `${borderLeftWidth}px solid rgba(${accent}, 0.9)`,
-            borderTop: `${borderTopWidth}px solid rgba(${accent}, 0.9)`,
-            borderRight: `1px solid rgba(${accent}, 0.9)`,
-            borderBottom: `1px solid rgba(${accent}, 0.9)`,
-        };
-
-        const characterBox = document.createElement("div");
-        Object.assign(characterBox.style, style);
-
-        document.body.appendChild(characterBox);
-
-        this.compositingBox = characterBox;
-    }
-
-    // Find the background the composing glyph actually sits on: the first opaque
-    // background-color walking up from the editor. A transparent (alpha < 1)
-    // background lets what's behind it show through, so it can't occlude the glyph
-    // on its own — keep walking. If nothing opaque is found, fall back to the
-    // `Canvas` system color, which tracks the user's light/dark color scheme.
-    private resolveOpaqueBackground(): string {
-        let element: Element | null = this.element;
-
-        while (element) {
-            const backgroundColor = window.getComputedStyle(element).backgroundColor;
-            if (isOpaqueColor(backgroundColor)) {
-                return backgroundColor;
-            }
-            element = element.parentElement;
+        const caret = selection.getRangeAt(0);
+        const node = caret.startContainer;
+        if (node.nodeType !== Node.TEXT_NODE || caret.startOffset < 1) {
+            return undefined;
         }
 
-        return "Canvas";
-    }
+        const glyph = document.createRange();
+        glyph.setStart(node, caret.startOffset - 1);
+        glyph.setEnd(node, caret.startOffset);
+        const rect = glyph.getBoundingClientRect();
 
-    private getAssignableStyles(sourceElement: Element): Partial<CSSStyleDeclaration> {
-        const computedStyles = window.getComputedStyle(sourceElement);
-
-        const styles: Record<CSSStringKey, string> = {} as Record<CSSStringKey, string>;
-
-        // get the default styles for an element at document root
-        const testElement = document.createElement("div");
-        testElement.innerText = "test";
-        document.body.appendChild(testElement);
-        const defaultStyles = window.getComputedStyle(testElement);
-
-        for (let i = 0; i < computedStyles.length; i++) {
-            const styleName = computedStyles[i] as CSSStringKey;
-            if (shouldExclude(styleName, computedStyles, defaultStyles)) {
-                continue;
-            }
-            styles[styleName] = computedStyles.getPropertyValue(styleName);
+        if (rect.width === 0 && rect.height === 0) {
+            return undefined;
         }
 
-        testElement.remove();
-
-        return styles;
-
-        function shouldExclude(
-            styleName: string,
-            computedStyles: CSSStyleDeclaration,
-            defaultStyles: CSSStyleDeclaration
-        ) {
-            const excludeStartWith = ["background", "border", "outline", "position", "display", "visibility"];
-
-            if (excludeStartWith.some((prefix) => styleName.startsWith(prefix))) {
-                return true;
-            }
-
-            if (computedStyles.getPropertyValue(styleName) === defaultStyles.getPropertyValue(styleName)) {
-                return true;
-            }
-
-            return false;
-        }
+        return { left: rect.left, top: rect.top, width: rect.width, height: rect.height };
     }
-
-    private removeCompositingBox() {
-        if (this.compositingBox) {
-            this.compositingBox.remove();
-            this.compositingBox = undefined;
-        }
-    }
-}
-
-type StringStyleKeys<T> = {
-    [K in keyof T]: T[K] extends string ? K : never;
-}[keyof T];
-
-type CSSStringKey = Extract<StringStyleKeys<CSSStyleDeclaration>, string>;
-
-// True only for a fully opaque color. getComputedStyle normalizes background-color
-// to "rgb(...)"/"rgba(...)", or "rgba(0, 0, 0, 0)" / "transparent" when unset; we
-// treat anything with alpha < 1 (or unparseable) as see-through.
-function isOpaqueColor(color: string): boolean {
-    const channels = color.match(/^rgba?\(([^)]+)\)/);
-    if (!channels) {
-        return false;
-    }
-
-    const parts = channels[1].split(",");
-    const alpha = parts.length >= 4 ? parseFloat(parts[3]) : 1;
-    return alpha === 1;
 }

--- a/src/composition/composition-adapters/input-adapter.ts
+++ b/src/composition/composition-adapters/input-adapter.ts
@@ -1,9 +1,16 @@
 import { KeyCode } from "../../keyboard/korean-keyboard-map";
 import { CompositionAdapter } from "./composition-adapter";
+import { CompositingBox } from "./compositing-box";
+import { measureInputRangeRect } from "./input-range-rect";
 
 export class InputAdapter extends CompositionAdapter {
     private isCompositing = false;
     private currentBlock = "";
+    // Where the composing block starts in `value`. We track it explicitly rather
+    // than leaning on the field's selection because the composing region is shown
+    // with the overlay box (caret collapsed), not a native selection.
+    private blockStart = 0;
+    private box?: CompositingBox;
 
     constructor(protected element: HTMLInputElement | HTMLTextAreaElement) {
         super(element);
@@ -22,46 +29,54 @@ export class InputAdapter extends CompositionAdapter {
     }
 
     beginComposition(text: string, keyCode: KeyCode): void {
-        this._beginComposition(text, keyCode, () => this.replaceComposingRegion(text));
-        this.isCompositing = true;
+        const start = this.element.selectionStart ?? 0;
+        const end = this.element.selectionEnd ?? start;
+        this.blockStart = start;
+
+        this._beginComposition(text, keyCode, () => this.spliceValue(start, end, text));
         this.currentBlock = text;
+        this.isCompositing = true;
+
+        // Draw the composing block as an overlay box, mirroring the contentEditable
+        // adapter (which collapses the caret and overlays the glyph). `spliceValue`
+        // already collapsed the selection, so there's no native highlight underneath.
+        this.box = new CompositingBox(this.element, () => this.measureCompositingRect());
+        this.box.show(text);
     }
 
     updateComposition(text: string, keyCode: KeyCode) {
-        this._updateComposition(text, keyCode, () => this.replaceComposingRegion(text));
+        const previous = this.currentBlock;
+        this._updateComposition(text, keyCode, () =>
+            this.spliceValue(this.blockStart, this.blockStart + previous.length, text)
+        );
         this.currentBlock = text;
+        this.box?.update(text);
     }
 
-    /**
-     * @param {string} text
-     */
     endComposition(text: string) {
-        this._endComposition(text, () => this.replaceComposingRegion(text));
-        this.collapseSelection();
+        const previous = this.currentBlock;
+        this._endComposition(text, () => this.spliceValue(this.blockStart, this.blockStart + previous.length, text));
         this.isCompositing = false;
         this.currentBlock = "";
+        this.box?.remove();
+        this.box = undefined;
     }
 
     /**
-     * Replace the currently-selected composing region with `text` and re-select it,
-     * mirroring how a browser keeps the in-progress block highlighted. The previous
-     * block is what's selected between `selectionStart` and `selectionEnd`, so this
-     * works for both the first jamo (collapsed caret → insert) and updates
-     * (selected block → replace).
+     * Replace `value[start, end)` with `text` and collapse the caret to the end of
+     * the inserted text — so the composing block is shown by the overlay box, not a
+     * native selection highlight.
      */
-    private replaceComposingRegion(text: string) {
+    private spliceValue(start: number, end: number, text: string) {
         const element = this.element;
-        const start = element.selectionStart;
+        element.value = element.value.substring(0, start) + text + element.value.substring(end);
+        const caret = start + text.length;
+        element.selectionStart = caret;
+        element.selectionEnd = caret;
+    }
 
-        if (start == null) {
-            return;
-        }
-
-        const end = element.selectionEnd || 0;
-
-        element.value = element.value.substring(0, start) + text + element.value.substring(end, element.value.length);
-        element.selectionStart = start;
-        element.selectionEnd = start + text.length;
+    private measureCompositingRect() {
+        return measureInputRangeRect(this.element, this.blockStart, this.blockStart + this.currentBlock.length);
     }
 
     inputCharacter(data: string, keyCode: KeyCode): void {

--- a/src/composition/composition-adapters/input-range-rect.test.ts
+++ b/src/composition/composition-adapters/input-range-rect.test.ts
@@ -1,0 +1,31 @@
+import { measureInputRangeRect } from "./input-range-rect";
+
+// jsdom doesn't do layout, so the mirror measurement can't produce real
+// coordinates — but it must fail gracefully (return undefined, throw nothing) and
+// must not leave its temporary mirror element behind in the document. The actual
+// positioning is verified in-browser (see #152).
+describe("measureInputRangeRect", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("returns undefined without throwing when layout is unavailable (jsdom)", () => {
+        const textarea = document.createElement("textarea");
+        textarea.value = "한국";
+        document.body.appendChild(textarea);
+
+        expect(measureInputRangeRect(textarea, 0, 1)).toBeUndefined();
+    });
+
+    it("cleans up its temporary mirror element", () => {
+        const textarea = document.createElement("textarea");
+        textarea.value = "한국";
+        document.body.appendChild(textarea);
+
+        measureInputRangeRect(textarea, 0, 1);
+
+        // only the textarea remains; the mirror div was removed
+        expect(document.body.childElementCount).toBe(1);
+        expect(document.body.firstElementChild).toBe(textarea);
+    });
+});

--- a/src/composition/composition-adapters/input-range-rect.ts
+++ b/src/composition/composition-adapters/input-range-rect.ts
@@ -1,0 +1,107 @@
+import { GlyphRect } from "./compositing-box";
+
+/**
+ * Measure the on-screen rect of a character range `[start, end)` inside an
+ * `<input>`/`<textarea>`. There's no addressable DOM for the text inside a form
+ * field, so we use the well-known **mirror** technique: build a hidden `<div>`
+ * that replicates the field's text-layout box (font, padding, border, width,
+ * wrapping), drop a marker span at the range, and read the marker's offset within
+ * the mirror. That offset, plus the field's own border-box position and minus its
+ * internal scroll, gives the range's viewport rect.
+ *
+ * Returns `undefined` when the marker can't be measured (e.g. jsdom, which has no
+ * layout) so the caller can skip drawing.
+ */
+const MIRRORED_PROPERTIES: string[] = [
+    "width",
+    "borderTopWidth",
+    "borderRightWidth",
+    "borderBottomWidth",
+    "borderLeftWidth",
+    "paddingTop",
+    "paddingRight",
+    "paddingBottom",
+    "paddingLeft",
+    "fontStyle",
+    "fontVariant",
+    "fontWeight",
+    "fontStretch",
+    "fontSize",
+    "fontSizeAdjust",
+    "lineHeight",
+    "fontFamily",
+    "textAlign",
+    "textTransform",
+    "textIndent",
+    "letterSpacing",
+    "wordSpacing",
+    "tabSize",
+    "direction",
+];
+
+export function measureInputRangeRect(
+    field: HTMLInputElement | HTMLTextAreaElement,
+    start: number,
+    end: number
+): GlyphRect | undefined {
+    const doc = field.ownerDocument;
+    const computed = window.getComputedStyle(field);
+    const isSingleLine = field.nodeName === "INPUT";
+
+    const mirror = doc.createElement("div");
+    const style = mirror.style as unknown as Record<string, string>;
+    for (const property of MIRRORED_PROPERTIES) {
+        style[property] = computed.getPropertyValue(toKebabCase(property));
+    }
+    // getComputedStyle resolves `width` to the *content-box* width regardless of the
+    // field's own box-sizing, so force content-box here: the copied width is then the
+    // content width and the copied padding/border sit outside it, matching the field's
+    // text-layout box exactly (otherwise a border-box textarea would wrap too early).
+    mirror.style.boxSizing = "content-box";
+    mirror.style.position = "absolute";
+    mirror.style.top = "0";
+    mirror.style.left = "0";
+    mirror.style.visibility = "hidden";
+    mirror.style.overflow = "hidden";
+    // A single-line input never wraps; a textarea wraps at its content width.
+    mirror.style.whiteSpace = isSingleLine ? "pre" : "pre-wrap";
+    mirror.style.wordWrap = isSingleLine ? "normal" : "break-word";
+    if (isSingleLine) {
+        mirror.style.width = "auto";
+    }
+
+    const value = field.value;
+    mirror.textContent = value.substring(0, start);
+    const marker = doc.createElement("span");
+    // A zero-width range (collapsed) still needs something to measure.
+    marker.textContent = value.substring(start, end) || "\u200b";
+    mirror.appendChild(marker);
+    mirror.appendChild(doc.createTextNode(value.substring(end)));
+
+    doc.body.appendChild(mirror);
+    const mirrorRect = mirror.getBoundingClientRect();
+    const markerRect = marker.getBoundingClientRect();
+    doc.body.removeChild(mirror);
+
+    if (markerRect.width === 0 && markerRect.height === 0) {
+        return undefined;
+    }
+
+    // The mirror replicates the field's border + padding, so the marker's offset
+    // from the mirror's border-box equals its offset from the field's border-box
+    // (before the field scrolls its content).
+    const offsetLeft = markerRect.left - mirrorRect.left;
+    const offsetTop = markerRect.top - mirrorRect.top;
+
+    const fieldRect = field.getBoundingClientRect();
+    return {
+        left: fieldRect.left + offsetLeft - field.scrollLeft,
+        top: fieldRect.top + offsetTop - field.scrollTop,
+        width: markerRect.width,
+        height: markerRect.height,
+    };
+}
+
+function toKebabCase(property: string): string {
+    return property.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+}

--- a/src/composition/composition-adapters/input-range-rect.ts
+++ b/src/composition/composition-adapters/input-range-rect.ts
@@ -14,14 +14,17 @@ import { GlyphRect } from "./compositing-box";
  */
 const MIRRORED_PROPERTIES: string[] = [
     "width",
-    "borderTopWidth",
-    "borderRightWidth",
-    "borderBottomWidth",
-    "borderLeftWidth",
+    "boxSizing",
+    "borderTop",
+    "borderRight",
+    "borderBottom",
+    "borderLeft",
     "paddingTop",
     "paddingRight",
     "paddingBottom",
     "paddingLeft",
+    "paddingBlock",
+    "paddingInline",
     "fontStyle",
     "fontVariant",
     "fontWeight",
@@ -33,10 +36,12 @@ const MIRRORED_PROPERTIES: string[] = [
     "textAlign",
     "textTransform",
     "textIndent",
+    "textRendering",
     "letterSpacing",
     "wordSpacing",
     "tabSize",
     "direction",
+    "overflowWrap",
 ];
 
 export function measureInputRangeRect(
@@ -57,49 +62,45 @@ export function measureInputRangeRect(
     // field's own box-sizing, so force content-box here: the copied width is then the
     // content width and the copied padding/border sit outside it, matching the field's
     // text-layout box exactly (otherwise a border-box textarea would wrap too early).
-    mirror.style.boxSizing = "content-box";
-    mirror.style.position = "absolute";
+    mirror.style.position = "fixed";
     mirror.style.top = "0";
     mirror.style.left = "0";
     mirror.style.visibility = "hidden";
-    mirror.style.overflow = "hidden";
+    mirror.style.boxSizing = "content-box";
     // A single-line input never wraps; a textarea wraps at its content width.
     mirror.style.whiteSpace = isSingleLine ? "pre" : "pre-wrap";
-    mirror.style.wordWrap = isSingleLine ? "normal" : "break-word";
+    mirror.style.overflowWrap = isSingleLine ? "normal" : "break-word";
+
     if (isSingleLine) {
         mirror.style.width = "auto";
     }
 
     const value = field.value;
-    mirror.textContent = value.substring(0, start);
-    const marker = doc.createElement("span");
-    // A zero-width range (collapsed) still needs something to measure.
-    marker.textContent = value.substring(start, end) || "\u200b";
-    mirror.appendChild(marker);
-    mirror.appendChild(doc.createTextNode(value.substring(end)));
+    if (value.length === 0) return undefined;
+
+    mirror.textContent = value;
 
     doc.body.appendChild(mirror);
-    const mirrorRect = mirror.getBoundingClientRect();
-    const markerRect = marker.getBoundingClientRect();
+
+    const range = document.createRange();
+    range.setStart(mirror.firstChild || mirror, start);
+    range.setEnd(mirror.firstChild || mirror, end);
+    const markerRect = range.getBoundingClientRect();
+
     doc.body.removeChild(mirror);
 
-    if (markerRect.width === 0 && markerRect.height === 0) {
-        return undefined;
-    }
-
-    // The mirror replicates the field's border + padding, so the marker's offset
-    // from the mirror's border-box equals its offset from the field's border-box
-    // (before the field scrolls its content).
-    const offsetLeft = markerRect.left - mirrorRect.left;
-    const offsetTop = markerRect.top - mirrorRect.top;
-
     const fieldRect = field.getBoundingClientRect();
-    return {
-        left: fieldRect.left + offsetLeft - field.scrollLeft,
-        top: fieldRect.top + offsetTop - field.scrollTop,
+    const measure = {
+        left: markerRect.left + fieldRect.left - field.scrollLeft,
+        top: markerRect.top + fieldRect.top - field.scrollTop,
         width: markerRect.width,
         height: markerRect.height,
     };
+
+    console.log("[KIME MEASURE]", measure);
+    console.log("[KIME FIELD]", fieldRect);
+    console.log("[KIME COMPUTED]", computed);
+    return measure;
 }
 
 function toKebabCase(property: string): string {

--- a/src/composition/composition-adapters/input-range-rect.ts
+++ b/src/composition/composition-adapters/input-range-rect.ts
@@ -13,7 +13,6 @@ import { GlyphRect } from "./compositing-box";
  * layout) so the caller can skip drawing.
  */
 const MIRRORED_PROPERTIES: string[] = [
-    "width",
     "boxSizing",
     "borderTop",
     "borderRight",
@@ -74,7 +73,14 @@ export function measureInputRangeRect(
     mirror.style.overflowWrap = isSingleLine ? "normal" : "break-word";
 
     if (isSingleLine) {
+        // A single-line input never wraps, so the mirror can take its natural width.
         mirror.style.width = "auto";
+    } else {
+        // Wrap at the textarea's real text-layout width. clientWidth already excludes
+        // the border and any vertical scrollbar.
+        const paddingLeft = parseFloat(computed.paddingLeft) || 0;
+        const paddingRight = parseFloat(computed.paddingRight) || 0;
+        mirror.style.width = `${field.clientWidth - paddingLeft - paddingRight}px`;
     }
 
     const value = field.value;

--- a/src/composition/composition-adapters/input-range-rect.ts
+++ b/src/composition/composition-adapters/input-range-rect.ts
@@ -97,6 +97,12 @@ export function measureInputRangeRect(
 
     doc.body.removeChild(mirror);
 
+    // A zero-size rect means the glyph isn't measurable — a detached or hidden field,
+    // or jsdom's no-layout stub — so skip drawing rather than placing the box at 0,0.
+    if (markerRect.width === 0 && markerRect.height === 0) {
+        return undefined;
+    }
+
     const fieldRect = field.getBoundingClientRect();
     const measure = {
         left: markerRect.left + fieldRect.left - field.scrollLeft,

--- a/src/composition/composition-adapters/input-range-rect.ts
+++ b/src/composition/composition-adapters/input-range-rect.ts
@@ -42,6 +42,8 @@ const MIRRORED_PROPERTIES: string[] = [
     "tabSize",
     "direction",
     "overflowWrap",
+    "overflowClip",
+    "overflowClipMargin",
 ];
 
 export function measureInputRangeRect(
@@ -97,9 +99,6 @@ export function measureInputRangeRect(
         height: markerRect.height,
     };
 
-    console.log("[KIME MEASURE]", measure);
-    console.log("[KIME FIELD]", fieldRect);
-    console.log("[KIME COMPUTED]", computed);
     return measure;
 }
 

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -2,4 +2,12 @@
 // suites that call jest.restoreAllMocks() in their own teardown.
 beforeEach(() => {
     jest.spyOn(console, "debug").mockImplementation(() => {});
+
+    // jsdom has no layout, so Range#getBoundingClientRect is missing; stub it to a zero
+    // rect (production then bails through its normal zero-size path). Guarded because
+    // some suites run in the `node` env, which has no `Range`.
+    if (typeof Range !== "undefined") {
+        Range.prototype.getBoundingClientRect = () =>
+            ({ x: 0, y: 0, top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0, toJSON: () => ({}) }) as DOMRect;
+    }
 });


### PR DESCRIPTION
Closes #152
Closes #153

Extracts the contentEditable adapter's compositing-box overlay into a shared `CompositingBox` and uses it from `InputAdapter` too, so inputs/textareas show the same box over the composing block (caret collapsed, matching contentEditable) instead of the native selection highlight. The shared box re-measures on scroll/resize, which also fixes the overlay being left behind when an editor scrolls its own content (#153). Inputs/textareas are measured with a mirror element; contentEditable now measures via a `Range`.

On-screen positioning isn't unit-testable in jsdom (no layout) — the box lifecycle and scroll re-align are covered with a stubbed rect; visual positioning to be verified in-browser.