### PR TITLE
Document issue-based branch workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,18 +11,16 @@ on-screen keyboard. TypeScript, bundled with **Parcel**; the options page uses
 
 ## Workflow
 
-**`master` is protected — never commit to it directly.** Features and fixes
-should start with a GitHub issue. Branch off `master` using
+Features and fixes should start with a GitHub issue. Branch off `master` using
 `issue/<issue-number>-<short-kebab-case-description>` (release prep keeps its
-own `release/vX.Y.Z` branch pattern). All changes land via pull request: push
-the branch, open a PR that references the issue, and merge it (GitHub
-auto-deletes the merged branch). A direct push to `master` will be rejected, so
-don't try it even for a one-line doc fix. Run `npm run validate` before pushing
-so CI passes on the first try. After a merge, **confirm it via the PR's merged
-state** (e.g. `gh pr view <n> --json state`) rather than inferring it from local
-`git` — a local checkout that's behind `origin/master`, or that still has the
-feature branch around, can look merged when it isn't (or vice versa). `git
-checkout master && git pull` first if you do check locally.
+own `release/vX.Y.Z` branch pattern). Open a PR that references the issue and
+run `npm run validate` before pushing so CI passes on the first try. `master` is
+protected, so changes are merged through PRs and GitHub auto-deletes the merged
+branch. After a merge, **confirm it via the PR's merged state** (e.g. `gh pr
+view <n> --json state`) rather than inferring it from local `git` — a local
+checkout that's behind `origin/master`, or that still has the feature branch
+around, can look merged when it isn't (or vice versa). `git checkout master &&
+git pull` first if you do check locally.
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,15 +11,18 @@ on-screen keyboard. TypeScript, bundled with **Parcel**; the options page uses
 
 ## Workflow
 
-**`master` is protected — never commit to it directly.** All changes land via
-pull request: branch off `master`, push the branch, open a PR, and merge it
-(GitHub auto-deletes the merged branch). A direct push to `master` will be
-rejected, so don't try it even for a one-line doc fix. Run `npm run validate`
-before pushing so CI passes on the first try. After a merge, **confirm it via the
-PR's merged state** (e.g. `gh pr view <n> --json state`) rather than inferring it
-from local `git` — a local checkout that's behind `origin/master`, or that still
-has the feature branch around, can look merged when it isn't (or vice versa).
-`git checkout master && git pull` first if you do check locally.
+**`master` is protected — never commit to it directly.** Features and fixes
+should start with a GitHub issue. Branch off `master` using
+`issue/<issue-number>-<short-kebab-case-description>` (release prep keeps its
+own `release/vX.Y.Z` branch pattern). All changes land via pull request: push
+the branch, open a PR that references the issue, and merge it (GitHub
+auto-deletes the merged branch). A direct push to `master` will be rejected, so
+don't try it even for a one-line doc fix. Run `npm run validate` before pushing
+so CI passes on the first try. After a merge, **confirm it via the PR's merged
+state** (e.g. `gh pr view <n> --json state`) rather than inferring it from local
+`git` — a local checkout that's behind `origin/master`, or that still has the
+feature branch around, can look merged when it isn't (or vice versa). `git
+checkout master && git pull` first if you do check locally.
 
 ## Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,11 @@ If you want to contribute, please discuss with me first
 and if it fits in with my vision for the project I'll accept it, but
 communication could save us both some time.
 
-`master` is protected: all changes land via pull request — branch off `master`,
-push your branch, and open a PR. Run `npm run validate` before pushing so CI
+For features and bugfixes, please open a GitHub issue first so the change has a
+clear discussion and tracking point. `master` is protected: all changes land via
+pull request. Branch off `master` using
+`issue/<issue-number>-<short-kebab-case-description>`, push your branch, and
+open a PR that references the issue. Run `npm run validate` before pushing so CI
 passes.
 
 For translation tone, locale inheritance, and regional wording preferences, see

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,10 @@ and if it fits in with my vision for the project I'll accept it, but
 communication could save us both some time.
 
 For features and bugfixes, please open a GitHub issue first so the change has a
-clear discussion and tracking point. `master` is protected: all changes land via
-pull request. Branch off `master` using
-`issue/<issue-number>-<short-kebab-case-description>`, push your branch, and
-open a PR that references the issue. Run `npm run validate` before pushing so CI
-passes.
+clear discussion and tracking point. Branch off `master` using
+`issue/<issue-number>-<short-kebab-case-description>`, then open a PR that
+references the issue. `master` is protected, so changes are merged through PRs.
+Run `npm run validate` before pushing so CI passes.
 
 For translation tone, locale inheritance, and regional wording preferences, see
 `TRANSLATIONS.md`.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ ever need to.
 
 ## Contributing
 
-Contributions are welcome — please open an issue or pull request on [GitHub](https://github.com/vmcnabb/korean-ime). It's worth discussing your idea first to make sure it fits the direction of the project. `master` is protected, so all changes go through a pull request.
+Contributions are welcome — please open an issue on [GitHub](https://github.com/vmcnabb/korean-ime) first, then send a pull request for the agreed change. It's worth discussing your idea first to make sure it fits the direction of the project. `master` is protected, so all changes go through a pull request.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ ever need to.
 
 ## Contributing
 
-Contributions are welcome — please open an issue on [GitHub](https://github.com/vmcnabb/korean-ime) first, then send a pull request for the agreed change. It's worth discussing your idea first to make sure it fits the direction of the project. `master` is protected, so all changes go through a pull request.
+Contributions are welcome — please open an issue on [GitHub](https://github.com/vmcnabb/korean-ime) first, then send a pull request for the agreed change. It's worth discussing your idea first to make sure it fits the direction of the project.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Document that features and fixes should start with a GitHub issue
- Add the `issue/<issue-number>-<short-kebab-case-description>` branch naming convention
- Align AGENTS.md, CONTRIBUTING.md, and the README contribution pointer

Closes #159

## Validation
- `npm run validate`