### PR TITLE
Modularize design-system styles for injected overlays

### DIFF
--- a/src/composition/hanja/hanja-candidate-window.scss
+++ b/src/composition/hanja/hanja-candidate-window.scss
@@ -1,16 +1,12 @@
-#hanja-candidate-window-27c8a11a-b4d6-4388-9928-2d578bbb1fc {
-    --candidate-item-height: 44px;
-    --candidates-per-page: 9;
-    --text-primary: light-dark(#1a1a1a, #e5e5e5);
-    --description-color: light-dark(#666, #999);
-    --field-bg: light-dark(white, #141414);
-    --section-bg: light-dark(#f9f9f9, #1e1e1e);
-    --section-border: light-dark(#ddd, #333);
-    --button-hover-bg: light-dark(#f1f5f9, #292929);
-    --accent-subtle-bg: light-dark(#f3edff, #2b1340);
-    --radius-sm: 6px;
-    --dropdown-shadow: light-dark(0 6px 18px rgba(0, 0, 0, 0.18), 0 8px 22px rgba(0, 0, 0, 0.5));
+// Shared design tokens, scoped to this overlay's unique root only. Including the
+// token mixin (rather than copying values) keeps a single source of truth with
+// the page surfaces while leaking nothing into the host page. It must come
+// *after* the `all: unset` reset below: `all` clears `color-scheme` (which the
+// mixin sets, and which light-dark() needs) back to initial, but it leaves
+// custom properties alone.
+@use "../../styles/design-tokens";
 
+#hanja-candidate-window-27c8a11a-b4d6-4388-9928-2d578bbb1fc {
     &,
     * {
         all: unset;
@@ -18,9 +14,15 @@
         user-select: none;
     }
 
+    @include design-tokens.design-token-vars;
+
+    /* Overlay-local tokens (not part of the shared page-surface set). */
+    --candidate-item-height: 44px;
+    --candidates-per-page: 9;
+    --dropdown-shadow: light-dark(0 6px 18px rgba(0, 0, 0, 0.18), 0 8px 22px rgba(0, 0, 0, 0.5));
+
     position: fixed;
     z-index: 2147483647;
-    color-scheme: light dark;
     display: inline-flex;
     flex-direction: column;
     max-width: calc(100vw - 8px);

--- a/src/options-app/options-app.ts
+++ b/src/options-app/options-app.ts
@@ -1,5 +1,5 @@
 import { createApp } from "vue";
-import "../styles/design-system.css";
+import "../styles/design-system.scss";
 import { gettingStartedView } from "../getting-started-route";
 import GettingStartedPage from "./GettingStartedPage.vue";
 import OptionsPage from "./options-page.vue";

--- a/src/options-app/options-page.vue
+++ b/src/options-app/options-page.vue
@@ -17,7 +17,7 @@ onMounted(initSettings);
 </template>
 
 <!-- Design tokens, base typography and the .label / .description utility text
-     are shared in src/styles/design-system.css (imported in options-app.ts).
+     are shared in src/styles/design-system.scss (imported in options-app.ts).
      This file keeps only the options-app layout. The section card and heading
      rules are element selectors so the child-component <section>s and the
      getting-started page pick them up too. -->

--- a/src/service-worker/popup-converter/popup-converter.html
+++ b/src/service-worker/popup-converter/popup-converter.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8" />
         <meta name="google" value="notranslate" />
         <title data-message="romanize_popup_title"></title>
-        <link type="text/css" rel="stylesheet" href="popup-converter.css" />
+        <link type="text/css" rel="stylesheet" href="popup-converter.scss" />
     </head>
     <body>
         <main class="popup-shell">

--- a/src/service-worker/popup-converter/popup-converter.scss
+++ b/src/service-worker/popup-converter/popup-converter.scss
@@ -1,7 +1,8 @@
-/* Design tokens, base typography and the shared control primitives
-   (.ds-btn, .ds-icon-btn, .ds-circle-btn, .ds-pill, .ds-field, .visually-hidden,
-   the focus ring) all live here. This file keeps only popup-specific layout. */
-@import "../../styles/design-system.css";
+// Pull in the page-surface design system: :root tokens, base typography and the
+// shared control primitives (.ds-btn, .ds-icon-btn, .ds-circle-btn, .ds-pill,
+// .ds-field, .visually-hidden, the focus ring). This file keeps only
+// popup-specific layout.
+@use "../../styles/design-system";
 
 html,
 body {

--- a/src/styles/_control-primitives.scss
+++ b/src/styles/_control-primitives.scss
@@ -1,66 +1,13 @@
-/* Shared design system for the extension's own page surfaces: the romanization
-   popup (src/service-worker/popup-converter/) and the Vue options /
-   getting-started pages (src/options-app/). One obvious place for design tokens
-   and the reusable control primitives both surfaces draw on.
-
-   NOT a consumer: the on-screen keyboard (src/content-script/on-screen-keyboard/).
-   It injects into arbitrary web pages under an `all: unset` reset and keeps its
-   own self-contained palette, so these page-level :root tokens can't reach it. */
-
-:root {
-    color-scheme: light dark;
-
-    /* Foreground / background / surface */
-    --bg-primary: light-dark(white, black);
-    --text-primary: light-dark(#1a1a1a, #e5e5e5);
-    --description-color: light-dark(#666, #999);
-    --section-bg: light-dark(#f9f9f9, #1e1e1e);
-    --section-border: light-dark(#ddd, #333);
-
-    /* Fields */
-    --field-bg: light-dark(white, #141414);
-    --field-readonly-bg: light-dark(#f3f4f6, #181818);
-    --placeholder-color: light-dark(#777, #888);
-    --label-font-size: 1.1em;
-    --checkbox-size: var(--label-font-size);
-
-    /* Accent / toggle / subtle states. The accent is the logo's violet
-       (icon_h.svg: #5a2d82→#2b1340, with a #dcbfff glyph), brightened in dark
-       mode the way the rest of the palette is. --accent-on is the ink for
-       text/icons sitting on a filled accent: white reads on the light-mode
-       violet, but the lighter dark-mode violet needs dark ink (the logo's deep
-       aubergine) to stay legible. */
-    --toggle-off-bg: light-dark(#ccc, #555);
-    --toggle-on-bg: light-dark(#6d28d9, #a78bfa);
-    --accent-on: light-dark(white, #2b1340);
-    --accent-subtle-bg: light-dark(#f3edff, #2b1340);
-    --button-hover-bg: light-dark(#f1f5f9, #292929);
-    --success-color: light-dark(#168a45, #63d38a);
-    --error-color: light-dark(#c0392b, #f87171);
-
-    /* Notice / error banners (were inline light-dark() literals in
-       GettingStartedPage). */
-    --notice-text: light-dark(#243b1e, #d7f5cb);
-    --notice-bg: light-dark(#edf8e8, #1f3219);
-    --notice-border: light-dark(#b9daa8, #476b38);
-    --error-banner-text: light-dark(#6b1f1f, #ffdede);
-    --error-banner-bg: light-dark(#fff0f0, #3a1717);
-    --error-banner-border: light-dark(#e3aaaa, #8a3b3b);
-
-    /* Shape / focus */
-    --radius: 8px;
-    --radius-sm: 6px;
-    --focus-ring-width: 2px;
-    /* Tight ring by default (offset 0). The ring colour is its own lever,
-       decoupled from the accent fill: --focus-ring-color defaults to the accent
-       but can be retoned without touching the fills. Filled-accent controls
-       (primary button, checked checkbox, toggle-on, selected card) would merge a
-       same-colour ring into the fill, so those alone stand it off by
-       --focus-ring-offset-filled — the one place we break the tight ring. */
-    --focus-ring-offset: 0;
-    --focus-ring-offset-filled: 3px;
-    --focus-ring-color: var(--toggle-on-bg);
-}
+// Base typography and the reusable control primitives (.ds-btn, .ds-icon-btn,
+// .ds-circle-btn, .ds-pill, .ds-field, .ds-checkbox, focus ring, utilities) that
+// the extension's *own* page surfaces draw on — the Vue options /
+// getting-started app and the romanize popup.
+//
+// These are deliberately kept out of the token layer so injected content-script
+// overlays can pull in the design tokens (see _design-tokens.scss) without also
+// inheriting global `body` typography or `.ds-*` component rules, which would
+// leak into arbitrary host pages. They assume the design tokens are present on
+// an ancestor (the page entry puts them on `:root` — see design-system.scss).
 
 /* Base typography shared by both page contexts. Surface-specific layout (the
    popup's grid shell, the options page's centred column) stays local. */

--- a/src/styles/_design-tokens.scss
+++ b/src/styles/_design-tokens.scss
@@ -1,0 +1,69 @@
+// Single source of truth for the design system's custom properties (tokens).
+//
+// Exposed as a mixin rather than a fixed `:root {}` block so the same token
+// declarations can be dropped under *any* selector:
+//
+//   - extension page surfaces include them on `:root` (see design-system.scss),
+//   - content-script overlays that inject into arbitrary host pages include them
+//     under their own unique root id so nothing leaks into the host page.
+//
+// `color-scheme` is part of the token set because the light-dark() values below
+// only resolve when the element they're declared on (or an ancestor) opts into
+// both schemes. Overlays under `all: unset` must therefore include this mixin
+// *after* their reset so the `all: unset` doesn't clear `color-scheme` back to
+// its initial value (custom properties survive `all`, but `color-scheme` does
+// not).
+@mixin design-token-vars {
+    color-scheme: light dark;
+
+    /* Foreground / background / surface */
+    --bg-primary: light-dark(white, black);
+    --text-primary: light-dark(#1a1a1a, #e5e5e5);
+    --description-color: light-dark(#666, #999);
+    --section-bg: light-dark(#f9f9f9, #1e1e1e);
+    --section-border: light-dark(#ddd, #333);
+
+    /* Fields */
+    --field-bg: light-dark(white, #141414);
+    --field-readonly-bg: light-dark(#f3f4f6, #181818);
+    --placeholder-color: light-dark(#777, #888);
+    --label-font-size: 1.1em;
+    --checkbox-size: var(--label-font-size);
+
+    /* Accent / toggle / subtle states. The accent is the logo's violet
+       (icon_h.svg: #5a2d82→#2b1340, with a #dcbfff glyph), brightened in dark
+       mode the way the rest of the palette is. --accent-on is the ink for
+       text/icons sitting on a filled accent: white reads on the light-mode
+       violet, but the lighter dark-mode violet needs dark ink (the logo's deep
+       aubergine) to stay legible. */
+    --toggle-off-bg: light-dark(#ccc, #555);
+    --toggle-on-bg: light-dark(#6d28d9, #a78bfa);
+    --accent-on: light-dark(white, #2b1340);
+    --accent-subtle-bg: light-dark(#f3edff, #2b1340);
+    --button-hover-bg: light-dark(#f1f5f9, #292929);
+    --success-color: light-dark(#168a45, #63d38a);
+    --error-color: light-dark(#c0392b, #f87171);
+
+    /* Notice / error banners (were inline light-dark() literals in
+       GettingStartedPage). */
+    --notice-text: light-dark(#243b1e, #d7f5cb);
+    --notice-bg: light-dark(#edf8e8, #1f3219);
+    --notice-border: light-dark(#b9daa8, #476b38);
+    --error-banner-text: light-dark(#6b1f1f, #ffdede);
+    --error-banner-bg: light-dark(#fff0f0, #3a1717);
+    --error-banner-border: light-dark(#e3aaaa, #8a3b3b);
+
+    /* Shape / focus */
+    --radius: 8px;
+    --radius-sm: 6px;
+    --focus-ring-width: 2px;
+    /* Tight ring by default (offset 0). The ring colour is its own lever,
+       decoupled from the accent fill: --focus-ring-color defaults to the accent
+       but can be retoned without touching the fills. Filled-accent controls
+       (primary button, checked checkbox, toggle-on, selected card) would merge a
+       same-colour ring into the fill, so those alone stand it off by
+       --focus-ring-offset-filled — the one place we break the tight ring. */
+    --focus-ring-offset: 0;
+    --focus-ring-offset-filled: 3px;
+    --focus-ring-color: var(--toggle-on-bg);
+}

--- a/src/styles/design-system.scss
+++ b/src/styles/design-system.scss
@@ -1,0 +1,23 @@
+// Page-surface entry for the extension's own UI: the Vue options /
+// getting-started app (imported from src/options-app/options-app.ts) and the
+// romanize popup (used by src/service-worker/popup-converter/popup-converter.scss).
+//
+// It wires the shared design tokens onto `:root` and pulls in base typography
+// plus the reusable control primitives. Both layers live in their own partials
+// so injected content-script overlays can reuse the *tokens* alone — under their
+// own isolated root — without dragging global `:root`, `body`, or `.ds-*` rules
+// into arbitrary host pages:
+//   - tokens:     _design-tokens.scss      (the design-token-vars mixin)
+//   - primitives: _control-primitives.scss (body + .ds-* + utilities)
+//
+// NOT a consumer: the on-screen keyboard
+// (src/content-script/on-screen-keyboard/). It injects into arbitrary web pages
+// under an `all: unset` reset and intentionally keeps its own self-contained
+// palette, so these page-level :root tokens can't (and shouldn't) reach it.
+
+@use "design-tokens";
+@use "control-primitives";
+
+:root {
+    @include design-tokens.design-token-vars;
+}


### PR DESCRIPTION
Closes #189

Splits the design system into a Sass structure (`_design-tokens.scss` mixin, `_control-primitives.scss`, `design-system.scss` entry) so the tokens have a single source of truth that can be included on `:root` for extension pages/popups or under an isolated overlay root for content-script UI — without leaking global `:root`/`body`/`.ds-*` rules into host pages. The Hanja candidate window now `@include`s the token mixin instead of hand-copying token values; the OSK stays self-contained.