### PR TITLE
Treat Ctrl/Cmd/Alt IME keys correctly in Hangul mode (Mac Command shortcuts)

### DIFF
--- a/src/composition/hangul-ime-controller.test.ts
+++ b/src/composition/hangul-ime-controller.test.ts
@@ -114,6 +114,56 @@ describe("HangulImeController functional keys during composition", () => {
     });
 });
 
+describe("HangulImeController lets Cmd/Ctrl shortcut chords through in Hangul mode", () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    function activeControllerOnTextarea() {
+        const beginComposition = jest.spyOn(InputAdapter.prototype, "beginComposition").mockImplementation(() => {});
+        jest.spyOn(InputAdapter.prototype, "updateComposition").mockImplementation(() => {});
+        jest.spyOn(InputAdapter.prototype, "endComposition").mockImplementation(() => {});
+
+        const element = document.createElement("textarea");
+        const controller = makeController(element);
+        controller.activate();
+        return { element, beginComposition };
+    }
+
+    // KeyC's jamo is ㅊ: without the fix this composed instead of triggering the
+    // shortcut, swallowing the key.
+    function pressC(element: HTMLElement, modifiers: { ctrlKey?: boolean; metaKey?: boolean }) {
+        const event = new KeyboardEvent("keydown", {
+            code: "KeyC",
+            key: "c",
+            bubbles: true,
+            cancelable: true,
+            ...modifiers,
+        });
+        element.dispatchEvent(event);
+        return event;
+    }
+
+    // Regression (macOS): in Hangul mode, Cmd+C used to compose the jamo ㅊ instead of
+    // copying, because the shortcut bypass only checked ctrlKey, not metaKey (Command).
+    it("does not compose Cmd+C (metaKey) and lets it reach the browser", () => {
+        const { element, beginComposition } = activeControllerOnTextarea();
+
+        const event = pressC(element, { metaKey: true });
+
+        expect(beginComposition).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    // Ctrl shortcuts (Windows/Linux) keep working exactly as before.
+    it("does not compose Ctrl+C (ctrlKey) and lets it reach the browser", () => {
+        const { element, beginComposition } = activeControllerOnTextarea();
+
+        const event = pressC(element, { ctrlKey: true });
+
+        expect(beginComposition).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+});
+
 describe("HangulImeController flushes OSK-driven compositions while inactive", () => {
     afterEach(() => jest.restoreAllMocks());
 
@@ -331,6 +381,30 @@ describe("HangulImeController intercepts the first jamo over a selection in the 
         expect(beginComposition).toHaveBeenCalledWith("ㅇ", KeyCode.KeyD); // still composed...
         expect(keydown.defaultPrevented).toBe(true);
         expect(reachedBodyCapture).toBe(true); // ...but via the bubble path, not capture
+    });
+
+    // Regression (macOS): Cmd+C over a selection must reach the browser so copy works.
+    // The capture guard must NOT begin composition — otherwise it deletes the selection
+    // and types the jamo ㅊ over it instead of copying.
+    it("leaves a Cmd-chord over a selection to the browser (does not begin composition)", () => {
+        const { element, beginComposition } = activeContentEditable("Hello Anyeon.");
+        selectWithin(element.firstChild as Node, 6, 12); // select "Anyeon"
+
+        let reachedBodyCapture = false;
+        document.body.addEventListener("keydown", () => (reachedBodyCapture = true), true);
+
+        const keydown = new KeyboardEvent("keydown", {
+            code: "KeyC", // jamo ㅊ
+            key: "c",
+            metaKey: true,
+            bubbles: true,
+            cancelable: true,
+        });
+        element.dispatchEvent(keydown);
+
+        expect(beginComposition).not.toHaveBeenCalled();
+        expect(keydown.defaultPrevented).toBe(false);
+        expect(reachedBodyCapture).toBe(true); // not intercepted at window-capture
     });
 });
 

--- a/src/composition/hangul-ime-controller.test.ts
+++ b/src/composition/hangul-ime-controller.test.ts
@@ -2,6 +2,7 @@ import { HangulImeController } from "./hangul-ime-controller";
 import { InputAdapter } from "./composition-adapters/input-adapter";
 import { ContentEditableAdapter } from "./composition-adapters/content-editable-adapter";
 import { KeyCode } from "../keyboard/korean-keyboard-map";
+import { KeyBinding, defaultToggleKeyBinding, macDefaultToggleKeyBinding } from "../keyboard/key-binding";
 import { HanjaDictionaryProvider } from "./hanja/hanja-dictionary-provider";
 import { HanjaCandidate } from "./hanja/hanja-candidate";
 import { HANJA_CANDIDATE_WINDOW_SELECTOR } from "./hanja/hanja-candidate-window";
@@ -160,6 +161,113 @@ describe("HangulImeController lets Cmd/Ctrl shortcut chords through in Hangul mo
         const event = pressC(element, { ctrlKey: true });
 
         expect(beginComposition).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+});
+
+describe("HangulImeController treats a held toggle key as the IME key, not a modifier", () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    function controllerOnTextarea(binding: KeyBinding | null) {
+        const beginComposition = jest.spyOn(InputAdapter.prototype, "beginComposition").mockImplementation(() => {});
+        jest.spyOn(InputAdapter.prototype, "updateComposition").mockImplementation(() => {});
+        jest.spyOn(InputAdapter.prototype, "endComposition").mockImplementation(() => {});
+        const inputCharacter = jest.spyOn(InputAdapter.prototype, "inputCharacter").mockImplementation(() => {});
+
+        const element = document.createElement("textarea");
+        const controller = makeController(element);
+        controller.setToggleKeyBinding(binding);
+        return { element, controller, beginComposition, inputCharacter };
+    }
+
+    // A bare modifier keydown: only its `code` is tracked (as the last modifier),
+    // which is how the controller tells the toggle key from its other-side sibling.
+    function pressModifier(element: HTMLElement, code: string) {
+        element.dispatchEvent(new KeyboardEvent("keydown", { code, key: "Meta", bubbles: true, cancelable: true }));
+    }
+
+    // KeyC's jamo is ㅊ, so a successful compose is observable via beginComposition.
+    function pressC(element: HTMLElement, modifiers: { ctrlKey?: boolean; altKey?: boolean; metaKey?: boolean }) {
+        const event = new KeyboardEvent("keydown", {
+            code: "KeyC",
+            key: "c",
+            bubbles: true,
+            cancelable: true,
+            ...modifiers,
+        });
+        element.dispatchEvent(event);
+        return event;
+    }
+
+    // Inactive (English) + the Mac toggle (Right Command) held: it's the IME key, so
+    // the letter is typed instead of letting Cmd+letter act as a shortcut/menu.
+    it("inserts the letter literally when the Right Command toggle is held — inactive", () => {
+        const { element, inputCharacter } = controllerOnTextarea(macDefaultToggleKeyBinding); // not activated
+
+        pressModifier(element, "MetaRight");
+        const event = pressC(element, { metaKey: true });
+
+        expect(inputCharacter).toHaveBeenCalledWith("c", KeyCode.KeyC);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    // Active (Hangul) + the toggle held: it must compose the jamo, NOT be treated as a
+    // Cmd shortcut (the companion to Part 1 — metaKey alone would otherwise pass through).
+    it("composes the jamo when the Right Command toggle is held — active", () => {
+        const { element, controller, beginComposition } = controllerOnTextarea(macDefaultToggleKeyBinding);
+        controller.activate();
+
+        pressModifier(element, "MetaRight");
+        const event = pressC(element, { metaKey: true }); // KeyC → ㅊ
+
+        expect(beginComposition).toHaveBeenCalledWith("ㅊ", KeyCode.KeyC);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    // The OTHER Command (Left) is a real modifier, so Cmd+C is a real shortcut and must
+    // pass through — this is the actual reported bug's happy path.
+    it("passes a real Cmd+C through when the held Command is not the toggle key — active", () => {
+        const { element, controller, beginComposition } = controllerOnTextarea(macDefaultToggleKeyBinding);
+        controller.activate();
+
+        pressModifier(element, "MetaLeft");
+        const event = pressC(element, { metaKey: true });
+
+        expect(beginComposition).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    // Regression: the default Right Alt toggle keeps its long-standing behavior.
+    it("still inserts the letter when the default Right Alt toggle is held — inactive", () => {
+        const { element, inputCharacter } = controllerOnTextarea(defaultToggleKeyBinding); // Right Alt
+
+        pressModifier(element, "AltRight");
+        const event = pressC(element, { altKey: true });
+
+        expect(inputCharacter).toHaveBeenCalledWith("c", KeyCode.KeyC);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    // The flag check guards against a stale last-modifier: once the toggle key is
+    // released, a plain letter is left to the browser.
+    it("does not insert once the toggle key has been released — inactive", () => {
+        const { element, inputCharacter } = controllerOnTextarea(macDefaultToggleKeyBinding);
+
+        pressModifier(element, "MetaRight"); // pressed...
+        const event = pressC(element, { metaKey: false }); // ...but no longer held
+
+        expect(inputCharacter).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    // With the toggle turned off, the key is an ordinary modifier again.
+    it("does not insert when the toggle key is turned off (null)", () => {
+        const { element, inputCharacter } = controllerOnTextarea(null);
+
+        pressModifier(element, "MetaRight");
+        const event = pressC(element, { metaKey: true });
+
+        expect(inputCharacter).not.toHaveBeenCalled();
         expect(event.defaultPrevented).toBe(false);
     });
 });

--- a/src/composition/hangul-ime-controller.ts
+++ b/src/composition/hangul-ime-controller.ts
@@ -1,5 +1,6 @@
 ﻿import { isKimeEvent } from "../messaging/dom-events";
-import { isAltKey, isModifierKey, KeyCode, keyMap } from "../keyboard/korean-keyboard-map";
+import { isModifierKey, isModifierKeyActive, KeyCode, keyMap } from "../keyboard/korean-keyboard-map";
+import { KeyBinding, defaultToggleKeyBindingForPlatform, isModifierOnlyBinding } from "../keyboard/key-binding";
 import { HangulCompositor } from "./hangul-compositor";
 import { CompositionAdapterFactory } from "./composition-adapter-factory";
 import { CompositionAdapter } from "./composition-adapters/composition-adapter";
@@ -37,7 +38,17 @@ export class HangulImeController {
         capture: boolean;
     }[] = [];
 
-    private lastAlt?: KeyCode.AltLeft | KeyCode.AltRight = undefined;
+    // The most recent modifier key pressed (any side). Combined with the event's live
+    // modifier flags, this lets isToggleKeyHeld tell the configured toggle key apart
+    // from its same-type sibling on the other side — `event.code` is the key pressed
+    // now, and a flag like `metaKey` doesn't say which side is down.
+    private lastModifierKey?: KeyCode = undefined;
+
+    // The configured Han/Yong toggle key. When it's a modifier-only key (e.g. Right
+    // Alt, or Right Command on macOS) and held down, it acts as the IME key rather
+    // than a Ctrl/Cmd/Alt modifier. Defaults to the platform default; the content
+    // script pushes the user's actual binding via setToggleKeyBinding.
+    private toggleKeyBinding: KeyBinding | null = defaultToggleKeyBindingForPlatform();
 
     constructor(
         private readonly element: HTMLElement,
@@ -121,6 +132,15 @@ export class HangulImeController {
         return this.compositionAdapter.getSupportedMethods();
     }
 
+    /**
+     * Set the configured Han/Yong toggle key (or null when the user turned it off).
+     * Pushed in by the content script so the controller knows which physical modifier
+     * key currently acts as the IME key rather than a Ctrl/Cmd/Alt modifier.
+     */
+    setToggleKeyBinding(binding: KeyBinding | null) {
+        this.toggleKeyBinding = binding;
+    }
+
     private notifyOnEntry() {
         this.changeListeners.forEach((listener) => {
             try {
@@ -157,14 +177,11 @@ export class HangulImeController {
 
             this.invalidateHanjaLookup();
 
-            // record which alt was down last, so we know if the "han/yong" key is down
-            if (isAltKey(code)) {
-                this.lastAlt = code;
-                return;
-            }
-
-            // don't process modifier keys
+            // Record the most recent modifier key (any side) and stop — modifier keys
+            // aren't text. Tracking which one lets isToggleKeyHeld tell the configured
+            // toggle key apart from its same-type sibling on the other side.
             if (isModifierKey(code)) {
+                this.lastModifierKey = code;
                 return;
             }
 
@@ -175,13 +192,13 @@ export class HangulImeController {
                 // otherwise the next OSK jamo would attach to a stale block.
                 this.flushComposition();
 
-                if (event.altKey && this.lastAlt === KeyCode.AltRight) {
-                    // insert character manually when "han/yong" key is down so that a menu isn't triggered
+                if (this.isToggleKeyHeld(event)) {
+                    // The configured toggle key (e.g. Right Alt, or Right Command on
+                    // macOS) is held: it's the IME key, not a modifier, so insert the
+                    // character instead of letting the OS treat Alt/Cmd+key as a
+                    // shortcut or menu trigger.
                     this.compositionAdapter.inputCharacter(event.key, code);
-
-                    event.preventDefault();
-                    event.stopPropagation();
-                    event.stopImmediatePropagation();
+                    this.cancelEvent(event);
                     return;
                 }
 
@@ -217,7 +234,7 @@ export class HangulImeController {
             // don't interfere with shortcuts, functional keys (Tab, Enter, …), or keys we
             // don't understand — commit any in-progress composition and let the browser
             // handle them natively
-            if (!key || hasShortcutModifier(event) || !isCharacterKey) {
+            if (!key || this.isShortcutChord(event) || !isCharacterKey) {
                 if (this.compositor.isCompositing()) {
                     this.compositionAdapter.endComposition(this.compositor.getCurrentChar());
                     this.compositor.reset();
@@ -312,7 +329,32 @@ export class HangulImeController {
 
     private isJamoKey(event: KeyboardEvent): boolean {
         const code = event.code as KeyCode;
-        return !hasShortcutModifier(event) && event.key.length === 1 && !!keyMap[code]?.jamo;
+        return !this.isShortcutChord(event) && event.key.length === 1 && !!keyMap[code]?.jamo;
+    }
+
+    /**
+     * Whether the configured Han/Yong toggle key is a modifier-only key that is
+     * currently held. When true, that key is acting as the IME key, not as a
+     * Ctrl/Cmd/Alt modifier, so a letter pressed with it should be composed/typed
+     * rather than treated as a browser shortcut. We require both that the toggle key
+     * was the last modifier pressed (so it's that side, not its sibling) and that its
+     * modifier flag is still down (so it wasn't already released).
+     */
+    private isToggleKeyHeld(event: KeyboardEvent): boolean {
+        const binding = this.toggleKeyBinding;
+        if (!binding || !isModifierOnlyBinding(binding)) {
+            return false;
+        }
+        return this.lastModifierKey === binding.code && isModifierKeyActive(event, binding.code);
+    }
+
+    /**
+     * Whether the event is a browser/OS shortcut chord the IME must not consume: a
+     * Ctrl/Cmd modifier is held and it isn't the toggle key being held (which would
+     * make it the IME key, not a modifier — see isToggleKeyHeld).
+     */
+    private isShortcutChord(event: KeyboardEvent): boolean {
+        return hasShortcutModifier(event) && !this.isToggleKeyHeld(event);
     }
 
     private hasNonCollapsedSelection(): boolean {

--- a/src/composition/hangul-ime-controller.ts
+++ b/src/composition/hangul-ime-controller.ts
@@ -217,7 +217,7 @@ export class HangulImeController {
             // don't interfere with shortcuts, functional keys (Tab, Enter, …), or keys we
             // don't understand — commit any in-progress composition and let the browser
             // handle them natively
-            if (!key || event.ctrlKey || !isCharacterKey) {
+            if (!key || hasShortcutModifier(event) || !isCharacterKey) {
                 if (this.compositor.isCompositing()) {
                     this.compositionAdapter.endComposition(this.compositor.getCurrentChar());
                     this.compositor.reset();
@@ -312,7 +312,7 @@ export class HangulImeController {
 
     private isJamoKey(event: KeyboardEvent): boolean {
         const code = event.code as KeyCode;
-        return !event.ctrlKey && event.key.length === 1 && !!keyMap[code]?.jamo;
+        return !hasShortcutModifier(event) && event.key.length === 1 && !!keyMap[code]?.jamo;
     }
 
     private hasNonCollapsedSelection(): boolean {
@@ -641,6 +641,17 @@ export class HangulImeController {
         event.stopPropagation();
         event.stopImmediatePropagation();
     }
+}
+
+/**
+ * Whether a key event carries a shortcut modifier, meaning it's a browser/OS
+ * shortcut (copy, paste, select-all, …) rather than text input — so the IME must
+ * step aside and let the browser handle it. `ctrlKey` covers Ctrl shortcuts
+ * (Windows/Linux); `metaKey` covers Command shortcuts (macOS). A modifier+letter
+ * chord is never an intended jamo on any platform, so both bypass composition.
+ */
+function hasShortcutModifier(event: KeyboardEvent): boolean {
+    return event.ctrlKey || event.metaKey;
 }
 
 function hanjaCandidateNumberIndex(event: KeyboardEvent): number | undefined {

--- a/src/content-script/content-script-controller.test.ts
+++ b/src/content-script/content-script-controller.test.ts
@@ -1,5 +1,6 @@
 import { ContentScriptController } from "./content-script-controller";
 import { OnScreenKeyboardController } from "./on-screen-keyboard/on-screen-keyboard-controller";
+import { TextInputManager } from "./text-input-manager";
 import { KeyCode } from "../keyboard/korean-keyboard-map";
 import { KeyBinding, defaultToggleKeyBinding } from "../keyboard/key-binding";
 import { loadToggleKeyBinding } from "../settings/toggle-key-store";
@@ -180,6 +181,16 @@ describe("ContentScriptController toggle-key handling", () => {
 
         expect(keydown.preventDefault).not.toHaveBeenCalled();
         expect(sendMessage).not.toHaveBeenCalled();
+    });
+
+    // The IME controller needs the binding too (to know when the toggle key is held as
+    // the IME key rather than a modifier), so the loaded binding is pushed to the manager.
+    it("pushes the loaded toggle binding to the text input manager", async () => {
+        const setToggleKeyBinding = jest.spyOn(TextInputManager.prototype, "setToggleKeyBinding");
+
+        await initController(altS);
+
+        expect(setToggleKeyBinding).toHaveBeenCalledWith(altS);
     });
 });
 

--- a/src/content-script/content-script-controller.ts
+++ b/src/content-script/content-script-controller.ts
@@ -136,6 +136,9 @@ export class ContentScriptController {
     /** Load the per-machine Han/Yong toggle key binding (see toggle-key-store). */
     private async loadToggleKey() {
         this.toggleKeyBinding = await loadToggleKeyBinding();
+        // The IME controller needs the binding too, to know when the toggle key is
+        // being held as the IME key rather than a Ctrl/Cmd/Alt modifier.
+        this.textInputManager.setToggleKeyBinding(this.toggleKeyBinding);
     }
 
     /** Re-read the toggle key when it changes — the options page writes it to local storage. */
@@ -201,7 +204,7 @@ export class ContentScriptController {
                     // A printable-key combo (e.g. Alt+S) must be swallowed fully so the
                     // character doesn't also reach the page or the IME. A modifier-only
                     // key (e.g. the default Right Alt/Command) is left to propagate so the IME can
-                    // still track it (see HangulImeController's `lastAlt`).
+                    // still track it (see HangulImeController's `lastModifierKey`).
                     if (!isModifierOnlyBinding(binding)) {
                         e.stopImmediatePropagation();
                     }

--- a/src/content-script/text-input-manager.test.ts
+++ b/src/content-script/text-input-manager.test.ts
@@ -1,6 +1,7 @@
 import { TextInputManager, textInputElementsSelector } from "./text-input-manager";
 import { HangulImeController } from "../composition/hangul-ime-controller";
 import { KeyCode } from "../keyboard/korean-keyboard-map";
+import { macDefaultToggleKeyBinding } from "../keyboard/key-binding";
 import { CompositionAdapterFactory } from "../composition/composition-adapter-factory";
 
 jest.mock("../composition/hanja/hanja-candidate-window.scss", () => ({}), { virtual: true });
@@ -202,5 +203,37 @@ describe("TextInputManager.enterCharacter", () => {
         expect(handled).toBe(true);
         expect(dispose).toHaveBeenCalledTimes(1);
         expect(addCharacter).toHaveBeenCalledWith("a", KeyCode.KeyA);
+    });
+});
+
+describe("TextInputManager.setToggleKeyBinding", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+        document.body.innerHTML = "";
+    });
+
+    it("forwards a binding change to the live controller", () => {
+        const setToggleKeyBinding = jest.spyOn(HangulImeController.prototype, "setToggleKeyBinding");
+        const manager = new TextInputManager();
+        const textarea = document.createElement("textarea");
+        document.body.appendChild(textarea);
+        manager.setActiveElement(textarea); // creates the controller
+
+        setToggleKeyBinding.mockClear();
+        manager.setToggleKeyBinding(macDefaultToggleKeyBinding);
+
+        expect(setToggleKeyBinding).toHaveBeenCalledWith(macDefaultToggleKeyBinding);
+    });
+
+    it("applies the current binding to a controller created later", () => {
+        const setToggleKeyBinding = jest.spyOn(HangulImeController.prototype, "setToggleKeyBinding");
+        const manager = new TextInputManager();
+        manager.setToggleKeyBinding(macDefaultToggleKeyBinding); // no controller yet
+
+        const textarea = document.createElement("textarea");
+        document.body.appendChild(textarea);
+        manager.setActiveElement(textarea); // controller created now
+
+        expect(setToggleKeyBinding).toHaveBeenCalledWith(macDefaultToggleKeyBinding);
     });
 });

--- a/src/content-script/text-input-manager.ts
+++ b/src/content-script/text-input-manager.ts
@@ -3,6 +3,7 @@ import { KoreanKeyboardMode } from "../extension-state/korean-keyboard-mode";
 import { CompositionAdapterFactory } from "../composition/composition-adapter-factory";
 import { isHangulOrJamo } from "../composition/hangul-maps";
 import { KeyCode } from "../keyboard/korean-keyboard-map";
+import { KeyBinding, defaultToggleKeyBindingForPlatform } from "../keyboard/key-binding";
 import { SupportedCompositionFeatures } from "../composition/composition-adapters/composition-adapter-interface";
 import { HanjaDictionaryProvider, StaticHanjaDictionaryProvider } from "../composition/hanja/hanja-dictionary-provider";
 
@@ -18,6 +19,10 @@ export class TextInputManager {
     private targetElement?: HTMLElement;
     private imeController?: HangulImeController;
     private textEntryMode: KoreanKeyboardMode = KoreanKeyboardMode.English;
+    // The configured Han/Yong toggle key, kept here so it survives controller
+    // recreation on focus change and is applied to each new controller. Defaults to
+    // the platform default until the content script pushes the user's binding.
+    private toggleKeyBinding: KeyBinding | null = defaultToggleKeyBindingForPlatform();
 
     constructor(
         private readonly hanjaDictionaryProvider: HanjaDictionaryProvider = new StaticHanjaDictionaryProvider()
@@ -27,6 +32,16 @@ export class TextInputManager {
         this.textEntryMode = mode;
 
         this.syncControllerMode();
+    }
+
+    /**
+     * Set the configured Han/Yong toggle key (null when turned off). Stored so it
+     * applies to controllers created later (on focus change) and forwarded to the
+     * live controller so a rebind takes effect immediately.
+     */
+    public setToggleKeyBinding(binding: KeyBinding | null) {
+        this.toggleKeyBinding = binding;
+        this.imeController?.setToggleKeyBinding(binding);
     }
 
     public setActiveElement(element: EventTarget | null): SupportedCompositionFeatures | undefined {
@@ -103,6 +118,7 @@ export class TextInputManager {
             }
             this.targetElement = element;
             this.imeController = new HangulImeController(element, compositionAdapter, this.hanjaDictionaryProvider);
+            this.imeController.setToggleKeyBinding(this.toggleKeyBinding);
         }
 
         this.syncControllerMode();

--- a/src/keyboard/korean-keyboard-map.ts
+++ b/src/keyboard/korean-keyboard-map.ts
@@ -100,6 +100,35 @@ export function isAltKey(code: KeyCode): code is KeyCode.AltLeft | KeyCode.AltRi
     return [KeyCode.AltLeft, KeyCode.AltRight].includes(code);
 }
 
+/**
+ * Whether the modifier flag corresponding to a (modifier) key `code` is currently
+ * held, per the event's live modifier state. Maps each side's Alt/Control/Meta/Shift
+ * key to its `*Key` flag. Returns false for any non-modifier code. Used to tell
+ * whether a specific physical modifier — e.g. the configured Han/Yong toggle key —
+ * is still down, which `event.code` alone (the key being pressed now) can't answer.
+ */
+export function isModifierKeyActive(
+    event: { ctrlKey: boolean; altKey: boolean; shiftKey: boolean; metaKey: boolean },
+    code: KeyCode
+): boolean {
+    switch (code) {
+        case KeyCode.AltLeft:
+        case KeyCode.AltRight:
+            return event.altKey;
+        case KeyCode.ControlLeft:
+        case KeyCode.ControlRight:
+            return event.ctrlKey;
+        case KeyCode.MetaLeft:
+        case KeyCode.MetaRight:
+            return event.metaKey;
+        case KeyCode.ShiftLeft:
+        case KeyCode.ShiftRight:
+            return event.shiftKey;
+        default:
+            return false;
+    }
+}
+
 export const keyMap: Record<KeyCode, KeyRecord> = {
     [KeyCode.KeyQ]: {
         normal: "q",


### PR DESCRIPTION
Closes #191

Two related changes so the configured Han/Yong toggle key and real shortcut modifiers don't get confused in Hangul mode:

- **Part 1** — `Cmd`+letter (macOS) now passes through to the browser like `Ctrl`+letter already does, so `Cmd+C` performs the shortcut instead of inserting a jamo.
- **Part 2** — when the configured (modifier-only) toggle key is *held*, it's treated as the IME key, not a modifier: the letter is typed (inactive) or composed (active) rather than read as a Cmd/Ctrl shortcut. Generalizes the previously Alt-only handling to whichever key is bound (e.g. Right Command on macOS), with the binding plumbed into the controller.