### PR TITLE
Re-tone UI accent from blue to the logo's violet

### DIFF
--- a/src/options-app/GettingStartedPage.vue
+++ b/src/options-app/GettingStartedPage.vue
@@ -110,6 +110,7 @@ function getPreferredPinningVideoSrc(): string {
                     <input
                         ref="typeHangulInput"
                         type="radio"
+                        class="visually-hidden"
                         name="getting-started-choice"
                         :checked="selectedChoice === gettingStartedChoices.typeHangul"
                         @change="choose(gettingStartedChoices.typeHangul)"
@@ -124,6 +125,7 @@ function getPreferredPinningVideoSrc(): string {
                     <input
                         ref="otherToolsInput"
                         type="radio"
+                        class="visually-hidden"
                         name="getting-started-choice"
                         :checked="selectedChoice === gettingStartedChoices.otherTools"
                         @change="choose(gettingStartedChoices.otherTools)"
@@ -210,12 +212,11 @@ legend {
 }
 
 .choice-card {
+    position: relative;
     display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 0.75em;
-    align-items: start;
     margin-top: 0.75em;
-    padding: 0.85em 1em;
+    /* Trailing room so a long translated label never runs under the check. */
+    padding: 0.85em 2.6em 0.85em 1em;
     border: 1px solid var(--section-border);
     border-radius: var(--radius);
     cursor: pointer;
@@ -231,8 +232,30 @@ legend {
     background-color: var(--accent-subtle-bg);
 }
 
-.choice-card input {
-    margin-top: 0.15em;
+/* The native radio is visually hidden (it still drives state + keyboard
+   navigation), so surface keyboard focus on the card itself. */
+.choice-card:has(:focus-visible) {
+    outline: var(--focus-ring-width) solid var(--toggle-on-bg);
+    outline-offset: var(--focus-ring-offset);
+}
+
+/* Selection is the card's border + tint plus this corner check — a shape cue, so
+   it doesn't lean on colour alone. */
+.choice-card::after {
+    content: "";
+    position: absolute;
+    top: 1.15em;
+    right: 1.05em;
+    width: 6px;
+    height: 11px;
+    border-right: 2px solid var(--toggle-on-bg);
+    border-bottom: 2px solid var(--toggle-on-bg);
+    transform: rotate(45deg) scale(0);
+    transition: transform 0.12s ease;
+}
+
+.choice-card.selected::after {
+    transform: rotate(45deg) scale(1);
 }
 
 .choice-card strong,

--- a/src/options-app/GettingStartedPage.vue
+++ b/src/options-app/GettingStartedPage.vue
@@ -10,8 +10,6 @@ import pinLightVideo from "url:../videos/pin-light.mp4";
 
 const loading = ref(true);
 const errorMessage = ref("");
-const typeHangulInput = ref<HTMLInputElement>();
-const otherToolsInput = ref<HTMLInputElement>();
 const pinningVideo = ref<HTMLVideoElement>();
 const showPinningVideo = ref(false);
 const optionsPageHref = getOptionsPageHref();
@@ -38,8 +36,6 @@ onMounted(async () => {
         console.error(error);
     } finally {
         loading.value = false;
-        await nextTick();
-        focusInitialChoice();
     }
 });
 
@@ -63,15 +59,6 @@ async function revealPinningVideo(): Promise<void> {
     } catch {
         // The controls remain visible if a browser blocks autoplay for any reason.
     }
-}
-
-function focusInitialChoice(): void {
-    if (selectedChoice.value === gettingStartedChoices.otherTools) {
-        otherToolsInput.value?.focus();
-        return;
-    }
-
-    typeHangulInput.value?.focus();
 }
 
 function browserHasFirefoxExtensionMenu(): boolean {
@@ -108,7 +95,6 @@ function getPreferredPinningVideoSrc(): string {
 
                 <label class="choice-card" :class="{ selected: selectedChoice === gettingStartedChoices.typeHangul }">
                     <input
-                        ref="typeHangulInput"
                         type="radio"
                         class="visually-hidden"
                         name="getting-started-choice"
@@ -123,7 +109,6 @@ function getPreferredPinningVideoSrc(): string {
 
                 <label class="choice-card" :class="{ selected: selectedChoice === gettingStartedChoices.otherTools }">
                     <input
-                        ref="otherToolsInput"
                         type="radio"
                         class="visually-hidden"
                         name="getting-started-choice"

--- a/src/options-app/GettingStartedPage.vue
+++ b/src/options-app/GettingStartedPage.vue
@@ -158,18 +158,20 @@ function getPreferredPinningVideoSrc(): string {
                 </button>
             </p>
             <Transition name="pinning-video-reveal">
-                <video
-                    v-if="showPinningVideo"
-                    :id="pinningVideoId"
-                    ref="pinningVideo"
-                    class="pinning-video"
-                    :src="pinningVideoSrc"
-                    controls
-                    muted
-                    playsinline
-                    preload="metadata"
-                    :aria-label="t('gettingStarted_showIcon_videoLabel')"
-                ></video>
+                <div class="video-container"
+                    v-if="showPinningVideo">
+                    <video
+                        :id="pinningVideoId"
+                        ref="pinningVideo"
+                        class="pinning-video"
+                        :src="pinningVideoSrc"
+                        controls
+                        muted
+                        playsinline
+                        preload="metadata"
+                        :aria-label="t('gettingStarted_showIcon_videoLabel')"
+                    ></video>
+                </div>
             </Transition>
         </section>
 
@@ -270,6 +272,13 @@ legend {
     margin: 0.85em 0 0;
 }
 
+.video-container {
+    display: block;
+    width: 100%;
+    max-height: 360px;
+    margin: 0;
+    object-fit: contain;
+}
 .pinning-video {
     display: block;
     width: 100%;
@@ -284,8 +293,8 @@ legend {
 .pinning-video-reveal-enter-active {
     overflow: hidden;
     transition:
-        max-height 180ms ease,
-        opacity 180ms ease;
+        max-height 1000ms ease,
+        opacity 500ms ease;
 }
 
 .pinning-video-reveal-enter-from {

--- a/src/options-app/GettingStartedPage.vue
+++ b/src/options-app/GettingStartedPage.vue
@@ -235,8 +235,13 @@ legend {
 /* The native radio is visually hidden (it still drives state + keyboard
    navigation), so surface keyboard focus on the card itself. */
 .choice-card:has(:focus-visible) {
-    outline: var(--focus-ring-width) solid var(--toggle-on-bg);
+    outline: var(--focus-ring-width) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
+}
+
+/* Selected card's border is the accent fill — stand the focus ring off it. */
+.choice-card.selected:has(:focus-visible) {
+    outline-offset: var(--focus-ring-offset-filled);
 }
 
 /* Selection is the card's border + tint plus this corner check — a shape cue, so

--- a/src/options-app/ToggleKeySetting.vue
+++ b/src/options-app/ToggleKeySetting.vue
@@ -262,7 +262,10 @@ function onCaptureKeyup(event: KeyboardEvent) {
 }
 
 .binding.capturing {
-    border-color: var(--toggle-on-bg);
+    /* "Listening for a key" is an active/focused state, so reuse the shared focus
+       ring rather than a bespoke accent border. */
+    outline: var(--focus-ring-width) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
     font-style: italic;
 }
 

--- a/src/options-app/ToggleKeySetting.vue
+++ b/src/options-app/ToggleKeySetting.vue
@@ -191,7 +191,7 @@ function onCaptureKeyup(event: KeyboardEvent) {
         <div class="controls">
             <span
                 class="binding"
-                :class="{ off: !capturing && !binding, capturing }"
+                :class="{ off: !capturing && !binding, capturing, 'ds-focus-ring': capturing }"
                 :title="bindingAccessibleLabel"
                 :aria-label="bindingAccessibleLabel"
             >
@@ -262,10 +262,9 @@ function onCaptureKeyup(event: KeyboardEvent) {
 }
 
 .binding.capturing {
-    /* "Listening for a key" is an active/focused state, so reuse the shared focus
-       ring rather than a bespoke accent border. */
-    outline: var(--focus-ring-width) solid var(--focus-ring-color);
-    outline-offset: var(--focus-ring-offset);
+    /* "Listening for a key" is an active state: the focus ring comes from the
+       shared .ds-focus-ring class (applied in the template), so it tracks any
+       future change to the ring. This rule only adds the italic. */
     font-style: italic;
 }
 

--- a/src/options-app/ToggleKeySetting.vue
+++ b/src/options-app/ToggleKeySetting.vue
@@ -45,6 +45,11 @@ const bindingAccessibleLabel = computed(() => {
         : t("options_hanYong_toggleKey_off");
 });
 
+// The binding box is now a button; give it a self-describing accessible name
+// (field label + current value) so it reads as the toggle-key control rather
+// than a bare value when a screen reader lands on it.
+const bindingButtonLabel = computed(() => `${t("options_hanYong_toggleKey_label")}: ${bindingAccessibleLabel.value}`);
+
 const hintMessageKey = computed<MessageKey>(() =>
     keyBindingPlatform === "mac" ? "options_hanYong_toggleKey_hint_mac" : "options_hanYong_toggleKey_hint"
 );
@@ -189,16 +194,19 @@ function onCaptureKeyup(event: KeyboardEvent) {
             >
         </span>
         <div class="controls">
-            <span
-                class="binding"
+            <!-- The binding box is the capture control: activating it (click or
+                 Enter/Space) starts listening for a key. It reuses .ds-field, so
+                 keyboard focus inherits the shared focus ring; .ds-focus-ring
+                 forces that same ring while capturing. -->
+            <button
+                type="button"
+                class="ds-field ds-field--compact binding"
                 :class="{ off: !capturing && !binding, capturing, 'ds-focus-ring': capturing }"
                 :title="bindingAccessibleLabel"
-                :aria-label="bindingAccessibleLabel"
+                :aria-label="bindingButtonLabel"
+                @click="startCapture"
             >
                 {{ bindingDisplay }}
-            </span>
-            <button type="button" class="ds-btn ds-btn--sm" :disabled="capturing" @click="startCapture">
-                {{ t("options_hanYong_toggleKey_change") }}
             </button>
             <button type="button" class="ds-btn ds-btn--sm" :disabled="!binding && !capturing" @click="turnOff">
                 {{ t("options_hanYong_toggleKey_turnOff") }}
@@ -210,7 +218,7 @@ function onCaptureKeyup(event: KeyboardEvent) {
         <!-- Shown only while capturing, right under the controls: the capture hint,
              or the validation error if an invalid key was pressed. The general
              description lives in the heading's "?" tooltip. -->
-        <p v-if="invalid || capturing" class="feedback" :class="{ error: invalid }">
+        <p v-if="invalid || capturing" class="feedback" :class="{ error: invalid }" role="status">
             {{ invalid ? t(invalidMessageKey) : t(hintMessageKey) }}
         </p>
     </div>
@@ -248,12 +256,18 @@ function onCaptureKeyup(event: KeyboardEvent) {
 }
 
 .binding {
+    /* .ds-field provides the border, background, padding and the :focus-visible
+       ring; only the bits specific to a clickable monospace value box live here. */
     min-width: 5em;
-    padding: 0.2em 0.6em;
-    border: 1px solid var(--section-border);
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     font-family: monospace;
     text-align: center;
+    cursor: pointer;
+    appearance: none;
+}
+
+.binding:hover {
+    background-color: var(--button-hover-bg);
 }
 
 .binding.off {

--- a/src/options-app/ToggleKeySetting.vue
+++ b/src/options-app/ToggleKeySetting.vue
@@ -197,7 +197,9 @@ function onCaptureKeyup(event: KeyboardEvent) {
             <!-- The binding box is the capture control: activating it (click or
                  Enter/Space) starts listening for a key. It reuses .ds-field, so
                  keyboard focus inherits the shared focus ring; .ds-focus-ring
-                 forces that same ring while capturing. -->
+                 forces that same ring while capturing. Blur cancels an in-progress
+                 capture, so clicking (or otherwise moving focus) away bails out —
+                 the same as Esc. -->
             <button
                 type="button"
                 class="ds-field ds-field--compact binding"
@@ -205,6 +207,7 @@ function onCaptureKeyup(event: KeyboardEvent) {
                 :title="bindingAccessibleLabel"
                 :aria-label="bindingButtonLabel"
                 @click="startCapture"
+                @blur="stopCapture"
             >
                 {{ bindingDisplay }}
             </button>

--- a/src/options-app/ToggleSwitch.vue
+++ b/src/options-app/ToggleSwitch.vue
@@ -54,7 +54,12 @@ const model = defineModel<boolean>({ required: true });
 }
 
 .switch input:focus-visible + .slider {
-    outline: var(--focus-ring-width) solid var(--toggle-on-bg);
+    outline: var(--focus-ring-width) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
+}
+
+/* When on, the track is the accent fill — stand the ring off so it doesn't merge. */
+.switch input:checked:focus-visible + .slider {
+    outline-offset: var(--focus-ring-offset-filled);
 }
 </style>

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -24,10 +24,16 @@
     --label-font-size: 1.1em;
     --checkbox-size: var(--label-font-size);
 
-    /* Accent / toggle / subtle states */
+    /* Accent / toggle / subtle states. The accent is the logo's violet
+       (icon_h.svg: #5a2d82→#2b1340, with a #dcbfff glyph), brightened in dark
+       mode the way the rest of the palette is. --accent-on is the ink for
+       text/icons sitting on a filled accent: white reads on the light-mode
+       violet, but the lighter dark-mode violet needs dark ink (the logo's deep
+       aubergine) to stay legible. */
     --toggle-off-bg: light-dark(#ccc, #555);
-    --toggle-on-bg: light-dark(#2563eb, #3b82f6);
-    --accent-subtle-bg: light-dark(#eef4ff, #10213d);
+    --toggle-on-bg: light-dark(#6d28d9, #a78bfa);
+    --accent-on: light-dark(white, #2b1340);
+    --accent-subtle-bg: light-dark(#f3edff, #2b1340);
     --button-hover-bg: light-dark(#f1f5f9, #292929);
     --success-color: light-dark(#168a45, #63d38a);
     --error-color: light-dark(#c0392b, #f87171);
@@ -85,7 +91,7 @@ body {
 
 /* Filled accent button (the getting-started "show video" action). */
 .ds-btn--primary {
-    color: white;
+    color: var(--accent-on);
     font-weight: 700;
     background-color: var(--toggle-on-bg);
     border-color: var(--toggle-on-bg);
@@ -186,7 +192,7 @@ body {
     height: var(--checkbox-size);
     margin: 0;
     font: inherit;
-    color: white;
+    color: var(--accent-on);
     appearance: none;
     background-color: var(--field-bg);
     border: 1px solid var(--section-border);

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -257,10 +257,15 @@ body {
 
 /* --- Focus ring ---------------------------------------------------------- */
 
+/* The focus-ring appearance, shared between real :focus-visible states and the
+   .ds-focus-ring utility — so anything that needs to *look* focused without being
+   in a real focus state (e.g. a custom "listening" indicator) renders identically
+   and tracks any future change to the ring from this one place. */
 .ds-btn:focus-visible,
 .ds-icon-btn:focus-visible,
 .ds-field:focus-visible,
-.ds-checkbox:focus-visible {
+.ds-checkbox:focus-visible,
+.ds-focus-ring {
     outline: var(--focus-ring-width) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
 }

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -51,7 +51,15 @@
     --radius: 8px;
     --radius-sm: 6px;
     --focus-ring-width: 2px;
+    /* Tight ring by default (offset 0). The ring colour is its own lever,
+       decoupled from the accent fill: --focus-ring-color defaults to the accent
+       but can be retoned without touching the fills. Filled-accent controls
+       (primary button, checked checkbox, toggle-on, selected card) would merge a
+       same-colour ring into the fill, so those alone stand it off by
+       --focus-ring-offset-filled — the one place we break the tight ring. */
     --focus-ring-offset: 0;
+    --focus-ring-offset-filled: 3px;
+    --focus-ring-color: var(--toggle-on-bg);
 }
 
 /* Base typography shared by both page contexts. Surface-specific layout (the
@@ -253,8 +261,16 @@ body {
 .ds-icon-btn:focus-visible,
 .ds-field:focus-visible,
 .ds-checkbox:focus-visible {
-    outline: var(--focus-ring-width) solid var(--toggle-on-bg);
+    outline: var(--focus-ring-width) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
+}
+
+/* Filled-accent controls: a same-colour ring at offset 0 merges into the violet
+   fill, so stand it off just for these. After the base rule so the override wins
+   on equal specificity. */
+.ds-btn--primary:focus-visible,
+.ds-checkbox:checked:focus-visible {
+    outline-offset: var(--focus-ring-offset-filled);
 }
 
 /* --- Accessibility helper ------------------------------------------------ */

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -51,7 +51,7 @@
     --radius: 8px;
     --radius-sm: 6px;
     --focus-ring-width: 2px;
-    --focus-ring-offset: 2px;
+    --focus-ring-offset: 0;
 }
 
 /* Base typography shared by both page contexts. Surface-specific layout (the


### PR DESCRIPTION
Closes #170.

The logo (`icon_h.svg`) is violet, but every interactive accent on the page surfaces was blue. Swaps the centralized design-system accent tokens to a logo-derived violet, so the romanization popup and the options / getting-started pages match the brand mark — toggles, primary buttons, checked checkboxes, focus rings, the popup caret and the selected-row accent all follow.

Adds an `--accent-on` token (white in light, the logo's deep aubergine in dark) so on-accent text/checkmarks stay legible against the lighter dark-mode violet, replacing the two hardcoded `color: white` spots.

Page surfaces only; the on-screen keyboard keeps its separate palette (possible follow-up).
