### PR TITLE
Reap stray dev Chromes by throwaway profile

### DIFF
--- a/scripts/dev-shared.mjs
+++ b/scripts/dev-shared.mjs
@@ -88,6 +88,52 @@ export function killFirefoxByProfile(profileDirs) {
     }
 }
 
+// The dev Chrome runs on a throwaway profile created as mkdtemp(tmpdir/"kime-dev-…"),
+// so every dev Chrome's command line carries this prefix in its --user-data-dir.
+// Matching on it scopes our kills to our own throwaway sessions — never the
+// user's real Chrome.
+const DEV_CHROME_PROFILE_PREFIX = "kime-dev";
+
+// Tree-kill every chrome.exe whose command line contains `needle`. The captured
+// PID is unreliable on Windows: Chrome's launcher detaches the real browser into
+// a separate process tree, so a taskkill on the spawned PID can miss the actual
+// windows (the same problem the Firefox launcher has — see killFirefoxByProfile).
+// Matching the throwaway-profile name in the command line finds the detached tree.
+function killChromeMatchingCommandLine(needle) {
+    if (!needle) return;
+    if (process.platform === "win32") {
+        const escaped = needle.replace(/'/g, "''");
+        spawnSync(
+            "powershell.exe",
+            [
+                "-NoProfile",
+                "-Command",
+                `Get-CimInstance Win32_Process -Filter "Name='chrome.exe'" | Where-Object { $_.CommandLine -like '*${escaped}*' } | ForEach-Object { taskkill /PID $_.ProcessId /T /F }`,
+            ],
+            { stdio: "ignore" }
+        );
+    } else {
+        spawnSync("pkill", ["-f", needle], { stdio: "ignore" });
+    }
+}
+
+// Force-close the dev Chrome for a specific run by matching its unique throwaway
+// profile dir name. Mirrors killFirefoxByProfile — scoped to that one session, so
+// it never touches the user's own Chrome.
+export function killChromeByProfile(profileDirs) {
+    for (const dir of profileDirs) {
+        killChromeMatchingCommandLine(basename(dir));
+    }
+}
+
+// Clear *any* lingering dev Chrome left by an earlier run that didn't shut down
+// cleanly (a crash or abrupt kill can strand a kime-dev Chrome on the debug port,
+// which then breaks the next launch). Matches the shared kime-dev profile prefix,
+// so it only ever reaps our own throwaway sessions, never the user's own Chrome.
+export function killStrayDevChromes() {
+    killChromeMatchingCommandLine(DEV_CHROME_PROFILE_PREFIX);
+}
+
 // A built-in test page served over http://localhost so the content script
 // actually injects (it won't on file:/data:/about: URLs).
 export const TEST_PAGE = `<!DOCTYPE html>

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -34,7 +34,15 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import * as ChromeLauncher from "chrome-launcher";
-import { killTree, requestedColorScheme, requestedLocale, startTestPageServer, watchRequested } from "./dev-shared.mjs";
+import {
+    killChromeByProfile,
+    killStrayDevChromes,
+    killTree,
+    requestedColorScheme,
+    requestedLocale,
+    startTestPageServer,
+    watchRequested,
+} from "./dev-shared.mjs";
 
 const root = process.cwd();
 const DEFAULT_CHROME_DEBUG_PORT = 9222;
@@ -205,6 +213,11 @@ function shutdown(code = 0) {
     removeSessionFile();
     killTree(chrome);
     killTree(watch);
+    // The Windows Chrome launcher detaches the real browser from the PID we
+    // captured, so killTree(chrome) can miss it. Reap any Chrome still holding
+    // this run's throwaway profile — scoped to kime-dev, so it never touches the
+    // user's own Chrome. This must run before we rmSync the profile dir below.
+    if (profileDir) killChromeByProfile([profileDir]);
     server?.close();
     // Throwaway profile: drop it so runs don't accumulate temp dirs. Chrome may
     // still hold a lock for a moment after kill, so this is best-effort.
@@ -224,6 +237,14 @@ process.on("uncaughtException", (err) => {
 });
 process.on("SIGINT", () => shutdown(0));
 process.on("SIGTERM", () => shutdown(0));
+
+// 0. Clear any stray dev Chromes left by a previous run that didn't shut down
+//    cleanly. On Windows the Chrome launcher detaches the real browser from the
+//    PID we capture, so a crash or abrupt Ctrl+C can strand a kime-dev Chrome
+//    holding the debug port — which then breaks this launch with a "Timed out
+//    waiting for a Chrome page target" error. Scoped to the kime-dev throwaway
+//    profile, so it never touches the user's own Chrome.
+killStrayDevChromes();
 
 // 1. Serve the test page on a random localhost port.
 const { server, testUrl } = await startTestPageServer();

--- a/scripts/stop-dev.mjs
+++ b/scripts/stop-dev.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
+import { killChromeByProfile, killStrayDevChromes } from "./dev-shared.mjs";
 
 const sessionFile = resolve(process.cwd(), ".chrome-profile", "dev-session.json");
 
@@ -42,11 +43,21 @@ async function waitForSessionFileToClear(timeout = 5000) {
 
 const session = readSession();
 if (!session) {
+    // No recorded session, but a previous run may have crashed and stranded a
+    // kime-dev Chrome on the debug port. Sweep any such strays so the next launch
+    // isn't blocked, then we're done.
+    killStrayDevChromes();
     console.log("[stop-dev] No active dev session found.");
     process.exit(0);
 }
 
 killTree(session.chromePid);
+// The captured PID is the launcher Chrome spawned; on Windows it detaches the
+// real browser into a separate tree, so the kill above can miss it. Reap by the
+// throwaway profile name too — scoped to kime-dev, never the user's own Chrome.
+if (typeof session.profileDir === "string" && session.profileDir) {
+    killChromeByProfile([session.profileDir]);
+}
 
 if (!(await waitForSessionFileToClear())) {
     killTree(session.devPid);


### PR DESCRIPTION
Closes #178.

`dev:chrome` shutdown killed Chrome by its captured PID, but on Windows the Chrome launcher detaches the real browser into a separate process tree (the same problem the Firefox launcher already works around here), so the kill missed it. Stranded `kime-dev` Chromes then held the debug port and broke the next launch.

Mirrors the existing `killFirefoxByProfile` approach: a profile-scoped kill matching the unique `kime-dev` throwaway-profile name in the command line (so it never touches the user's real Chrome), wired into `dev.mjs` shutdown + a pre-launch sweep, and into `stop-dev.mjs`.

Verified on Windows: a stray squatting on port 9222 is cleared by the next `dev:chrome`'s pre-launch sweep (launches clean to "ready"); `stop-dev` and shutdown both leave 0 strays and a free port; `npm run validate` passes.