### PR TITLE
Refactor IME controller lifecycle

### DIFF
--- a/src/composition/hangul-ime-controller.test.ts
+++ b/src/composition/hangul-ime-controller.test.ts
@@ -10,10 +10,10 @@ function dispatchKeydown(target: EventTarget, code: string, key: string): Keyboa
 }
 
 // Each controller registers a capture-phase keydown listener on `window`. Tests
-// don't dispose controllers (production does, via TextInputManager's removal
-// observer), so without cleanup a controller from one test keeps reacting to
-// keystrokes dispatched by the next. Track every controller and dispose them all
-// after each test to keep tests isolated.
+// don't route controllers through TextInputManager, so without cleanup a
+// controller from one test keeps reacting to keystrokes dispatched by the next.
+// Track every controller and dispose them all after each test to keep tests
+// isolated.
 const liveControllers: HangulImeController[] = [];
 function makeController(element: HTMLElement): HangulImeController {
     const controller = new HangulImeController(element);

--- a/src/composition/hangul-ime-controller.ts
+++ b/src/composition/hangul-ime-controller.ts
@@ -13,7 +13,6 @@ export class HangulImeController {
     private _isActive = false;
     private compositor = new HangulCompositor();
     private compositionAdapter: CompositionAdapter;
-    private readonly element: HTMLElement;
 
     private changeListeners: (() => void)[] = [];
     private eventListeners: {
@@ -25,14 +24,15 @@ export class HangulImeController {
 
     private lastAlt?: KeyCode.AltLeft | KeyCode.AltRight = undefined;
 
-    constructor(element: HTMLElement) {
-        const compositionAdapter = CompositionAdapterFactory.createCompositionAdapter(element);
+    constructor(
+        element: HTMLElement,
+        compositionAdapter = CompositionAdapterFactory.createCompositionAdapter(element)
+    ) {
         if (!compositionAdapter) {
             throw new Error("Could not create composition adapter for element");
         }
 
         this.compositionAdapter = compositionAdapter;
-        this.element = element;
 
         // Backspace during composition must be intercepted in the *capture* phase, on
         // window (the earliest point in event propagation). Rich editors like Word for
@@ -80,16 +80,20 @@ export class HangulImeController {
     /**
      * Tears down the controller and removes every event listener it registered.
      * Some listeners live on `document` (e.g. mousedown for contenteditable), so
-     * without this the controller — and the element it references — would never
-     * be garbage-collected after the element leaves the DOM.
+     * without this the controller, its adapter, and listener targets would stay
+     * retained after the element leaves the DOM.
      */
     dispose() {
-        this._isActive = false;
-        for (const { target, type, listener, capture } of this.eventListeners) {
-            target.removeEventListener(type, listener, capture);
+        try {
+            this.flushComposition();
+        } finally {
+            this._isActive = false;
+            for (const { target, type, listener, capture } of this.eventListeners) {
+                target.removeEventListener(type, listener, capture);
+            }
+            this.eventListeners = [];
+            this.changeListeners = [];
         }
-        this.eventListeners = [];
-        this.changeListeners = [];
     }
 
     getCompositionFeatures() {
@@ -245,7 +249,7 @@ export class HangulImeController {
         if (code === KeyCode.Backspace) {
             if (this.compositor.isCompositing()) {
                 this.handleComposingBackspace(event);
-            } else if (event.shiftKey && this.ownsKeyEvent(event)) {
+            } else if (event.shiftKey) {
                 // Shift+Backspace must run here, ahead of the editor deleting the
                 // previous character itself — otherwise getPreviousCharacter() returns
                 // the character *before* the one the editor just removed, and we lift
@@ -259,14 +263,8 @@ export class HangulImeController {
         // Begin composition ahead of the editor's "type over selection" only when
         // there's a real, non-collapsed document selection to replace. The
         // no-selection path and plain <input> elements (whose selection isn't a
-        // document selection) stay on the bubble handler, unchanged. Scoped to our
-        // element so other active controllers on the page don't also act on it.
-        if (
-            !this.compositor.isCompositing() &&
-            this.isJamoKey(event) &&
-            this.hasNonCollapsedSelection() &&
-            this.ownsKeyEvent(event)
-        ) {
+        // document selection) stay on the bubble handler, unchanged.
+        if (!this.compositor.isCompositing() && this.isJamoKey(event) && this.hasNonCollapsedSelection()) {
             this.handleJamoKey(event);
         }
     };
@@ -279,20 +277,6 @@ export class HangulImeController {
     private hasNonCollapsedSelection(): boolean {
         const selection = document.getSelection();
         return !!selection && selection.rangeCount > 0 && !selection.getRangeAt(0).collapsed;
-    }
-
-    /**
-     * True if this controller's element owns the key event — i.e. the event targets
-     * (or the focus sits within) our element. Lets the window-level capture guard
-     * stay scoped to the focused editable when several controllers are active at once.
-     */
-    private ownsKeyEvent(event: Event): boolean {
-        const target = event.target as Node | null;
-        if (target && (this.element === target || this.element.contains(target))) {
-            return true;
-        }
-        const active = document.activeElement;
-        return !!active && (this.element === active || this.element.contains(active));
     }
 
     /**

--- a/src/content-script/text-input-manager.test.ts
+++ b/src/content-script/text-input-manager.test.ts
@@ -1,6 +1,7 @@
 import { TextInputManager, textInputElementsSelector } from "./text-input-manager";
 import { HangulImeController } from "../composition/hangul-ime-controller";
 import { KeyCode } from "../keyboard/korean-keyboard-map";
+import { CompositionAdapterFactory } from "../composition/composition-adapter-factory";
 
 function element(html: string): HTMLElement {
     const wrapper = document.createElement("div");
@@ -36,25 +37,6 @@ describe("textInputElementsSelector", () => {
     });
 });
 
-describe("TextInputManager DOM-removal cleanup", () => {
-    afterEach(() => jest.restoreAllMocks());
-
-    it("disposes a controller when its element leaves the DOM", async () => {
-        const dispose = jest.spyOn(HangulImeController.prototype, "dispose");
-        const manager = new TextInputManager();
-
-        const textarea = document.createElement("textarea");
-        document.body.appendChild(textarea);
-        manager.setActiveElement(textarea); // creates a controller + starts the observer
-
-        textarea.remove();
-        // MutationObserver callbacks run as microtasks; a macrotask tick lets it fire.
-        await new Promise((resolve) => setTimeout(resolve, 0));
-
-        expect(dispose).toHaveBeenCalledTimes(1);
-    });
-});
-
 describe("TextInputManager.setActiveElement", () => {
     afterEach(() => {
         jest.restoreAllMocks();
@@ -82,6 +64,83 @@ describe("TextInputManager.setActiveElement", () => {
 
         expect(manager.setActiveElement(button)).toBeUndefined();
     });
+
+    it("disposes the current controller when focus moves to another editable", () => {
+        const dispose = jest.spyOn(HangulImeController.prototype, "dispose");
+        const manager = new TextInputManager();
+
+        const first = document.createElement("textarea");
+        const second = document.createElement("textarea");
+        document.body.append(first, second);
+
+        manager.setActiveElement(first);
+        manager.setActiveElement(second);
+
+        expect(dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it("reuses the current controller when the same editable is reported twice", () => {
+        const dispose = jest.spyOn(HangulImeController.prototype, "dispose");
+        const manager = new TextInputManager();
+
+        const textarea = document.createElement("textarea");
+        document.body.appendChild(textarea);
+
+        manager.setActiveElement(textarea);
+        manager.setActiveElement(textarea);
+
+        expect(dispose).not.toHaveBeenCalled();
+    });
+
+    it("disposes the current controller when focus leaves editable input", () => {
+        const dispose = jest.spyOn(HangulImeController.prototype, "dispose");
+        const manager = new TextInputManager();
+
+        const textarea = document.createElement("textarea");
+        const button = document.createElement("button");
+        document.body.append(textarea, button);
+
+        manager.setActiveElement(textarea);
+        manager.setActiveElement(button);
+
+        expect(dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps only one window-capture keydown guard after replacing the controller", () => {
+        const add = jest.spyOn(window, "addEventListener");
+        const remove = jest.spyOn(window, "removeEventListener");
+        const manager = new TextInputManager();
+
+        const first = document.createElement("textarea");
+        const second = document.createElement("textarea");
+        document.body.append(first, second);
+
+        manager.setActiveElement(first);
+        manager.setActiveElement(second);
+
+        const keydownCaptureAdds = add.mock.calls.filter(([type, _listener, capture]) => {
+            return type === "keydown" && capture === true;
+        });
+
+        expect(keydownCaptureAdds).toHaveLength(2);
+        expect(remove).toHaveBeenCalledWith("keydown", keydownCaptureAdds[0][1], true);
+    });
+
+    it("clears the current controller when the focused editable has no adapter", () => {
+        const dispose = jest.spyOn(HangulImeController.prototype, "dispose");
+        const createAdapter = jest.spyOn(CompositionAdapterFactory, "createCompositionAdapter");
+        const manager = new TextInputManager();
+
+        const textarea = document.createElement("textarea");
+        const unsupported = element("<div contenteditable></div>");
+        document.body.append(textarea, unsupported);
+
+        manager.setActiveElement(textarea);
+        createAdapter.mockReturnValueOnce(undefined);
+
+        expect(manager.setActiveElement(unsupported)).toBeUndefined();
+        expect(dispose).toHaveBeenCalledTimes(1);
+    });
 });
 
 describe("TextInputManager.enterCharacter", () => {
@@ -96,6 +155,18 @@ describe("TextInputManager.enterCharacter", () => {
         expect(manager.enterCharacter("a", KeyCode.KeyA)).toBe(false);
     });
 
+    it("clears a stale controller when no editable element is focused", () => {
+        const dispose = jest.spyOn(HangulImeController.prototype, "dispose");
+        const manager = new TextInputManager();
+
+        const textarea = document.createElement("textarea");
+        document.body.appendChild(textarea);
+        manager.setActiveElement(textarea);
+
+        expect(manager.enterCharacter("a", KeyCode.KeyA)).toBe(false);
+        expect(dispose).toHaveBeenCalledTimes(1);
+    });
+
     it("creates a controller for the focused element and routes the character", () => {
         const addCharacter = jest.spyOn(HangulImeController.prototype, "addCharacter").mockImplementation(() => {});
         const manager = new TextInputManager();
@@ -105,10 +176,29 @@ describe("TextInputManager.enterCharacter", () => {
         input.focus();
 
         // No setActiveElement call first: enterCharacter must create the
-        // controller itself (via ensureController), not rely on a getter side effect.
+        // controller itself (via tryGetOrCreateController), not rely on a getter side effect.
         const handled = manager.enterCharacter("a", KeyCode.KeyA);
 
         expect(handled).toBe(true);
+        expect(addCharacter).toHaveBeenCalledWith("a", KeyCode.KeyA);
+    });
+
+    it("replaces the controller with one for the focused element before routing the character", () => {
+        const dispose = jest.spyOn(HangulImeController.prototype, "dispose");
+        const addCharacter = jest.spyOn(HangulImeController.prototype, "addCharacter").mockImplementation(() => {});
+        const manager = new TextInputManager();
+
+        const first = document.createElement("textarea");
+        const second = document.createElement("input");
+        document.body.append(first, second);
+
+        manager.setActiveElement(first);
+        second.focus();
+
+        const handled = manager.enterCharacter("a", KeyCode.KeyA);
+
+        expect(handled).toBe(true);
+        expect(dispose).toHaveBeenCalledTimes(1);
         expect(addCharacter).toHaveBeenCalledWith("a", KeyCode.KeyA);
     });
 });

--- a/src/content-script/text-input-manager.ts
+++ b/src/content-script/text-input-manager.ts
@@ -14,27 +14,24 @@ const inputSelector = `input:not(${nonTextInputTypes.map((t) => `[type=${t}]`).j
 export const textInputElementsSelector = `[contenteditable]:not([contenteditable=false]),textarea,${inputSelector}`;
 
 export class TextInputManager {
-    private imeControllers = new Map<HTMLElement, HangulImeController>();
+    private targetElement?: HTMLElement;
+    private imeController?: HangulImeController;
     private textEntryMode: KoreanKeyboardMode = KoreanKeyboardMode.English;
-    private removalObserver?: MutationObserver;
 
     public setMode(mode: KoreanKeyboardMode) {
         this.textEntryMode = mode;
 
-        for (const controller of this.imeControllers.values()) {
-            if (this.textEntryMode == KoreanKeyboardMode.Hangul) {
-                controller.activate();
-            } else {
-                controller.deactivate();
-            }
-        }
+        this.syncControllerMode();
     }
 
     public setActiveElement(element: EventTarget | null): SupportedCompositionFeatures | undefined {
-        if (element instanceof HTMLElement && element.matches(textInputElementsSelector)) {
-            return this.ensureController(element).getCompositionFeatures();
+        const activeElement = this.getTextInputElement(element) ?? this.getActiveElement(document);
+        if (!activeElement) {
+            this.clearActiveController();
+            return;
         }
-        return;
+
+        return this.tryGetOrCreateController(activeElement)?.getCompositionFeatures();
     }
 
     // Insert text at the caret in the active editable, replacing any selection.
@@ -63,10 +60,14 @@ export class TextInputManager {
     public enterCharacter(char: string, keyCode: KeyCode): boolean {
         const activeElement = this.getActiveElement(document);
         if (!activeElement) {
+            this.clearActiveController();
             return false;
         }
 
-        const imeController = this.ensureController(activeElement);
+        const imeController = this.tryGetOrCreateController(activeElement);
+        if (!imeController) {
+            return false;
+        }
 
         if (isHangulOrJamo(char)) {
             imeController.addJamo(char, keyCode);
@@ -82,57 +83,63 @@ export class TextInputManager {
     }
 
     /**
-     * Get (creating if necessary) the IME controller for an element, with its
-     * active state synced to the current text-entry mode. This is the single
-     * place that creates controllers; `getActiveElement` stays a pure query.
+     * Get (creating if necessary) the single IME controller for the currently
+     * focused element, with its active state synced to the current text-entry
+     * mode. When focus moves, the previous controller is disposed and a new one
+     * is created so only one window-capture listener and one handler set exist
+     * at a time.
      */
-    private ensureController(element: HTMLElement): HangulImeController {
-        let imeController = this.imeControllers.get(element);
+    private tryGetOrCreateController(element: HTMLElement): HangulImeController | undefined {
+        if (this.targetElement !== element) {
+            this.clearActiveController();
+            const compositionAdapter = CompositionAdapterFactory.createCompositionAdapter(element);
+            if (!compositionAdapter) {
+                return undefined;
+            }
+            this.targetElement = element;
+            this.imeController = new HangulImeController(element, compositionAdapter);
+        }
 
+        this.syncControllerMode();
+        return this.imeController;
+    }
+
+    private syncControllerMode() {
+        const imeController = this.imeController;
         if (!imeController) {
-            imeController = new HangulImeController(element);
-            this.imeControllers.set(element, imeController);
-            this.watchForRemoval();
+            return;
         }
 
         const isHangulMode = this.textEntryMode === KoreanKeyboardMode.Hangul;
-        if (imeController.isActive != isHangulMode) {
-            if (isHangulMode) {
-                imeController.activate();
-            } else {
-                imeController.deactivate();
-            }
-        }
-
-        return imeController;
-    }
-
-    // An element that leaves the DOM keeps its IME controller alive via this
-    // Map, and the controller holds listeners (some on `document`) that wouldn't
-    // be garbage-collected with the element. Watch for removals and tear those
-    // down. One observer per content-script frame, started lazily on first use.
-    private watchForRemoval() {
-        if (this.removalObserver) {
+        if (imeController.isActive === isHangulMode) {
             return;
         }
-        this.removalObserver = new MutationObserver(() => this.disposeDisconnectedControllers());
-        this.removalObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+        if (isHangulMode) {
+            imeController.activate();
+        } else {
+            imeController.deactivate();
+        }
     }
 
-    private disposeDisconnectedControllers() {
-        for (const [element, controller] of this.imeControllers) {
-            if (!element.isConnected) {
-                controller.dispose();
-                this.imeControllers.delete(element);
-            }
+    private clearActiveController() {
+        this.imeController?.dispose();
+        this.imeController = undefined;
+        this.targetElement = undefined;
+    }
+
+    private getTextInputElement(element: EventTarget | null): HTMLElement | undefined {
+        if (element instanceof HTMLElement && element.matches(textInputElementsSelector)) {
+            return element;
         }
+        return undefined;
     }
 
     /**
      * Pure query: find the focused editable element, descending into same-origin
      * iframes/objects. Returns null if there's no match (or a cross-origin
      * boundary blocks the walk). Creates nothing — controller creation is the
-     * caller's job via `ensureController`.
+     * caller's job via `tryGetOrCreateController`.
      */
     private getActiveElement(document: Document): HTMLElement | null {
         const isActiveElementInChildDocument =


### PR DESCRIPTION
## Summary
- Replace the per-element IME controller map with a single focused target/controller pair
- Dispose and recreate the controller when the focused editable changes or becomes unsupported
- Remove window-capture ownership scoping from HangulImeController and keep disposal flushing composition
- Add focused lifecycle coverage for controller replacement and stale cleanup

Closes #117

## Testing
- npm run validate