### PR TITLE
Add Hanja options behind feature flag

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -157,6 +157,49 @@
     "options_hanYong_hint": {
         "message": "Switches between Hangul and Latin input."
     },
+    "options_hanja_heading": {
+        "message": "Hanja conversion"
+    },
+    "options_hanja_hint": {
+        "message": "Converts Hangul syllables to Hanja candidates."
+    },
+    "options_hanja_disabled_hint": {
+        "message": "When off, the Hanja conversion key does nothing."
+    },
+    "options_hanja_conversionKey_label": {
+        "message": "Conversion key"
+    },
+    "options_hanja_conversionKey_description": {
+        "message": "The key or combination that opens Hanja candidates. The default is Right Option on Mac and Right Ctrl elsewhere, and it is saved on this computer only."
+    },
+    "options_hanja_showSimplified_label": {
+        "message": "Show Simplified Chinese"
+    },
+    "options_hanja_showSimplified_description": {
+        "message": "Show the Simplified Chinese form beside each Hanja candidate when available."
+    },
+    "options_hanja_showPinyin_label": {
+        "message": "Show Pinyin"
+    },
+    "options_hanja_showPinyin_description": {
+        "message": "Show Mandarin pinyin beside each Hanja candidate when available."
+    },
+    "options_keyBinding_hanYongUnbound": {
+        "message": "$key$ was unbound from the Han/Yong toggle key.",
+        "placeholders": {
+            "key": {
+                "content": "$1"
+            }
+        }
+    },
+    "options_keyBinding_hanjaUnbound": {
+        "message": "$key$ was unbound from the Hanja conversion key.",
+        "placeholders": {
+            "key": {
+                "content": "$1"
+            }
+        }
+    },
     "options_persistence_label": {
         "message": "When the browser starts"
     },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -124,28 +124,28 @@
     "options_hanYong_toggleKey_change": {
         "message": "Change"
     },
-    "options_hanYong_toggleKey_capturing": {
+    "options_keyBinding_capturing": {
         "message": "Press a key…"
     },
-    "options_hanYong_toggleKey_hint": {
+    "options_keyBinding_hint": {
         "message": "Press your key or combination. A normal key must be combined with Ctrl or Alt. Press Esc to cancel."
     },
-    "options_hanYong_toggleKey_hint_mac": {
+    "options_keyBinding_hint_mac": {
         "message": "Press your key or combination. On Mac, Command, Control, or Option can be used by itself. A normal key must include Control or Option; Command may be added. Press Esc to cancel."
     },
-    "options_hanYong_toggleKey_turnOff": {
+    "options_keyBinding_turnOff": {
         "message": "Turn off"
     },
-    "options_hanYong_toggleKey_reset": {
+    "options_keyBinding_reset": {
         "message": "Reset to default"
     },
-    "options_hanYong_toggleKey_off": {
+    "options_keyBinding_off": {
         "message": "Off"
     },
-    "options_hanYong_toggleKey_invalid": {
+    "options_keyBinding_invalid": {
         "message": "A normal key must be combined with Ctrl or Alt."
     },
-    "options_hanYong_toggleKey_invalid_mac": {
+    "options_keyBinding_invalid_mac": {
         "message": "Use Command, Control, or Option by itself, or include Control or Option with a normal key."
     },
     "options_hanYong_syncAcrossTabs_label": {

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -124,28 +124,28 @@
     "options_hanYong_toggleKey_change": {
         "message": "Cambiar"
     },
-    "options_hanYong_toggleKey_capturing": {
+    "options_keyBinding_capturing": {
         "message": "Pulse una tecla…"
     },
-    "options_hanYong_toggleKey_hint": {
+    "options_keyBinding_hint": {
         "message": "Pulse su tecla o combinación. Una tecla normal debe combinarse con Ctrl o Alt. Pulse Esc para cancelar."
     },
-    "options_hanYong_toggleKey_hint_mac": {
+    "options_keyBinding_hint_mac": {
         "message": "Pulse su tecla o combinación. En Mac, Comando, Control u Opción pueden usarse solas. Una tecla normal debe incluir Control u Opción; se puede añadir Comando. Pulse Esc para cancelar."
     },
-    "options_hanYong_toggleKey_turnOff": {
+    "options_keyBinding_turnOff": {
         "message": "Desactivar"
     },
-    "options_hanYong_toggleKey_reset": {
+    "options_keyBinding_reset": {
         "message": "Restablecer el valor predeterminado"
     },
-    "options_hanYong_toggleKey_off": {
+    "options_keyBinding_off": {
         "message": "Desactivado"
     },
-    "options_hanYong_toggleKey_invalid": {
+    "options_keyBinding_invalid": {
         "message": "Una tecla normal debe combinarse con Ctrl o Alt."
     },
-    "options_hanYong_toggleKey_invalid_mac": {
+    "options_keyBinding_invalid_mac": {
         "message": "Use Comando, Control u Opción solas, o incluya Control u Opción con una tecla normal."
     },
     "options_hanYong_syncAcrossTabs_label": {

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -157,6 +157,49 @@
     "options_hanYong_hint": {
         "message": "Alterna entre la entrada de hangul y la latina."
     },
+    "options_hanja_heading": {
+        "message": "Conversión a hanja"
+    },
+    "options_hanja_hint": {
+        "message": "Convierte sílabas hangul en candidatos hanja."
+    },
+    "options_hanja_disabled_hint": {
+        "message": "Cuando está desactivado, la tecla de conversión a hanja no hace nada."
+    },
+    "options_hanja_conversionKey_label": {
+        "message": "Tecla de conversión"
+    },
+    "options_hanja_conversionKey_description": {
+        "message": "La tecla o combinación que abre los candidatos hanja. El valor predeterminado es Opción derecha en Mac y Ctrl derecha en otros sistemas, y se guarda solo en este equipo."
+    },
+    "options_hanja_showSimplified_label": {
+        "message": "Mostrar chino simplificado"
+    },
+    "options_hanja_showSimplified_description": {
+        "message": "Muestra la forma en chino simplificado junto a cada candidato hanja cuando esté disponible."
+    },
+    "options_hanja_showPinyin_label": {
+        "message": "Mostrar pinyin"
+    },
+    "options_hanja_showPinyin_description": {
+        "message": "Muestra el pinyin mandarín junto a cada candidato hanja cuando esté disponible."
+    },
+    "options_keyBinding_hanYongUnbound": {
+        "message": "$key$ se desvinculó de la tecla de alternancia Han/Yong.",
+        "placeholders": {
+            "key": {
+                "content": "$1"
+            }
+        }
+    },
+    "options_keyBinding_hanjaUnbound": {
+        "message": "$key$ se desvinculó de la tecla de conversión a hanja.",
+        "placeholders": {
+            "key": {
+                "content": "$1"
+            }
+        }
+    },
     "options_persistence_label": {
         "message": "Al iniciar el navegador"
     },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -124,28 +124,28 @@
     "options_hanYong_toggleKey_change": {
         "message": "変更"
     },
-    "options_hanYong_toggleKey_capturing": {
+    "options_keyBinding_capturing": {
         "message": "キーを押してください…"
     },
-    "options_hanYong_toggleKey_hint": {
+    "options_keyBinding_hint": {
         "message": "使用するキーまたは組み合わせを押してください。通常のキーはCtrlまたはAltと組み合わせる必要があります。キャンセルするにはEscを押してください。"
     },
-    "options_hanYong_toggleKey_hint_mac": {
+    "options_keyBinding_hint_mac": {
         "message": "使用するキーまたは組み合わせを押してください。MacではCommand、Control、Optionを単独で使用できます。通常のキーにはControlまたはOptionを含める必要があり、Commandも追加できます。キャンセルするにはEscを押してください。"
     },
-    "options_hanYong_toggleKey_turnOff": {
+    "options_keyBinding_turnOff": {
         "message": "オフにする"
     },
-    "options_hanYong_toggleKey_reset": {
+    "options_keyBinding_reset": {
         "message": "既定値にリセット"
     },
-    "options_hanYong_toggleKey_off": {
+    "options_keyBinding_off": {
         "message": "オフ"
     },
-    "options_hanYong_toggleKey_invalid": {
+    "options_keyBinding_invalid": {
         "message": "通常のキーはCtrlまたはAltと組み合わせる必要があります。"
     },
-    "options_hanYong_toggleKey_invalid_mac": {
+    "options_keyBinding_invalid_mac": {
         "message": "Command、Control、Optionは単独で使用するか、通常のキーにはControlまたはOptionを含めてください。"
     },
     "options_hanYong_syncAcrossTabs_label": {

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -157,6 +157,49 @@
     "options_hanYong_hint": {
         "message": "ハングル入力とラテン文字入力を切り替えます。"
     },
+    "options_hanja_heading": {
+        "message": "漢字変換"
+    },
+    "options_hanja_hint": {
+        "message": "ハングル音節を漢字候補に変換します。"
+    },
+    "options_hanja_disabled_hint": {
+        "message": "オフにすると、漢字変換キーは何も動作しません。"
+    },
+    "options_hanja_conversionKey_label": {
+        "message": "変換キー"
+    },
+    "options_hanja_conversionKey_description": {
+        "message": "漢字候補を開くキーまたは組み合わせです。既定値はMacでは右Option、それ以外では右Ctrlで、このコンピューターにのみ保存されます。"
+    },
+    "options_hanja_showSimplified_label": {
+        "message": "簡体字を表示"
+    },
+    "options_hanja_showSimplified_description": {
+        "message": "利用できる場合、各漢字候補の横に中国語の簡体字を表示します。"
+    },
+    "options_hanja_showPinyin_label": {
+        "message": "ピンインを表示"
+    },
+    "options_hanja_showPinyin_description": {
+        "message": "利用できる場合、各漢字候補の横に中国語のピンインを表示します。"
+    },
+    "options_keyBinding_hanYongUnbound": {
+        "message": "$key$ は한/영切り替えキーから解除されました。",
+        "placeholders": {
+            "key": {
+                "content": "$1"
+            }
+        }
+    },
+    "options_keyBinding_hanjaUnbound": {
+        "message": "$key$ は漢字変換キーから解除されました。",
+        "placeholders": {
+            "key": {
+                "content": "$1"
+            }
+        }
+    },
     "options_persistence_label": {
         "message": "ブラウザの起動時"
     },

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -124,28 +124,28 @@
     "options_hanYong_toggleKey_change": {
         "message": "변경"
     },
-    "options_hanYong_toggleKey_capturing": {
+    "options_keyBinding_capturing": {
         "message": "키를 누르세요…"
     },
-    "options_hanYong_toggleKey_hint": {
+    "options_keyBinding_hint": {
         "message": "사용할 키 또는 조합을 누르세요. 일반 키는 Ctrl 또는 Alt와 함께 사용해야 합니다. 취소하려면 Esc를 누르세요."
     },
-    "options_hanYong_toggleKey_hint_mac": {
+    "options_keyBinding_hint_mac": {
         "message": "사용할 키 또는 조합을 누르세요. Mac에서는 Command, Control, Option을 단독으로 사용할 수 있습니다. 일반 키에는 Control 또는 Option이 포함되어야 하며 Command를 추가할 수 있습니다. 취소하려면 Esc를 누르세요."
     },
-    "options_hanYong_toggleKey_turnOff": {
+    "options_keyBinding_turnOff": {
         "message": "끄기"
     },
-    "options_hanYong_toggleKey_reset": {
+    "options_keyBinding_reset": {
         "message": "기본값으로 재설정"
     },
-    "options_hanYong_toggleKey_off": {
+    "options_keyBinding_off": {
         "message": "꺼짐"
     },
-    "options_hanYong_toggleKey_invalid": {
+    "options_keyBinding_invalid": {
         "message": "일반 키는 Ctrl 또는 Alt와 함께 사용해야 합니다."
     },
-    "options_hanYong_toggleKey_invalid_mac": {
+    "options_keyBinding_invalid_mac": {
         "message": "Command, Control, Option은 단독으로 사용하거나, 일반 키와 함께 Control 또는 Option을 포함해야 합니다."
     },
     "options_hanYong_syncAcrossTabs_label": {

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -157,6 +157,49 @@
     "options_hanYong_hint": {
         "message": "한글과 로마자 입력을 전환합니다."
     },
+    "options_hanja_heading": {
+        "message": "한자 변환"
+    },
+    "options_hanja_hint": {
+        "message": "한글 음절을 한자 후보로 변환합니다."
+    },
+    "options_hanja_disabled_hint": {
+        "message": "끄면 한자 변환 키가 동작하지 않습니다."
+    },
+    "options_hanja_conversionKey_label": {
+        "message": "변환 키"
+    },
+    "options_hanja_conversionKey_description": {
+        "message": "한자 후보를 여는 키 또는 조합입니다. 기본값은 Mac에서는 오른쪽 Option, 그 외에서는 오른쪽 Ctrl이며, 이 컴퓨터에만 저장됩니다."
+    },
+    "options_hanja_showSimplified_label": {
+        "message": "간체자 표시"
+    },
+    "options_hanja_showSimplified_description": {
+        "message": "가능한 경우 각 한자 후보 옆에 중국어 간체자를 표시합니다."
+    },
+    "options_hanja_showPinyin_label": {
+        "message": "병음 표시"
+    },
+    "options_hanja_showPinyin_description": {
+        "message": "가능한 경우 각 한자 후보 옆에 중국어 병음을 표시합니다."
+    },
+    "options_keyBinding_hanYongUnbound": {
+        "message": "$key$이(가) 한/영 전환 키에서 해제되었습니다.",
+        "placeholders": {
+            "key": {
+                "content": "$1"
+            }
+        }
+    },
+    "options_keyBinding_hanjaUnbound": {
+        "message": "$key$이(가) 한자 변환 키에서 해제되었습니다.",
+        "placeholders": {
+            "key": {
+                "content": "$1"
+            }
+        }
+    },
     "options_persistence_label": {
         "message": "브라우저를 시작할 때"
     },

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -157,6 +157,49 @@
     "options_hanYong_hint": {
         "message": "Alterna entre a entrada em hangul e a latina."
     },
+    "options_hanja_heading": {
+        "message": "Conversão para hanja"
+    },
+    "options_hanja_hint": {
+        "message": "Converte sílabas hangul em candidatos hanja."
+    },
+    "options_hanja_disabled_hint": {
+        "message": "Quando desativada, a tecla de conversão para hanja não faz nada."
+    },
+    "options_hanja_conversionKey_label": {
+        "message": "Tecla de conversão"
+    },
+    "options_hanja_conversionKey_description": {
+        "message": "A tecla ou combinação que abre os candidatos hanja. A tecla padrão é Option direito no Mac e Ctrl direito nos outros sistemas. Essa configuração é salva apenas neste computador."
+    },
+    "options_hanja_showSimplified_label": {
+        "message": "Mostrar chinês simplificado"
+    },
+    "options_hanja_showSimplified_description": {
+        "message": "Mostra a forma em chinês simplificado ao lado de cada candidato hanja quando disponível."
+    },
+    "options_hanja_showPinyin_label": {
+        "message": "Mostrar pinyin"
+    },
+    "options_hanja_showPinyin_description": {
+        "message": "Mostra o pinyin mandarim ao lado de cada candidato hanja quando disponível."
+    },
+    "options_keyBinding_hanYongUnbound": {
+        "message": "$key$ foi desvinculado da tecla de alternância Han/Yong.",
+        "placeholders": {
+            "key": {
+                "content": "$1"
+            }
+        }
+    },
+    "options_keyBinding_hanjaUnbound": {
+        "message": "$key$ foi desvinculado da tecla de conversão para hanja.",
+        "placeholders": {
+            "key": {
+                "content": "$1"
+            }
+        }
+    },
     "options_persistence_label": {
         "message": "Ao iniciar o navegador"
     },

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -124,28 +124,28 @@
     "options_hanYong_toggleKey_change": {
         "message": "Alterar"
     },
-    "options_hanYong_toggleKey_capturing": {
+    "options_keyBinding_capturing": {
         "message": "Pressione uma tecla…"
     },
-    "options_hanYong_toggleKey_hint": {
+    "options_keyBinding_hint": {
         "message": "Pressione sua tecla ou combinação. Uma tecla normal deve ser combinada com Ctrl ou Alt. Pressione Esc para cancelar."
     },
-    "options_hanYong_toggleKey_hint_mac": {
+    "options_keyBinding_hint_mac": {
         "message": "Pressione sua tecla ou combinação. No Mac, Command, Control ou Option podem ser usados isoladamente. Uma tecla normal deve incluir Control ou Option; Command pode ser adicionado. Pressione Esc para cancelar."
     },
-    "options_hanYong_toggleKey_turnOff": {
+    "options_keyBinding_turnOff": {
         "message": "Desativar"
     },
-    "options_hanYong_toggleKey_reset": {
+    "options_keyBinding_reset": {
         "message": "Redefinir para o padrão"
     },
-    "options_hanYong_toggleKey_off": {
+    "options_keyBinding_off": {
         "message": "Desativado"
     },
-    "options_hanYong_toggleKey_invalid": {
+    "options_keyBinding_invalid": {
         "message": "Uma tecla normal deve ser combinada com Ctrl ou Alt."
     },
-    "options_hanYong_toggleKey_invalid_mac": {
+    "options_keyBinding_invalid_mac": {
         "message": "Use Command, Control ou Option isoladamente, ou inclua Control ou Option com uma tecla normal."
     },
     "options_hanYong_syncAcrossTabs_label": {

--- a/src/_locales/pt_PT/messages.json
+++ b/src/_locales/pt_PT/messages.json
@@ -26,13 +26,13 @@
     "options_hanYong_toggleKey_description": {
         "message": "A tecla ou combinação que alterna entre hangul e inglês. A tecla predefinida é Command direito no Mac e Alt direito nos outros sistemas. Esta configuração é guardada apenas neste computador."
     },
-    "options_hanYong_toggleKey_hint_mac": {
+    "options_keyBinding_hint_mac": {
         "message": "Prima a sua tecla ou combinação. No Mac, Command, Control ou Option podem ser usados isoladamente. Uma tecla normal deve incluir Control ou Option; Command pode ser adicionado. Prima Esc para cancelar."
     },
-    "options_hanYong_toggleKey_invalid_mac": {
+    "options_keyBinding_invalid_mac": {
         "message": "Use Command, Control ou Option isoladamente, ou inclua Control ou Option com uma tecla normal."
     },
-    "options_hanYong_toggleKey_reset": {
+    "options_keyBinding_reset": {
         "message": "Repor a predefinição"
     },
     "options_hanYong_syncAcrossTabs_label": {

--- a/src/composition/hangul-ime-controller.test.ts
+++ b/src/composition/hangul-ime-controller.test.ts
@@ -1,4 +1,4 @@
-import { HangulImeController } from "./hangul-ime-controller";
+import { HangulImeController, HanjaImeOptions } from "./hangul-ime-controller";
 import { InputAdapter } from "./composition-adapters/input-adapter";
 import { ContentEditableAdapter } from "./composition-adapters/content-editable-adapter";
 import { KeyCode } from "../keyboard/korean-keyboard-map";
@@ -21,8 +21,12 @@ function dispatchKeydown(target: EventTarget, code: string, key: string): Keyboa
 // Track every controller and dispose them all after each test to keep tests
 // isolated.
 const liveControllers: HangulImeController[] = [];
-function makeController(element: HTMLElement, hanjaDictionaryProvider?: HanjaDictionaryProvider): HangulImeController {
-    const controller = new HangulImeController(element, undefined, hanjaDictionaryProvider);
+function makeController(
+    element: HTMLElement,
+    hanjaDictionaryProvider?: HanjaDictionaryProvider,
+    hanjaOptions?: Partial<HanjaImeOptions>
+): HangulImeController {
+    const controller = new HangulImeController(element, undefined, hanjaDictionaryProvider, hanjaOptions);
     liveControllers.push(controller);
     return controller;
 }
@@ -597,7 +601,7 @@ describe("HangulImeController Hanja candidate selection (KIME_ENABLE_HANJA)", ()
 
     // Drive composition state in jsdom by stubbing the adapter's DOM mutations, then
     // type the jamo for a syllable so the compositor is genuinely mid-composition.
-    function composingController() {
+    function composingController(hanjaOptions?: Partial<HanjaImeOptions>) {
         jest.spyOn(InputAdapter.prototype, "beginComposition").mockImplementation(() => {});
         jest.spyOn(InputAdapter.prototype, "updateComposition").mockImplementation(() => {});
         const endComposition = jest.spyOn(InputAdapter.prototype, "endComposition").mockImplementation(() => {});
@@ -607,7 +611,7 @@ describe("HangulImeController Hanja candidate selection (KIME_ENABLE_HANJA)", ()
         const inputCharacter = jest.spyOn(InputAdapter.prototype, "inputCharacter").mockImplementation(() => {});
 
         const element = document.createElement("textarea");
-        const controller = makeController(element);
+        const controller = makeController(element, undefined, hanjaOptions);
         controller.activate();
         return { element, endComposition, deleteContentBackwards, inputCharacter };
     }
@@ -971,6 +975,42 @@ describe("HangulImeController Hanja candidate selection (KIME_ENABLE_HANJA)", ()
 
         expect(candidateTexts()).toEqual(["1韓", "2寒", "3恨"]);
         expect(option.defaultPrevented).toBe(true);
+    });
+
+    it("does not open candidates when Hanja conversion is disabled", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element, endComposition } = composingController({ enabled: false });
+        composeHan(element);
+
+        const ctrl = pressRightCtrl(element);
+        await settleHanjaLookup();
+
+        expect(endComposition).not.toHaveBeenCalledWith("한");
+        expect(document.querySelector(HANJA_CANDIDATE_WINDOW_SELECTOR)).toBeNull();
+        expect(ctrl.defaultPrevented).toBe(false);
+    });
+
+    it("uses a configured Hanja key binding", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element } = composingController({
+            keyBinding: { code: KeyCode.KeyH, ctrl: false, alt: true, shift: false, meta: false },
+        });
+        composeHan(element);
+
+        const rightCtrl = pressRightCtrl(element);
+        const altH = new KeyboardEvent("keydown", {
+            code: "KeyH",
+            key: "h",
+            altKey: true,
+            bubbles: true,
+            cancelable: true,
+        });
+        element.dispatchEvent(altH);
+        await settleHanjaLookup();
+
+        expect(rightCtrl.defaultPrevented).toBe(false);
+        expect(candidateTexts()).toEqual(["1韓", "2寒", "3恨"]);
+        expect(altH.defaultPrevented).toBe(true);
     });
 
     it("does nothing when the flag is off (Right-Ctrl is just a modifier)", () => {

--- a/src/composition/hangul-ime-controller.ts
+++ b/src/composition/hangul-ime-controller.ts
@@ -1,16 +1,25 @@
 ﻿import { isKimeEvent } from "../messaging/dom-events";
 import { isModifierKey, isModifierKeyActive, KeyCode, keyMap } from "../keyboard/korean-keyboard-map";
-import { KeyBinding, defaultToggleKeyBindingForPlatform, isModifierOnlyBinding } from "../keyboard/key-binding";
+import {
+    KeyBinding,
+    defaultToggleKeyBindingForPlatform,
+    isModifierOnlyBinding,
+    matchesKeyBinding,
+} from "../keyboard/key-binding";
 import { HangulCompositor } from "./hangul-compositor";
 import { CompositionAdapterFactory } from "./composition-adapter-factory";
 import { CompositionAdapter } from "./composition-adapters/composition-adapter";
 import { HanjaCandidatePager } from "./hanja/hanja-candidate-pager";
-import { HanjaCandidateWindow, HanjaCandidateWindowPage } from "./hanja/hanja-candidate-window";
+import {
+    HanjaCandidateDisplayOptions,
+    HanjaCandidateWindow,
+    HanjaCandidateWindowPage,
+} from "./hanja/hanja-candidate-window";
 import { HanjaCompositionOverlay } from "./hanja/hanja-composition-overlay";
 import { commitHanjaCandidate, getHanjaConversionTarget, HanjaConversionTarget } from "./hanja/hanja-converter";
 import { HanjaCandidate } from "./hanja/hanja-candidate";
 import { HanjaDictionaryProvider, StaticHanjaDictionaryProvider } from "./hanja/hanja-dictionary-provider";
-import { isDefaultHanjaKey } from "./hanja/hanja-key";
+import { defaultHanjaKeyBindingForPlatform } from "./hanja/hanja-key";
 
 type HanjaCandidateSelection = {
     target: HanjaConversionTarget;
@@ -18,6 +27,22 @@ type HanjaCandidateSelection = {
     overlay: HanjaCompositionOverlay;
     window: HanjaCandidateWindow;
 };
+
+export type HanjaImeOptions = {
+    enabled: boolean;
+    keyBinding: KeyBinding | null;
+    showSimplified: boolean;
+    showPinyin: boolean;
+};
+
+function defaultHanjaImeOptions(): HanjaImeOptions {
+    return {
+        enabled: true,
+        keyBinding: defaultHanjaKeyBindingForPlatform(),
+        showSimplified: true,
+        showPinyin: true,
+    };
+}
 
 /**
  * Controls the Hangul IME for a given element.
@@ -29,6 +54,7 @@ export class HangulImeController {
     private compositionAdapter: CompositionAdapter;
     private hanjaCandidateSelection?: HanjaCandidateSelection;
     private hanjaLookupGeneration = 0;
+    private hanjaOptions: HanjaImeOptions;
 
     private changeListeners: (() => void)[] = [];
     private eventListeners: {
@@ -53,13 +79,15 @@ export class HangulImeController {
     constructor(
         private readonly element: HTMLElement,
         compositionAdapter = CompositionAdapterFactory.createCompositionAdapter(element),
-        private readonly hanjaDictionaryProvider: HanjaDictionaryProvider = new StaticHanjaDictionaryProvider()
+        private readonly hanjaDictionaryProvider: HanjaDictionaryProvider = new StaticHanjaDictionaryProvider(),
+        hanjaOptions: Partial<HanjaImeOptions> = {}
     ) {
         if (!compositionAdapter) {
             throw new Error("Could not create composition adapter for element");
         }
 
         this.compositionAdapter = compositionAdapter;
+        this.hanjaOptions = { ...defaultHanjaImeOptions(), ...hanjaOptions };
 
         // Backspace during composition must be intercepted in the *capture* phase, on
         // window (the earliest point in event propagation). Rich editors like Word for
@@ -141,6 +169,25 @@ export class HangulImeController {
         this.toggleKeyBinding = binding;
     }
 
+    setHanjaOptions(options: Partial<HanjaImeOptions>) {
+        const previousDisplayOptions = this.hanjaCandidateDisplayOptions();
+        this.hanjaOptions = { ...this.hanjaOptions, ...options };
+
+        if (!this.hanjaOptions.enabled || !this.hanjaOptions.keyBinding) {
+            this.invalidateHanjaLookup();
+            this.closeHanjaCandidateSelection();
+            return;
+        }
+
+        const nextDisplayOptions = this.hanjaCandidateDisplayOptions();
+        if (
+            previousDisplayOptions.showSimplified !== nextDisplayOptions.showSimplified ||
+            previousDisplayOptions.showPinyin !== nextDisplayOptions.showPinyin
+        ) {
+            this.refreshHanjaCandidateWindow();
+        }
+    }
+
     private notifyOnEntry() {
         this.changeListeners.forEach((listener) => {
             try {
@@ -168,8 +215,12 @@ export class HangulImeController {
                 this.closeHanjaCandidateSelection();
             }
 
-            // Temporary scaffolding for Issues 150/181; graduates to Settings when the feature ships.
-            if (process.env.KIME_ENABLE_HANJA === "true" && isDefaultHanjaKey(event)) {
+            if (
+                process.env.KIME_ENABLE_HANJA === "true" &&
+                this.hanjaOptions.enabled &&
+                this.hanjaOptions.keyBinding &&
+                matchesKeyBinding(event, this.hanjaOptions.keyBinding)
+            ) {
                 if (this.startHanjaCandidateSelection(event)) {
                     return;
                 }
@@ -475,6 +526,7 @@ export class HangulImeController {
                 onNextPage: () => this.moveHanjaCandidatePage(1),
                 onMoveSelection: (delta) => this.moveHanjaCandidateSelection(delta),
                 onSelectCandidate: (visibleIndex) => this.commitVisibleHanjaCandidate(visibleIndex, KeyCode.Lang2),
+                displayOptions: this.hanjaCandidateDisplayOptions(),
             }),
         };
     }
@@ -543,7 +595,7 @@ export class HangulImeController {
         }
 
         selection.pager.moveSelection(delta);
-        selection.window.update(this.hanjaCandidatePage(selection.pager));
+        this.refreshHanjaCandidateWindow();
     }
 
     private moveHanjaCandidatePage(delta: number): void {
@@ -553,7 +605,7 @@ export class HangulImeController {
         }
 
         selection.pager.movePage(delta);
-        selection.window.update(this.hanjaCandidatePage(selection.pager));
+        this.refreshHanjaCandidateWindow();
     }
 
     private commitVisibleHanjaCandidate(visibleIndex: number, keyCode: KeyCode): void {
@@ -593,6 +645,23 @@ export class HangulImeController {
             pageIndex: pager.pageIndex,
             pageCount: pager.pageCount,
         };
+    }
+
+    private hanjaCandidateDisplayOptions(): HanjaCandidateDisplayOptions {
+        return {
+            showSimplified: this.hanjaOptions.showSimplified,
+            showPinyin: this.hanjaOptions.showPinyin,
+        };
+    }
+
+    private refreshHanjaCandidateWindow(): void {
+        const selection = this.hanjaCandidateSelection;
+        if (!selection) {
+            return;
+        }
+
+        selection.window.setDisplayOptions(this.hanjaCandidateDisplayOptions());
+        selection.window.update(this.hanjaCandidatePage(selection.pager));
     }
 
     private closeHanjaCandidateSelection(): void {

--- a/src/composition/hanja/hanja-candidate-window.test.ts
+++ b/src/composition/hanja/hanja-candidate-window.test.ts
@@ -260,6 +260,65 @@ describe("HanjaCandidateWindow", () => {
         expect(document.querySelector(".can-pinyin")?.textContent).toBe("");
     });
 
+    it("hides Simplified Chinese and Pinyin metadata when disabled", () => {
+        new HanjaCandidateWindow(
+            document.createElement("textarea"),
+            page({
+                candidates: [
+                    candidate("韓", {
+                        korean: "나라 이름 한, 한나라 한",
+                        simplified: "韩",
+                        pinyin: "hán",
+                    }),
+                ],
+            }),
+            rect(100, 20, 10, 10),
+            {
+                ...windowOptions(),
+                displayOptions: { showSimplified: false, showPinyin: false },
+            }
+        );
+
+        expect(document.querySelector(".can-hanja")?.textContent).toBe("韓");
+        expect(document.querySelector(".can-korean")?.textContent).toBe("나라 이름 한, 한나라 한");
+        expect(document.querySelector(".can-simplified")).toBeNull();
+        expect(document.querySelector(".can-pinyin")).toBeNull();
+    });
+
+    it("can update metadata visibility for an already-open candidate window", () => {
+        const window = new HanjaCandidateWindow(
+            document.createElement("textarea"),
+            page({
+                candidates: [
+                    candidate("韓", {
+                        korean: "나라 이름 한, 한나라 한",
+                        simplified: "韩",
+                        pinyin: "hán",
+                    }),
+                ],
+            }),
+            rect(100, 20, 10, 10),
+            windowOptions()
+        );
+
+        window.setDisplayOptions({ showSimplified: false, showPinyin: true });
+        window.update(
+            page({
+                candidates: [
+                    candidate("韓", {
+                        korean: "나라 이름 한, 한나라 한",
+                        simplified: "韩",
+                        pinyin: "hán",
+                    }),
+                ],
+            })
+        );
+
+        expect(document.querySelector(".can-korean")?.textContent).toBe("나라 이름 한, 한나라 한");
+        expect(document.querySelector(".can-simplified")).toBeNull();
+        expect(document.querySelector(".can-pinyin")?.textContent).toBe("hán");
+    });
+
     it("highlights a hovered candidate without changing the selected candidate", () => {
         new HanjaCandidateWindow(
             document.createElement("textarea"),

--- a/src/composition/hanja/hanja-candidate-window.ts
+++ b/src/composition/hanja/hanja-candidate-window.ts
@@ -12,11 +12,22 @@ export type HanjaCandidateWindowPage = {
     pageCount: number;
 };
 
+export type HanjaCandidateDisplayOptions = {
+    showSimplified: boolean;
+    showPinyin: boolean;
+};
+
+export const defaultHanjaCandidateDisplayOptions: HanjaCandidateDisplayOptions = {
+    showSimplified: true,
+    showPinyin: true,
+};
+
 type HanjaCandidateWindowOptions = {
     onPreviousPage: () => void;
     onNextPage: () => void;
     onMoveSelection: (delta: number) => void;
     onSelectCandidate: (visibleIndex: number) => void;
+    displayOptions?: HanjaCandidateDisplayOptions;
 };
 
 type PageButtonKind = "previous" | "next";
@@ -27,6 +38,7 @@ export class HanjaCandidateWindow {
     private readonly controls: HTMLDivElement;
     private readonly pageHint: HTMLDivElement;
     private readonly onSelectCandidate: (visibleIndex: number) => void;
+    private displayOptions: HanjaCandidateDisplayOptions;
     private hoveredIndex: number | undefined;
 
     constructor(
@@ -36,6 +48,7 @@ export class HanjaCandidateWindow {
         options: HanjaCandidateWindowOptions
     ) {
         this.onSelectCandidate = options.onSelectCandidate;
+        this.displayOptions = options.displayOptions ?? defaultHanjaCandidateDisplayOptions;
         this.root = document.createElement("div");
         this.root.id = HANJA_CANDIDATE_WINDOW_ID;
 
@@ -97,6 +110,10 @@ export class HanjaCandidateWindow {
         }
 
         this.setActiveIndex(page.selectedIndex);
+    }
+
+    setDisplayOptions(displayOptions: HanjaCandidateDisplayOptions): void {
+        this.displayOptions = displayOptions;
     }
 
     setActiveIndex(index: number): void {
@@ -165,8 +182,15 @@ export class HanjaCandidateWindow {
         number.className = "can-number";
         number.textContent = String(index + 1);
 
+        const visibleKeys = HANJA_CANDIDATE_KEYS.filter(
+            (key) =>
+                key === "hanja" ||
+                key === "korean" ||
+                (key === "simplified" && this.displayOptions.showSimplified) ||
+                (key === "pinyin" && this.displayOptions.showPinyin)
+        );
         const elements: HTMLSpanElement[] = [];
-        for (const key of HANJA_CANDIDATE_KEYS) {
+        for (const key of visibleKeys) {
             const span = document.createElement("span");
             span.className = `can-${key}`;
             span.textContent = candidate[key] ?? "";

--- a/src/composition/hanja/hanja-key.test.ts
+++ b/src/composition/hanja/hanja-key.test.ts
@@ -1,9 +1,26 @@
 import { KeyCode } from "../../keyboard/korean-keyboard-map";
-import { defaultHanjaKeyCodeForPlatform } from "./hanja-key";
+import { defaultHanjaKeyBinding, defaultHanjaKeyBindingForPlatform, macDefaultHanjaKeyBinding } from "./hanja-key";
 
-describe("defaultHanjaKeyCodeForPlatform", () => {
+describe("defaultHanjaKeyBindingForPlatform", () => {
     it("uses Right Ctrl by default and Right Option on macOS", () => {
-        expect(defaultHanjaKeyCodeForPlatform("default")).toBe(KeyCode.ControlRight);
-        expect(defaultHanjaKeyCodeForPlatform("mac")).toBe(KeyCode.AltRight);
+        expect(defaultHanjaKeyBindingForPlatform("default")).toEqual({
+            code: KeyCode.ControlRight,
+            ctrl: true,
+            alt: false,
+            shift: false,
+            meta: false,
+        });
+        expect(defaultHanjaKeyBindingForPlatform("mac")).toEqual({
+            code: KeyCode.AltRight,
+            ctrl: false,
+            alt: true,
+            shift: false,
+            meta: false,
+        });
+    });
+
+    it("returns fresh copies of the shared defaults", () => {
+        expect(defaultHanjaKeyBindingForPlatform("default")).not.toBe(defaultHanjaKeyBinding);
+        expect(defaultHanjaKeyBindingForPlatform("mac")).not.toBe(macDefaultHanjaKeyBinding);
     });
 });

--- a/src/composition/hanja/hanja-key.ts
+++ b/src/composition/hanja/hanja-key.ts
@@ -1,10 +1,24 @@
-import { currentKeyBindingPlatform, KeyBindingPlatform } from "../../keyboard/key-binding";
+import { currentKeyBindingPlatform, KeyBinding, KeyBindingPlatform } from "../../keyboard/key-binding";
 import { KeyCode } from "../../keyboard/korean-keyboard-map";
 
-export function defaultHanjaKeyCodeForPlatform(platform: KeyBindingPlatform = currentKeyBindingPlatform()): KeyCode {
-    return platform === "mac" ? KeyCode.AltRight : KeyCode.ControlRight;
-}
+export const defaultHanjaKeyBinding: KeyBinding = {
+    code: KeyCode.ControlRight,
+    ctrl: true,
+    alt: false,
+    shift: false,
+    meta: false,
+};
 
-export function isDefaultHanjaKey(event: { code: string }): boolean {
-    return event.code === defaultHanjaKeyCodeForPlatform();
+export const macDefaultHanjaKeyBinding: KeyBinding = {
+    code: KeyCode.AltRight,
+    ctrl: false,
+    alt: true,
+    shift: false,
+    meta: false,
+};
+
+export function defaultHanjaKeyBindingForPlatform(
+    platform: KeyBindingPlatform = currentKeyBindingPlatform()
+): KeyBinding {
+    return { ...(platform === "mac" ? macDefaultHanjaKeyBinding : defaultHanjaKeyBinding) };
 }

--- a/src/content-script/content-script-controller.test.ts
+++ b/src/content-script/content-script-controller.test.ts
@@ -4,6 +4,7 @@ import { TextInputManager } from "./text-input-manager";
 import { KeyCode } from "../keyboard/korean-keyboard-map";
 import { KeyBinding, defaultToggleKeyBinding } from "../keyboard/key-binding";
 import { loadToggleKeyBinding } from "../settings/toggle-key-store";
+import { loadHanjaKeyBinding } from "../settings/hanja-key-store";
 import { KoreanKeyboardMode } from "../extension-state/korean-keyboard-mode";
 import { ServiceScriptMessageAction } from "../messaging/service-to-content-messages";
 import { ContentScriptRequestAction } from "../messaging/content-to-service-messages";
@@ -17,6 +18,11 @@ jest.mock("../settings/settings-store", () => ({
 jest.mock("../settings/toggle-key-store", () => ({
     TOGGLE_KEY_STORAGE_KEY: "hanYongToggleKey",
     loadToggleKeyBinding: jest.fn(),
+}));
+
+jest.mock("../settings/hanja-key-store", () => ({
+    HANJA_KEY_STORAGE_KEY: "hanjaConversionKey",
+    loadHanjaKeyBinding: jest.fn(),
 }));
 
 jest.mock("./on-screen-keyboard/on-screen-keyboard-controller", () => ({
@@ -73,6 +79,7 @@ describe("ContentScriptController toggle-key handling", () => {
     // test's controller fire on a later test's events.
     async function initController(binding: KeyBinding | null) {
         (loadToggleKeyBinding as jest.Mock).mockResolvedValue(binding);
+        (loadHanjaKeyBinding as jest.Mock).mockResolvedValue(null);
         const add = jest.spyOn(document, "addEventListener").mockImplementation((type, handler, opts) => {
             if (opts === true && type === "keydown") {
                 keydownHandler = handler as never;
@@ -94,6 +101,9 @@ describe("ContentScriptController toggle-key handling", () => {
             action: ServiceScriptMessageAction.UpdateState,
             data: {
                 isHanYongEnabled: enabled,
+                isHanjaEnabled: true,
+                showHanjaSimplified: true,
+                showHanjaPinyin: true,
                 isOnScreenKeyboardEnabled: false,
                 koreanKeyboardMode: KoreanKeyboardMode.English,
             },
@@ -201,6 +211,7 @@ describe("ContentScriptController on-screen-keyboard layout", () => {
     beforeEach(() => {
         (OnScreenKeyboardController as unknown as jest.Mock).mockClear();
         (loadToggleKeyBinding as jest.Mock).mockResolvedValue(defaultToggleKeyBinding);
+        (loadHanjaKeyBinding as jest.Mock).mockResolvedValue(null);
         listeners = [];
         sendMessage = jest.fn();
         Object.assign(globalThis, {
@@ -220,6 +231,9 @@ describe("ContentScriptController on-screen-keyboard layout", () => {
         action: ServiceScriptMessageAction.UpdateState,
         data: {
             isHanYongEnabled: false,
+            isHanjaEnabled: true,
+            showHanjaSimplified: true,
+            showHanjaPinyin: true,
             isOnScreenKeyboardEnabled,
             koreanKeyboardMode: KoreanKeyboardMode.English,
         },

--- a/src/content-script/content-script-controller.ts
+++ b/src/content-script/content-script-controller.ts
@@ -20,6 +20,7 @@ import { routeByAction } from "../messaging/route-message";
 import { currentOskSite } from "./osk-site";
 import { loadSettings, saveSettings } from "../settings/settings-store";
 import { TOGGLE_KEY_STORAGE_KEY, loadToggleKeyBinding } from "../settings/toggle-key-store";
+import { HANJA_KEY_STORAGE_KEY, loadHanjaKeyBinding } from "../settings/hanja-key-store";
 import { LayoutId } from "../extension-state/osk-layout";
 
 export class ContentScriptController {
@@ -27,6 +28,10 @@ export class ContentScriptController {
     // The per-machine toggle key (see toggle-key-store); null means no key
     // toggles modes. Loaded from local storage and re-read when it changes.
     private toggleKeyBinding: KeyBinding | null = null;
+    private hanjaKeyBinding: KeyBinding | null = null;
+    private isHanjaEnabled = true;
+    private showHanjaSimplified = true;
+    private showHanjaPinyin = true;
     private textEntryMode = KoreanKeyboardMode.English;
     private textInputManager = new TextInputManager(new ServiceWorkerHanjaDictionaryProviderClient());
     private keyboardController?: OnScreenKeyboardController;
@@ -58,6 +63,8 @@ export class ContentScriptController {
         this.requestState();
         void this.loadToggleKey();
         this.watchToggleKey();
+        void this.loadHanjaKey();
+        this.watchHanjaKey();
 
         // Only the top window hosts the keyboard, so only it needs the saved
         // position layout (the reply gates the first show — see
@@ -150,8 +157,27 @@ export class ContentScriptController {
         });
     }
 
+    /** Load the per-machine Hanja conversion key binding (see hanja-key-store). */
+    private async loadHanjaKey() {
+        this.hanjaKeyBinding = await loadHanjaKeyBinding();
+        this.syncHanjaOptions();
+    }
+
+    /** Re-read the Hanja key when it changes — the options page writes it to local storage. */
+    private watchHanjaKey() {
+        api.storage.onChanged.addListener((changes, area) => {
+            if (area === "local" && HANJA_KEY_STORAGE_KEY in changes) {
+                this.loadHanjaKey().catch((error) => debugLog("loadHanjaKey failed:", error));
+            }
+        });
+    }
+
     private handleTabStateMessage(message: TabStateMessage) {
         this.isHanYongEnabled = message.data.isHanYongEnabled;
+        this.isHanjaEnabled = message.data.isHanjaEnabled;
+        this.showHanjaSimplified = message.data.showHanjaSimplified;
+        this.showHanjaPinyin = message.data.showHanjaPinyin;
+        this.syncHanjaOptions();
 
         // Tell the on-screen keyboard about the master state first, so it can
         // reset its independent (master-off) mode when the regime changes.
@@ -176,6 +202,15 @@ export class ContentScriptController {
 
         this.shouldShowOsk = message.data.isOnScreenKeyboardEnabled;
         this.updateOskVisibility();
+    }
+
+    private syncHanjaOptions() {
+        this.textInputManager.setHanjaOptions({
+            enabled: this.isHanjaEnabled,
+            keyBinding: this.hanjaKeyBinding,
+            showSimplified: this.showHanjaSimplified,
+            showPinyin: this.showHanjaPinyin,
+        });
     }
 
     // Show the keyboard only once it's both wanted and its saved layout has been

--- a/src/content-script/text-input-manager.ts
+++ b/src/content-script/text-input-manager.ts
@@ -1,4 +1,4 @@
-import { HangulImeController } from "../composition/hangul-ime-controller";
+import { HangulImeController, HanjaImeOptions } from "../composition/hangul-ime-controller";
 import { KoreanKeyboardMode } from "../extension-state/korean-keyboard-mode";
 import { CompositionAdapterFactory } from "../composition/composition-adapter-factory";
 import { isHangulOrJamo } from "../composition/hangul-maps";
@@ -23,6 +23,7 @@ export class TextInputManager {
     // recreation on focus change and is applied to each new controller. Defaults to
     // the platform default until the content script pushes the user's binding.
     private toggleKeyBinding: KeyBinding | null = defaultToggleKeyBindingForPlatform();
+    private hanjaOptions: Partial<HanjaImeOptions> = {};
 
     constructor(
         private readonly hanjaDictionaryProvider: HanjaDictionaryProvider = new StaticHanjaDictionaryProvider()
@@ -42,6 +43,11 @@ export class TextInputManager {
     public setToggleKeyBinding(binding: KeyBinding | null) {
         this.toggleKeyBinding = binding;
         this.imeController?.setToggleKeyBinding(binding);
+    }
+
+    public setHanjaOptions(options: Partial<HanjaImeOptions>) {
+        this.hanjaOptions = { ...this.hanjaOptions, ...options };
+        this.imeController?.setHanjaOptions(this.hanjaOptions);
     }
 
     public setActiveElement(element: EventTarget | null): SupportedCompositionFeatures | undefined {
@@ -117,7 +123,12 @@ export class TextInputManager {
                 return undefined;
             }
             this.targetElement = element;
-            this.imeController = new HangulImeController(element, compositionAdapter, this.hanjaDictionaryProvider);
+            this.imeController = new HangulImeController(
+                element,
+                compositionAdapter,
+                this.hanjaDictionaryProvider,
+                this.hanjaOptions
+            );
             this.imeController.setToggleKeyBinding(this.toggleKeyBinding);
         }
 

--- a/src/extension-state/tab-state.ts
+++ b/src/extension-state/tab-state.ts
@@ -2,6 +2,9 @@ import { KoreanKeyboardMode } from "./korean-keyboard-mode";
 
 export type TabState = {
     isHanYongEnabled: boolean;
+    isHanjaEnabled: boolean;
+    showHanjaSimplified: boolean;
+    showHanjaPinyin: boolean;
     koreanKeyboardMode: KoreanKeyboardMode;
     isOnScreenKeyboardEnabled: boolean;
 };

--- a/src/keyboard/key-binding.test.ts
+++ b/src/keyboard/key-binding.test.ts
@@ -7,7 +7,6 @@ import {
     formatModifierKeyPrefix,
     isValidImeActionKeyBinding,
     isModifierOnlyBinding,
-    isValidToggleKeyBinding,
     keyBindingsCollide,
     keyBindingPlatformFromNavigator,
     keyBindingFromEvent,
@@ -61,47 +60,40 @@ describe("isModifierOnlyBinding", () => {
     });
 });
 
-describe("isValidToggleKeyBinding", () => {
+describe("isValidImeActionKeyBinding", () => {
     it("allows a lone Ctrl or Alt key on all platforms", () => {
-        expect(isValidToggleKeyBinding(binding(KeyCode.AltRight, { alt: true }))).toBe(true);
-        expect(isValidToggleKeyBinding(binding(KeyCode.ControlRight, { ctrl: true }))).toBe(true);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.AltRight, { alt: true }))).toBe(true);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.ControlRight, { ctrl: true }))).toBe(true);
     });
 
     it("allows a printable key combined with Ctrl or Alt on all platforms", () => {
-        expect(isValidToggleKeyBinding(binding(KeyCode.KeyS, { alt: true }))).toBe(true);
-        expect(isValidToggleKeyBinding(binding(KeyCode.Space, { ctrl: true }))).toBe(true);
-        expect(isValidToggleKeyBinding(binding(KeyCode.KeyS, { ctrl: true, shift: true }))).toBe(true);
-        expect(isValidToggleKeyBinding(binding(KeyCode.Space, { ctrl: true, meta: true }))).toBe(true);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.KeyS, { alt: true }))).toBe(true);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.Space, { ctrl: true }))).toBe(true);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.KeyS, { ctrl: true, shift: true }))).toBe(true);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.Space, { ctrl: true, meta: true }))).toBe(true);
     });
 
     it("rejects a bare printable key", () => {
-        expect(isValidToggleKeyBinding(binding(KeyCode.KeyS))).toBe(false);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.KeyS))).toBe(false);
     });
 
     it("rejects Shift- or Meta-only combinations by default", () => {
-        expect(isValidToggleKeyBinding(binding(KeyCode.KeyS, { shift: true }))).toBe(false);
-        expect(isValidToggleKeyBinding(binding(KeyCode.Space, { meta: true }))).toBe(false);
-        expect(isValidToggleKeyBinding(binding(KeyCode.ShiftLeft, { shift: true }))).toBe(false);
-        expect(isValidToggleKeyBinding(binding(KeyCode.MetaLeft, { meta: true }))).toBe(false);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.KeyS, { shift: true }))).toBe(false);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.Space, { meta: true }))).toBe(false);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.ShiftLeft, { shift: true }))).toBe(false);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.MetaLeft, { meta: true }))).toBe(false);
     });
 
     it("allows a lone Command key on macOS", () => {
-        expect(isValidToggleKeyBinding(binding(KeyCode.MetaLeft, { meta: true }), "mac")).toBe(true);
-        expect(isValidToggleKeyBinding(binding(KeyCode.MetaRight, { meta: true }), "mac")).toBe(true);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.MetaLeft, { meta: true }), "mac")).toBe(true);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.MetaRight, { meta: true }), "mac")).toBe(true);
     });
 
     it("requires Control or Option for normal-key combinations on macOS", () => {
-        expect(isValidToggleKeyBinding(binding(KeyCode.KeyS, { meta: true }), "mac")).toBe(false);
-        expect(isValidToggleKeyBinding(binding(KeyCode.KeyK, { shift: true, meta: true }), "mac")).toBe(false);
-        expect(isValidToggleKeyBinding(binding(KeyCode.KeyC, { meta: true, alt: true }), "mac")).toBe(true);
-        expect(isValidToggleKeyBinding(binding(KeyCode.Space, { meta: true, ctrl: true }), "mac")).toBe(true);
-    });
-});
-
-describe("isValidImeActionKeyBinding", () => {
-    it("uses the same validity rules as the Han/Yong toggle key", () => {
-        expect(isValidImeActionKeyBinding(binding(KeyCode.ControlRight, { ctrl: true }))).toBe(true);
-        expect(isValidImeActionKeyBinding(binding(KeyCode.KeyS))).toBe(false);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.KeyS, { meta: true }), "mac")).toBe(false);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.KeyK, { shift: true, meta: true }), "mac")).toBe(false);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.KeyC, { meta: true, alt: true }), "mac")).toBe(true);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.Space, { meta: true, ctrl: true }), "mac")).toBe(true);
     });
 });
 

--- a/src/keyboard/key-binding.test.ts
+++ b/src/keyboard/key-binding.test.ts
@@ -5,8 +5,10 @@ import {
     defaultToggleKeyBinding,
     formatKeyBinding,
     formatModifierKeyPrefix,
+    isValidImeActionKeyBinding,
     isModifierOnlyBinding,
     isValidToggleKeyBinding,
+    keyBindingsCollide,
     keyBindingPlatformFromNavigator,
     keyBindingFromEvent,
     matchesKeyBinding,
@@ -96,6 +98,13 @@ describe("isValidToggleKeyBinding", () => {
     });
 });
 
+describe("isValidImeActionKeyBinding", () => {
+    it("uses the same validity rules as the Han/Yong toggle key", () => {
+        expect(isValidImeActionKeyBinding(binding(KeyCode.ControlRight, { ctrl: true }))).toBe(true);
+        expect(isValidImeActionKeyBinding(binding(KeyCode.KeyS))).toBe(false);
+    });
+});
+
 describe("matchesKeyBinding", () => {
     it("matches the default Right Alt on code alone, ignoring extra modifiers (e.g. AltGr's Ctrl)", () => {
         expect(matchesKeyBinding(event(KeyCode.AltRight, { altKey: true }), defaultToggleKeyBinding)).toBe(true);
@@ -113,6 +122,32 @@ describe("matchesKeyBinding", () => {
         expect(matchesKeyBinding(event(KeyCode.KeyS, { altKey: true }), altS)).toBe(true);
         expect(matchesKeyBinding(event(KeyCode.KeyS, { altKey: true, ctrlKey: true }), altS)).toBe(false);
         expect(matchesKeyBinding(event(KeyCode.KeyS), altS)).toBe(false);
+    });
+});
+
+describe("keyBindingsCollide", () => {
+    it("collides modifier-only bindings by physical key code", () => {
+        expect(
+            keyBindingsCollide(
+                binding(KeyCode.ControlRight, { ctrl: true }),
+                binding(KeyCode.ControlRight, { ctrl: true, alt: true })
+            )
+        ).toBe(true);
+    });
+
+    it("collides printable combos only when the full modifier state matches", () => {
+        expect(keyBindingsCollide(binding(KeyCode.KeyS, { alt: true }), binding(KeyCode.KeyS, { alt: true }))).toBe(
+            true
+        );
+        expect(
+            keyBindingsCollide(binding(KeyCode.KeyS, { alt: true }), binding(KeyCode.KeyS, { alt: true, ctrl: true }))
+        ).toBe(false);
+    });
+
+    it("does not collide different physical keys", () => {
+        expect(keyBindingsCollide(binding(KeyCode.KeyS, { alt: true }), binding(KeyCode.KeyD, { alt: true }))).toBe(
+            false
+        );
     });
 });
 

--- a/src/keyboard/key-binding.ts
+++ b/src/keyboard/key-binding.ts
@@ -94,12 +94,16 @@ function isMetaKey(code: KeyCode): boolean {
  * as toggle keys are Ctrl/Control and Alt/Option everywhere, plus Command on
  * macOS.
  */
-export function isValidToggleKeyBinding(binding: KeyBinding, platform: KeyBindingPlatform = "default"): boolean {
+export function isValidImeActionKeyBinding(binding: KeyBinding, platform: KeyBindingPlatform = "default"): boolean {
     if (isModifierOnlyBinding(binding)) {
         return isControlOrAltKey(binding.code) || (platform === "mac" && isMetaKey(binding.code));
     }
 
     return binding.ctrl || binding.alt;
+}
+
+export function isValidToggleKeyBinding(binding: KeyBinding, platform: KeyBindingPlatform = "default"): boolean {
+    return isValidImeActionKeyBinding(binding, platform);
 }
 
 /**
@@ -128,6 +132,23 @@ export function matchesKeyBinding(
         event.altKey === binding.alt &&
         event.shiftKey === binding.shift &&
         event.metaKey === binding.meta
+    );
+}
+
+export function keyBindingsCollide(first: KeyBinding, second: KeyBinding): boolean {
+    if (first.code !== second.code) {
+        return false;
+    }
+
+    if (isModifierOnlyBinding(first) || isModifierOnlyBinding(second)) {
+        return true;
+    }
+
+    return (
+        first.ctrl === second.ctrl &&
+        first.alt === second.alt &&
+        first.shift === second.shift &&
+        first.meta === second.meta
     );
 }
 

--- a/src/keyboard/key-binding.ts
+++ b/src/keyboard/key-binding.ts
@@ -102,10 +102,6 @@ export function isValidImeActionKeyBinding(binding: KeyBinding, platform: KeyBin
     return binding.ctrl || binding.alt;
 }
 
-export function isValidToggleKeyBinding(binding: KeyBinding, platform: KeyBindingPlatform = "default"): boolean {
-    return isValidImeActionKeyBinding(binding, platform);
-}
-
 /**
  * Whether a keydown/keyup event matches a binding.
  *

--- a/src/options-app/HanYongSection.vue
+++ b/src/options-app/HanYongSection.vue
@@ -5,7 +5,8 @@ import { t } from "../i18n";
 import SelectSetting from "./SelectSetting.vue";
 import LabeledCheckbox from "./LabeledCheckbox.vue";
 import ToggleSwitch from "./ToggleSwitch.vue";
-import ToggleKeySetting from "./ToggleKeySetting.vue";
+import KeyBindingField from "./KeyBindingField.vue";
+import { hanYongKeyConfig } from "./key-binding-settings";
 import { useKeyBindingFlash } from "./use-key-binding-flash";
 
 const persistenceOptions: { value: Persistence; name: string }[] = [
@@ -27,7 +28,7 @@ const { keyBindingFlash } = useKeyBindingFlash("hanYong");
         </div>
         <template v-if="settings.hanYong.enabled">
             <div class="setting" :class="{ 'key-binding-flash': keyBindingFlash }">
-                <ToggleKeySetting kind="hanYong" />
+                <KeyBindingField :config="hanYongKeyConfig" />
             </div>
             <div class="setting">
                 <LabeledCheckbox

--- a/src/options-app/HanYongSection.vue
+++ b/src/options-app/HanYongSection.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from "vue";
 import { settings } from "./use-settings";
 import { Persistence } from "../settings/settings";
 import { t } from "../i18n";
@@ -7,7 +6,7 @@ import SelectSetting from "./SelectSetting.vue";
 import LabeledCheckbox from "./LabeledCheckbox.vue";
 import ToggleSwitch from "./ToggleSwitch.vue";
 import ToggleKeySetting from "./ToggleKeySetting.vue";
-import { KeyBindingUnboundEventDetail, keyBindingUnboundEvent } from "./key-binding-events";
+import { useKeyBindingFlash } from "./use-key-binding-flash";
 
 const persistenceOptions: { value: Persistence; name: string }[] = [
     { value: Persistence.AlwaysOff, name: t("options_hanYong_startOff") },
@@ -15,30 +14,7 @@ const persistenceOptions: { value: Persistence; name: string }[] = [
     { value: Persistence.KeepLastState, name: t("options_hanYong_restore") },
 ];
 
-const keyBindingFlash = ref(false);
-let flashTimeout: number | undefined;
-
-function onKeyBindingUnbound(event: Event) {
-    const detail = (event as CustomEvent<KeyBindingUnboundEventDetail>).detail;
-    if (detail.kind !== "hanYong") {
-        return;
-    }
-
-    keyBindingFlash.value = false;
-    window.clearTimeout(flashTimeout);
-    window.requestAnimationFrame(() => {
-        keyBindingFlash.value = true;
-        flashTimeout = window.setTimeout(() => {
-            keyBindingFlash.value = false;
-        }, 1500);
-    });
-}
-
-onMounted(() => window.addEventListener(keyBindingUnboundEvent, onKeyBindingUnbound));
-onUnmounted(() => {
-    window.removeEventListener(keyBindingUnboundEvent, onKeyBindingUnbound);
-    window.clearTimeout(flashTimeout);
-});
+const { keyBindingFlash } = useKeyBindingFlash("hanYong");
 </script>
 
 <template>

--- a/src/options-app/HanjaSection.vue
+++ b/src/options-app/HanjaSection.vue
@@ -3,7 +3,8 @@ import { settings } from "./use-settings";
 import { t } from "../i18n";
 import LabeledCheckbox from "./LabeledCheckbox.vue";
 import ToggleSwitch from "./ToggleSwitch.vue";
-import ToggleKeySetting from "./ToggleKeySetting.vue";
+import KeyBindingField from "./KeyBindingField.vue";
+import { hanjaKeyConfig } from "./key-binding-settings";
 import { useKeyBindingFlash } from "./use-key-binding-flash";
 
 const { keyBindingFlash } = useKeyBindingFlash("hanja");
@@ -19,7 +20,7 @@ const { keyBindingFlash } = useKeyBindingFlash("hanja");
         </div>
         <template v-if="settings.hanja.enabled">
             <div class="setting" :class="{ 'key-binding-flash': keyBindingFlash }">
-                <ToggleKeySetting kind="hanja" />
+                <KeyBindingField :config="hanjaKeyConfig" />
             </div>
             <div class="setting">
                 <LabeledCheckbox

--- a/src/options-app/HanjaSection.vue
+++ b/src/options-app/HanjaSection.vue
@@ -1,36 +1,12 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from "vue";
 import { settings } from "./use-settings";
 import { t } from "../i18n";
 import LabeledCheckbox from "./LabeledCheckbox.vue";
 import ToggleSwitch from "./ToggleSwitch.vue";
 import ToggleKeySetting from "./ToggleKeySetting.vue";
-import { KeyBindingUnboundEventDetail, keyBindingUnboundEvent } from "./key-binding-events";
+import { useKeyBindingFlash } from "./use-key-binding-flash";
 
-const keyBindingFlash = ref(false);
-let flashTimeout: number | undefined;
-
-function onKeyBindingUnbound(event: Event) {
-    const detail = (event as CustomEvent<KeyBindingUnboundEventDetail>).detail;
-    if (detail.kind !== "hanja") {
-        return;
-    }
-
-    keyBindingFlash.value = false;
-    window.clearTimeout(flashTimeout);
-    window.requestAnimationFrame(() => {
-        keyBindingFlash.value = true;
-        flashTimeout = window.setTimeout(() => {
-            keyBindingFlash.value = false;
-        }, 1500);
-    });
-}
-
-onMounted(() => window.addEventListener(keyBindingUnboundEvent, onKeyBindingUnbound));
-onUnmounted(() => {
-    window.removeEventListener(keyBindingUnboundEvent, onKeyBindingUnbound);
-    window.clearTimeout(flashTimeout);
-});
+const { keyBindingFlash } = useKeyBindingFlash("hanja");
 </script>
 
 <template>

--- a/src/options-app/HanjaSection.vue
+++ b/src/options-app/HanjaSection.vue
@@ -1,26 +1,18 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from "vue";
 import { settings } from "./use-settings";
-import { Persistence } from "../settings/settings";
 import { t } from "../i18n";
-import SelectSetting from "./SelectSetting.vue";
 import LabeledCheckbox from "./LabeledCheckbox.vue";
 import ToggleSwitch from "./ToggleSwitch.vue";
 import ToggleKeySetting from "./ToggleKeySetting.vue";
 import { KeyBindingUnboundEventDetail, keyBindingUnboundEvent } from "./key-binding-events";
-
-const persistenceOptions: { value: Persistence; name: string }[] = [
-    { value: Persistence.AlwaysOff, name: t("options_hanYong_startOff") },
-    { value: Persistence.AlwaysOn, name: t("options_hanYong_startOn") },
-    { value: Persistence.KeepLastState, name: t("options_hanYong_restore") },
-];
 
 const keyBindingFlash = ref(false);
 let flashTimeout: number | undefined;
 
 function onKeyBindingUnbound(event: Event) {
     const detail = (event as CustomEvent<KeyBindingUnboundEventDetail>).detail;
-    if (detail.kind !== "hanYong") {
+    if (detail.kind !== "hanja") {
         return;
     }
 
@@ -44,27 +36,27 @@ onUnmounted(() => {
 <template>
     <section>
         <div class="section-header">
-            <ToggleSwitch v-model="settings.hanYong.enabled" :ariaLabel="t('options_hanYong_heading')" />
-            <h2>{{ t("options_hanYong_heading") }}</h2>
-            <p v-if="settings.hanYong.enabled" class="description section-hint">{{ t("options_hanYong_hint") }}</p>
-            <p v-else class="description section-hint">{{ t("options_hanYong_disabled_hint") }}</p>
+            <ToggleSwitch v-model="settings.hanja.enabled" :ariaLabel="t('options_hanja_heading')" />
+            <h2>{{ t("options_hanja_heading") }}</h2>
+            <p v-if="settings.hanja.enabled" class="description section-hint">{{ t("options_hanja_hint") }}</p>
+            <p v-else class="description section-hint">{{ t("options_hanja_disabled_hint") }}</p>
         </div>
-        <template v-if="settings.hanYong.enabled">
+        <template v-if="settings.hanja.enabled">
             <div class="setting" :class="{ 'key-binding-flash': keyBindingFlash }">
-                <ToggleKeySetting kind="hanYong" />
+                <ToggleKeySetting kind="hanja" />
             </div>
             <div class="setting">
                 <LabeledCheckbox
-                    v-model="settings.hanYong.syncAcrossTabs"
-                    :label="t('options_hanYong_syncAcrossTabs_label')"
-                    :description="t('options_hanYong_syncAcrossTabs_description')"
+                    v-model="settings.hanja.showSimplified"
+                    :label="t('options_hanja_showSimplified_label')"
+                    :description="t('options_hanja_showSimplified_description')"
                 />
             </div>
             <div class="setting">
-                <SelectSetting
-                    v-model="settings.hanYong.persistence"
-                    :label="t('options_persistence_label')"
-                    :options="persistenceOptions"
+                <LabeledCheckbox
+                    v-model="settings.hanja.showPinyin"
+                    :label="t('options_hanja_showPinyin_label')"
+                    :description="t('options_hanja_showPinyin_description')"
                 />
             </div>
         </template>

--- a/src/options-app/KeyBindingField.vue
+++ b/src/options-app/KeyBindingField.vue
@@ -26,6 +26,9 @@ const capturing = ref(false);
 const invalid = ref(false);
 const statusMessage = ref("");
 const statusWarning = ref(false);
+// While a collision notice is shown, the storage key of the peer we unbound, so
+// the notice can clear once that peer is rebound. Null when no notice is shown.
+let collisionPeerStorageKey: string | null = null;
 // Live "Ctrl + Shift +" prefix shown while modifiers are held mid-capture.
 const captureProgress = ref("");
 const captureProgressAccessible = ref("");
@@ -72,8 +75,17 @@ const invalidMessageKey = computed<MessageKey>(() =>
 onMounted(async () => {
     await reloadBinding();
     storageChangeListener = (changes, areaName) => {
-        if (areaName === "local" && config.value.storageKey in changes) {
+        if (areaName !== "local") {
+            return;
+        }
+        if (config.value.storageKey in changes) {
             reloadBinding().catch((error) => console.error("reloadBinding failed:", error));
+        }
+        // Our "X was unbound" notice is stale once X is given a new binding, so
+        // drop it then. A non-null newValue means a rebind; the original unbind we
+        // caused writes null, so it never clears its own freshly shown notice.
+        if (collisionPeerStorageKey && changes[collisionPeerStorageKey]?.newValue != null) {
+            clearStatus();
         }
     };
     api.storage.onChanged.addListener(storageChangeListener);
@@ -91,14 +103,22 @@ async function reloadBinding() {
     binding.value = await config.value.loadBinding();
 }
 
-async function persist(next: KeyBinding | null) {
+function clearStatus() {
     statusMessage.value = "";
     statusWarning.value = false;
-    const collisionStatus = next ? await resolveKeyBindingCollision(config.value, next) : "";
+    collisionPeerStorageKey = null;
+}
+
+async function persist(next: KeyBinding | null) {
+    clearStatus();
+    const collision = next ? await resolveKeyBindingCollision(config.value, next) : null;
     binding.value = next;
     await config.value.saveBinding(next);
-    statusMessage.value = collisionStatus;
-    statusWarning.value = !!collisionStatus;
+    if (collision) {
+        statusMessage.value = collision.message;
+        statusWarning.value = true;
+        collisionPeerStorageKey = collision.unboundStorageKey;
+    }
 }
 
 function turnOff() {
@@ -112,8 +132,7 @@ function resetToDefault() {
 }
 
 function startCapture() {
-    statusMessage.value = "";
-    statusWarning.value = false;
+    clearStatus();
     invalid.value = false;
     captureProgress.value = "";
     captureProgressAccessible.value = "";

--- a/src/options-app/KeyBindingField.vue
+++ b/src/options-app/KeyBindingField.vue
@@ -1,80 +1,25 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref, toRefs } from "vue";
 import { t, type MessageKey } from "../i18n";
 import {
     KeyBinding,
-    KeyBindingPlatform,
     currentKeyBindingPlatform,
-    defaultToggleKeyBindingForPlatform,
     formatKeyBinding,
     formatModifierKeyPrefix,
     isValidImeActionKeyBinding,
-    keyBindingsCollide,
     keyBindingFromEvent,
 } from "../keyboard/key-binding";
 import { KeyCode, isModifierKey } from "../keyboard/korean-keyboard-map";
-import { TOGGLE_KEY_STORAGE_KEY, loadToggleKeyBinding, saveToggleKeyBinding } from "../settings/toggle-key-store";
-import { HANJA_KEY_STORAGE_KEY, loadHanjaKeyBinding, saveHanjaKeyBinding } from "../settings/hanja-key-store";
-import { defaultHanjaKeyBindingForPlatform } from "../composition/hanja/hanja-key";
 import { api } from "../platform/browser-api";
-import { ImeKeySettingKind, notifyKeyBindingUnbound } from "./key-binding-events";
+import { KeyBindingFieldConfig, resolveKeyBindingCollision } from "./key-binding-settings";
 
-const props = withDefaults(
-    defineProps<{
-        kind?: ImeKeySettingKind;
-    }>(),
-    { kind: "hanYong" }
-);
+// One configurable IME key, supplied by the parent section as data (see
+// key-binding-settings.ts). The component knows nothing feature-specific.
+const props = defineProps<{
+    config: KeyBindingFieldConfig;
+}>();
 
-type KeySettingConfig = {
-    kind: ImeKeySettingKind;
-    storageKey: string;
-    loadBinding: () => Promise<KeyBinding | null>;
-    saveBinding: (binding: KeyBinding | null) => Promise<void>;
-    defaultBindingForPlatform: (platform: KeyBindingPlatform) => KeyBinding;
-    labelKey: MessageKey;
-    descriptionKey: MessageKey;
-    peerKind: ImeKeySettingKind;
-    peerUnboundMessageKey: MessageKey;
-};
-
-const keySettingConfigs: Record<ImeKeySettingKind, KeySettingConfig> = {
-    hanYong: {
-        kind: "hanYong",
-        storageKey: TOGGLE_KEY_STORAGE_KEY,
-        loadBinding: loadToggleKeyBinding,
-        saveBinding: saveToggleKeyBinding,
-        defaultBindingForPlatform: defaultToggleKeyBindingForPlatform,
-        labelKey: "options_hanYong_toggleKey_label",
-        descriptionKey: "options_hanYong_toggleKey_description",
-        peerKind: "hanja",
-        peerUnboundMessageKey: "options_keyBinding_hanjaUnbound",
-    },
-    hanja: {
-        kind: "hanja",
-        storageKey: HANJA_KEY_STORAGE_KEY,
-        loadBinding: loadHanjaKeyBinding,
-        saveBinding: saveHanjaKeyBinding,
-        defaultBindingForPlatform: defaultHanjaKeyBindingForPlatform,
-        labelKey: "options_hanja_conversionKey_label",
-        descriptionKey: "options_hanja_conversionKey_description",
-        peerKind: "hanYong",
-        peerUnboundMessageKey: "options_keyBinding_hanYongUnbound",
-    },
-};
-
-const config = computed(() => keySettingConfigs[props.kind]);
-// The Hanja key only exists when its feature flag is on; with the flag off there
-// is no reachable Hanja setting to collide with, so the toggle key has no peer.
-// (`process.env.KIME_ENABLE_HANJA` is inlined at build time, so the off case
-// compiles to a constant.)
-const peerConfig = computed<KeySettingConfig | null>(() => {
-    const peerKind = config.value.peerKind;
-    if (peerKind === "hanja" && process.env.KIME_ENABLE_HANJA !== "true") {
-        return null;
-    }
-    return keySettingConfigs[peerKind];
-});
+const { config } = toRefs(props);
 
 const binding = ref<KeyBinding | null>(null);
 const capturing = ref(false);
@@ -113,7 +58,7 @@ const bindingAccessibleLabel = computed(() => {
 });
 
 // The binding box is now a button; give it a self-describing accessible name
-// (field label + current value) so it reads as the toggle-key control rather
+// (field label + current value) so it reads as the key-binding control rather
 // than a bare value when a screen reader lands on it.
 const bindingButtonLabel = computed(() => `${t(config.value.labelKey)}: ${bindingAccessibleLabel.value}`);
 
@@ -149,27 +94,11 @@ async function reloadBinding() {
 async function persist(next: KeyBinding | null) {
     statusMessage.value = "";
     statusWarning.value = false;
-    const collisionStatus = next ? await unbindCollidingPeer(next) : "";
+    const collisionStatus = next ? await resolveKeyBindingCollision(config.value, next) : "";
     binding.value = next;
     await config.value.saveBinding(next);
     statusMessage.value = collisionStatus;
     statusWarning.value = !!collisionStatus;
-}
-
-async function unbindCollidingPeer(next: KeyBinding): Promise<string> {
-    const peer = peerConfig.value;
-    if (!peer) {
-        return "";
-    }
-
-    const other = await peer.loadBinding();
-    if (!other || !keyBindingsCollide(next, other)) {
-        return "";
-    }
-
-    await peer.saveBinding(null);
-    notifyKeyBindingUnbound(peer.kind);
-    return t(config.value.peerUnboundMessageKey, formatKeyBinding(other, { platform: keyBindingPlatform }));
 }
 
 function turnOff() {
@@ -289,7 +218,7 @@ function onCaptureKeyup(event: KeyboardEvent) {
 </script>
 
 <template>
-    <div class="toggle-key">
+    <div class="key-binding-field">
         <span class="label">
             {{ t(config.labelKey) }}
             <span
@@ -340,7 +269,7 @@ function onCaptureKeyup(event: KeyboardEvent) {
 
 <style scoped>
 /* `.label` typography is shared globally in options-page.vue */
-.toggle-key .label {
+.key-binding-field .label {
     display: block;
 }
 

--- a/src/options-app/ToggleKeySetting.vue
+++ b/src/options-app/ToggleKeySetting.vue
@@ -64,7 +64,17 @@ const keySettingConfigs: Record<ImeKeySettingKind, KeySettingConfig> = {
 };
 
 const config = computed(() => keySettingConfigs[props.kind]);
-const peerConfig = computed(() => keySettingConfigs[config.value.peerKind]);
+// The Hanja key only exists when its feature flag is on; with the flag off there
+// is no reachable Hanja setting to collide with, so the toggle key has no peer.
+// (`process.env.KIME_ENABLE_HANJA` is inlined at build time, so the off case
+// compiles to a constant.)
+const peerConfig = computed<KeySettingConfig | null>(() => {
+    const peerKind = config.value.peerKind;
+    if (peerKind === "hanja" && process.env.KIME_ENABLE_HANJA !== "true") {
+        return null;
+    }
+    return keySettingConfigs[peerKind];
+});
 
 const binding = ref<KeyBinding | null>(null);
 const capturing = ref(false);
@@ -86,20 +96,20 @@ let pendingModifier: KeyBinding | null = null;
 
 const bindingDisplay = computed(() => {
     if (capturing.value) {
-        return captureProgress.value || t("options_hanYong_toggleKey_capturing");
+        return captureProgress.value || t("options_keyBinding_capturing");
     }
     return binding.value
         ? formatKeyBinding(binding.value, { platform: keyBindingPlatform })
-        : t("options_hanYong_toggleKey_off");
+        : t("options_keyBinding_off");
 });
 
 const bindingAccessibleLabel = computed(() => {
     if (capturing.value) {
-        return captureProgressAccessible.value || t("options_hanYong_toggleKey_capturing");
+        return captureProgressAccessible.value || t("options_keyBinding_capturing");
     }
     return binding.value
         ? formatKeyBinding(binding.value, { platform: keyBindingPlatform, labelMode: "accessible" })
-        : t("options_hanYong_toggleKey_off");
+        : t("options_keyBinding_off");
 });
 
 // The binding box is now a button; give it a self-describing accessible name
@@ -108,10 +118,10 @@ const bindingAccessibleLabel = computed(() => {
 const bindingButtonLabel = computed(() => `${t(config.value.labelKey)}: ${bindingAccessibleLabel.value}`);
 
 const hintMessageKey = computed<MessageKey>(() =>
-    keyBindingPlatform === "mac" ? "options_hanYong_toggleKey_hint_mac" : "options_hanYong_toggleKey_hint"
+    keyBindingPlatform === "mac" ? "options_keyBinding_hint_mac" : "options_keyBinding_hint"
 );
 const invalidMessageKey = computed<MessageKey>(() =>
-    keyBindingPlatform === "mac" ? "options_hanYong_toggleKey_invalid_mac" : "options_hanYong_toggleKey_invalid"
+    keyBindingPlatform === "mac" ? "options_keyBinding_invalid_mac" : "options_keyBinding_invalid"
 );
 
 onMounted(async () => {
@@ -148,6 +158,10 @@ async function persist(next: KeyBinding | null) {
 
 async function unbindCollidingPeer(next: KeyBinding): Promise<string> {
     const peer = peerConfig.value;
+    if (!peer) {
+        return "";
+    }
+
     const other = await peer.loadBinding();
     if (!other || !keyBindingsCollide(next, other)) {
         return "";
@@ -304,10 +318,10 @@ function onCaptureKeyup(event: KeyboardEvent) {
                 {{ bindingDisplay }}
             </button>
             <button type="button" class="ds-btn ds-btn--sm" :disabled="!binding && !capturing" @click="turnOff">
-                {{ t("options_hanYong_toggleKey_turnOff") }}
+                {{ t("options_keyBinding_turnOff") }}
             </button>
             <button type="button" class="ds-btn ds-btn--sm" @click="resetToDefault">
-                {{ t("options_hanYong_toggleKey_reset") }}
+                {{ t("options_keyBinding_reset") }}
             </button>
         </div>
         <!-- Shown only while capturing, right under the controls: the capture hint,

--- a/src/options-app/ToggleKeySetting.vue
+++ b/src/options-app/ToggleKeySetting.vue
@@ -3,23 +3,80 @@ import { computed, onMounted, onUnmounted, ref } from "vue";
 import { t, type MessageKey } from "../i18n";
 import {
     KeyBinding,
+    KeyBindingPlatform,
     currentKeyBindingPlatform,
     defaultToggleKeyBindingForPlatform,
     formatKeyBinding,
     formatModifierKeyPrefix,
-    isValidToggleKeyBinding,
+    isValidImeActionKeyBinding,
+    keyBindingsCollide,
     keyBindingFromEvent,
 } from "../keyboard/key-binding";
 import { KeyCode, isModifierKey } from "../keyboard/korean-keyboard-map";
-import { loadToggleKeyBinding, saveToggleKeyBinding } from "../settings/toggle-key-store";
+import { TOGGLE_KEY_STORAGE_KEY, loadToggleKeyBinding, saveToggleKeyBinding } from "../settings/toggle-key-store";
+import { HANJA_KEY_STORAGE_KEY, loadHanjaKeyBinding, saveHanjaKeyBinding } from "../settings/hanja-key-store";
+import { defaultHanjaKeyBindingForPlatform } from "../composition/hanja/hanja-key";
+import { api } from "../platform/browser-api";
+import { ImeKeySettingKind, notifyKeyBindingUnbound } from "./key-binding-events";
+
+const props = withDefaults(
+    defineProps<{
+        kind?: ImeKeySettingKind;
+    }>(),
+    { kind: "hanYong" }
+);
+
+type KeySettingConfig = {
+    kind: ImeKeySettingKind;
+    storageKey: string;
+    loadBinding: () => Promise<KeyBinding | null>;
+    saveBinding: (binding: KeyBinding | null) => Promise<void>;
+    defaultBindingForPlatform: (platform: KeyBindingPlatform) => KeyBinding;
+    labelKey: MessageKey;
+    descriptionKey: MessageKey;
+    peerKind: ImeKeySettingKind;
+    peerUnboundMessageKey: MessageKey;
+};
+
+const keySettingConfigs: Record<ImeKeySettingKind, KeySettingConfig> = {
+    hanYong: {
+        kind: "hanYong",
+        storageKey: TOGGLE_KEY_STORAGE_KEY,
+        loadBinding: loadToggleKeyBinding,
+        saveBinding: saveToggleKeyBinding,
+        defaultBindingForPlatform: defaultToggleKeyBindingForPlatform,
+        labelKey: "options_hanYong_toggleKey_label",
+        descriptionKey: "options_hanYong_toggleKey_description",
+        peerKind: "hanja",
+        peerUnboundMessageKey: "options_keyBinding_hanjaUnbound",
+    },
+    hanja: {
+        kind: "hanja",
+        storageKey: HANJA_KEY_STORAGE_KEY,
+        loadBinding: loadHanjaKeyBinding,
+        saveBinding: saveHanjaKeyBinding,
+        defaultBindingForPlatform: defaultHanjaKeyBindingForPlatform,
+        labelKey: "options_hanja_conversionKey_label",
+        descriptionKey: "options_hanja_conversionKey_description",
+        peerKind: "hanYong",
+        peerUnboundMessageKey: "options_keyBinding_hanYongUnbound",
+    },
+};
+
+const config = computed(() => keySettingConfigs[props.kind]);
+const peerConfig = computed(() => keySettingConfigs[config.value.peerKind]);
 
 const binding = ref<KeyBinding | null>(null);
 const capturing = ref(false);
 const invalid = ref(false);
+const statusMessage = ref("");
+const statusWarning = ref(false);
 // Live "Ctrl + Shift +" prefix shown while modifiers are held mid-capture.
 const captureProgress = ref("");
 const captureProgressAccessible = ref("");
 const keyBindingPlatform = currentKeyBindingPlatform();
+let storageChangeListener: ((changes: Record<string, chrome.storage.StorageChange>, areaName: string) => void) | null =
+    null;
 
 // A bare modifier keydown is ambiguous: pressed and released alone it's a
 // lone-modifier binding (e.g. Right Alt); held while another key arrives it's
@@ -48,7 +105,7 @@ const bindingAccessibleLabel = computed(() => {
 // The binding box is now a button; give it a self-describing accessible name
 // (field label + current value) so it reads as the toggle-key control rather
 // than a bare value when a screen reader lands on it.
-const bindingButtonLabel = computed(() => `${t("options_hanYong_toggleKey_label")}: ${bindingAccessibleLabel.value}`);
+const bindingButtonLabel = computed(() => `${t(config.value.labelKey)}: ${bindingAccessibleLabel.value}`);
 
 const hintMessageKey = computed<MessageKey>(() =>
     keyBindingPlatform === "mac" ? "options_hanYong_toggleKey_hint_mac" : "options_hanYong_toggleKey_hint"
@@ -58,27 +115,62 @@ const invalidMessageKey = computed<MessageKey>(() =>
 );
 
 onMounted(async () => {
-    binding.value = await loadToggleKeyBinding();
+    await reloadBinding();
+    storageChangeListener = (changes, areaName) => {
+        if (areaName === "local" && config.value.storageKey in changes) {
+            reloadBinding().catch((error) => console.error("reloadBinding failed:", error));
+        }
+    };
+    api.storage.onChanged.addListener(storageChangeListener);
 });
 
-onUnmounted(stopCapture);
+onUnmounted(() => {
+    stopCapture();
+    if (storageChangeListener) {
+        api.storage.onChanged.removeListener(storageChangeListener);
+        storageChangeListener = null;
+    }
+});
 
-function persist(next: KeyBinding | null) {
+async function reloadBinding() {
+    binding.value = await config.value.loadBinding();
+}
+
+async function persist(next: KeyBinding | null) {
+    statusMessage.value = "";
+    statusWarning.value = false;
+    const collisionStatus = next ? await unbindCollidingPeer(next) : "";
     binding.value = next;
-    void saveToggleKeyBinding(next);
+    await config.value.saveBinding(next);
+    statusMessage.value = collisionStatus;
+    statusWarning.value = !!collisionStatus;
+}
+
+async function unbindCollidingPeer(next: KeyBinding): Promise<string> {
+    const peer = peerConfig.value;
+    const other = await peer.loadBinding();
+    if (!other || !keyBindingsCollide(next, other)) {
+        return "";
+    }
+
+    await peer.saveBinding(null);
+    notifyKeyBindingUnbound(peer.kind);
+    return t(config.value.peerUnboundMessageKey, formatKeyBinding(other, { platform: keyBindingPlatform }));
 }
 
 function turnOff() {
     stopCapture();
-    persist(null);
+    void persist(null);
 }
 
 function resetToDefault() {
     stopCapture();
-    persist(defaultToggleKeyBindingForPlatform(keyBindingPlatform));
+    void persist(config.value.defaultBindingForPlatform(keyBindingPlatform));
 }
 
 function startCapture() {
+    statusMessage.value = "";
+    statusWarning.value = false;
     invalid.value = false;
     captureProgress.value = "";
     captureProgressAccessible.value = "";
@@ -99,7 +191,7 @@ function stopCapture() {
 }
 
 function finishCapture(captured: KeyBinding) {
-    persist(captured);
+    void persist(captured);
     stopCapture();
 }
 
@@ -147,7 +239,7 @@ function onCaptureKeydown(event: KeyboardEvent) {
     // A non-modifier key (with any held modifiers) completes the combo.
     pendingModifier = null;
     const captured = keyBindingFromEvent(event);
-    if (!isValidToggleKeyBinding(captured, keyBindingPlatform)) {
+    if (!isValidImeActionKeyBinding(captured, keyBindingPlatform)) {
         invalid.value = true; // invalid binding — keep capturing
         captureProgress.value = "";
         captureProgressAccessible.value = "";
@@ -167,7 +259,7 @@ function onCaptureKeyup(event: KeyboardEvent) {
     if (pendingModifier?.code === event.code && modifierCount(event) === 0) {
         const captured = pendingModifier;
         pendingModifier = null;
-        if (!isValidToggleKeyBinding(captured, keyBindingPlatform)) {
+        if (!isValidImeActionKeyBinding(captured, keyBindingPlatform)) {
             invalid.value = true; // e.g. lone Shift / Win on non-Mac
             captureProgress.value = "";
             captureProgressAccessible.value = "";
@@ -185,11 +277,11 @@ function onCaptureKeyup(event: KeyboardEvent) {
 <template>
     <div class="toggle-key">
         <span class="label">
-            {{ t("options_hanYong_toggleKey_label") }}
+            {{ t(config.labelKey) }}
             <span
                 class="help"
-                :title="t('options_hanYong_toggleKey_description')"
-                :aria-label="t('options_hanYong_toggleKey_description')"
+                :title="t(config.descriptionKey)"
+                :aria-label="t(config.descriptionKey)"
                 >?</span
             >
         </span>
@@ -221,8 +313,13 @@ function onCaptureKeyup(event: KeyboardEvent) {
         <!-- Shown only while capturing, right under the controls: the capture hint,
              or the validation error if an invalid key was pressed. The general
              description lives in the heading's "?" tooltip. -->
-        <p v-if="invalid || capturing" class="feedback" :class="{ error: invalid }" role="status">
-            {{ invalid ? t(invalidMessageKey) : t(hintMessageKey) }}
+        <p
+            v-if="invalid || capturing || statusMessage"
+            class="feedback"
+            :class="{ error: invalid, warning: statusWarning && !invalid }"
+            role="status"
+        >
+            {{ invalid ? t(invalidMessageKey) : statusMessage || t(hintMessageKey) }}
         </p>
     </div>
 </template>
@@ -296,5 +393,10 @@ function onCaptureKeyup(event: KeyboardEvent) {
 .feedback.error {
     font-style: normal;
     color: var(--error-color);
+}
+
+.feedback.warning {
+    font-style: normal;
+    color: var(--warning-text-color);
 }
 </style>

--- a/src/options-app/key-binding-events.ts
+++ b/src/options-app/key-binding-events.ts
@@ -1,0 +1,15 @@
+export type ImeKeySettingKind = "hanYong" | "hanja";
+
+export const keyBindingUnboundEvent = "kime-key-binding-unbound";
+
+export type KeyBindingUnboundEventDetail = {
+    kind: ImeKeySettingKind;
+};
+
+export function notifyKeyBindingUnbound(kind: ImeKeySettingKind): void {
+    window.dispatchEvent(
+        new CustomEvent<KeyBindingUnboundEventDetail>(keyBindingUnboundEvent, {
+            detail: { kind },
+        })
+    );
+}

--- a/src/options-app/key-binding-settings.ts
+++ b/src/options-app/key-binding-settings.ts
@@ -1,0 +1,96 @@
+import {
+    KeyBinding,
+    KeyBindingPlatform,
+    currentKeyBindingPlatform,
+    defaultToggleKeyBindingForPlatform,
+    formatKeyBinding,
+    keyBindingsCollide,
+} from "../keyboard/key-binding";
+import { defaultHanjaKeyBindingForPlatform } from "../composition/hanja/hanja-key";
+import { TOGGLE_KEY_STORAGE_KEY, loadToggleKeyBinding, saveToggleKeyBinding } from "../settings/toggle-key-store";
+import { HANJA_KEY_STORAGE_KEY, loadHanjaKeyBinding, saveHanjaKeyBinding } from "../settings/hanja-key-store";
+import { t, type MessageKey } from "../i18n";
+import { ImeKeySettingKind, notifyKeyBindingUnbound } from "./key-binding-events";
+
+/**
+ * Everything a `KeyBindingField` needs to drive one configurable IME key, as
+ * plain data. The field component is generic and receives one of these as a
+ * prop; the registry below lists every key so collision handling can scan across
+ * all of them.
+ *
+ * **To add another configurable key:** add a config object and list it in
+ * `keyBindingFieldConfigs` (guarded by its feature flag, if any). The field,
+ * collision, and flash machinery need no changes — they are driven entirely by
+ * this data.
+ */
+export type KeyBindingFieldConfig = {
+    kind: ImeKeySettingKind;
+    storageKey: string;
+    loadBinding: () => Promise<KeyBinding | null>;
+    saveBinding: (binding: KeyBinding | null) => Promise<void>;
+    defaultBindingForPlatform: (platform: KeyBindingPlatform) => KeyBinding;
+    labelKey: MessageKey;
+    descriptionKey: MessageKey;
+    /** Shown in another field when *this* key is the one unbound by a collision. */
+    unboundMessageKey: MessageKey;
+};
+
+export const hanYongKeyConfig: KeyBindingFieldConfig = {
+    kind: "hanYong",
+    storageKey: TOGGLE_KEY_STORAGE_KEY,
+    loadBinding: loadToggleKeyBinding,
+    saveBinding: saveToggleKeyBinding,
+    defaultBindingForPlatform: defaultToggleKeyBindingForPlatform,
+    labelKey: "options_hanYong_toggleKey_label",
+    descriptionKey: "options_hanYong_toggleKey_description",
+    unboundMessageKey: "options_keyBinding_hanYongUnbound",
+};
+
+export const hanjaKeyConfig: KeyBindingFieldConfig = {
+    kind: "hanja",
+    storageKey: HANJA_KEY_STORAGE_KEY,
+    loadBinding: loadHanjaKeyBinding,
+    saveBinding: saveHanjaKeyBinding,
+    defaultBindingForPlatform: defaultHanjaKeyBindingForPlatform,
+    labelKey: "options_hanja_conversionKey_label",
+    descriptionKey: "options_hanja_conversionKey_description",
+    unboundMessageKey: "options_keyBinding_hanjaUnbound",
+};
+
+/**
+ * Every configurable key that exists in this build. Flag-gated keys are only
+ * included when their feature is built in: `process.env.KIME_ENABLE_HANJA` is
+ * inlined at build time, so with the flag off the Hanja entry (and, with it, the
+ * Hanja key store) tree-shakes out of the production bundle — and the Han/Yong
+ * key can never "collide" with a key the user can't reach.
+ */
+export const keyBindingFieldConfigs: readonly KeyBindingFieldConfig[] = [
+    hanYongKeyConfig,
+    ...(process.env.KIME_ENABLE_HANJA === "true" ? [hanjaKeyConfig] : []),
+];
+
+/**
+ * Resolve a collision for a key the user is about to set. If `next` would fire on
+ * the same keydown as another configured key's current binding, that other key is
+ * unbound (a physical key can't drive two IME actions), its field is flashed, and
+ * a message naming what was unbound is returned. Scans every *other* available
+ * key, so it scales as more keys are added. Returns "" when there is no collision.
+ */
+export async function resolveKeyBindingCollision(self: KeyBindingFieldConfig, next: KeyBinding): Promise<string> {
+    const platform = currentKeyBindingPlatform();
+
+    for (const other of keyBindingFieldConfigs) {
+        if (other.kind === self.kind) {
+            continue;
+        }
+
+        const otherBinding = await other.loadBinding();
+        if (otherBinding && keyBindingsCollide(next, otherBinding)) {
+            await other.saveBinding(null);
+            notifyKeyBindingUnbound(other.kind);
+            return t(other.unboundMessageKey, formatKeyBinding(otherBinding, { platform }));
+        }
+    }
+
+    return "";
+}

--- a/src/options-app/key-binding-settings.ts
+++ b/src/options-app/key-binding-settings.ts
@@ -69,14 +69,26 @@ export const keyBindingFieldConfigs: readonly KeyBindingFieldConfig[] = [
     ...(process.env.KIME_ENABLE_HANJA === "true" ? [hanjaKeyConfig] : []),
 ];
 
+export type KeyBindingCollision = {
+    /** The storage key of the key that was unbound — so the field that triggered
+     *  the collision can drop its notice once that key is rebound. */
+    unboundStorageKey: string;
+    /** A message naming what was unbound, to show on the triggering field. */
+    message: string;
+};
+
 /**
  * Resolve a collision for a key the user is about to set. If `next` would fire on
  * the same keydown as another configured key's current binding, that other key is
  * unbound (a physical key can't drive two IME actions), its field is flashed, and
- * a message naming what was unbound is returned. Scans every *other* available
- * key, so it scales as more keys are added. Returns "" when there is no collision.
+ * the unbound key + a message naming it are returned. Scans every *other*
+ * available key, so it scales as more keys are added. Returns null when there is
+ * no collision.
  */
-export async function resolveKeyBindingCollision(self: KeyBindingFieldConfig, next: KeyBinding): Promise<string> {
+export async function resolveKeyBindingCollision(
+    self: KeyBindingFieldConfig,
+    next: KeyBinding
+): Promise<KeyBindingCollision | null> {
     const platform = currentKeyBindingPlatform();
 
     for (const other of keyBindingFieldConfigs) {
@@ -88,9 +100,12 @@ export async function resolveKeyBindingCollision(self: KeyBindingFieldConfig, ne
         if (otherBinding && keyBindingsCollide(next, otherBinding)) {
             await other.saveBinding(null);
             notifyKeyBindingUnbound(other.kind);
-            return t(other.unboundMessageKey, formatKeyBinding(otherBinding, { platform }));
+            return {
+                unboundStorageKey: other.storageKey,
+                message: t(other.unboundMessageKey, formatKeyBinding(otherBinding, { platform })),
+            };
         }
     }
 
-    return "";
+    return null;
 }

--- a/src/options-app/options-page.vue
+++ b/src/options-app/options-page.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
-import { onMounted } from "vue";
+import { defineAsyncComponent, onMounted } from "vue";
 import { initSettings } from "./use-settings";
 import { t } from "../i18n";
 import OnScreenKeyboardSection from "./OnScreenKeyboardSection.vue";
 import HanYongSection from "./HanYongSection.vue";
+
+const HanjaSection =
+    process.env.KIME_ENABLE_HANJA === "true" ? defineAsyncComponent(() => import("./HanjaSection.vue")) : undefined;
+const showHanjaSection = !!HanjaSection;
 
 onMounted(initSettings);
 </script>
@@ -12,6 +16,7 @@ onMounted(initSettings);
     <main class="options-page">
         <h1>{{ t("options_title") }}</h1>
         <HanYongSection />
+        <HanjaSection v-if="showHanjaSection" />
         <OnScreenKeyboardSection />
     </main>
 </template>
@@ -62,6 +67,23 @@ section {
     background-color: var(--section-bg);
     border: 1px solid var(--section-border);
     border-radius: var(--radius);
+}
+
+div.setting.key-binding-flash {
+    border-radius: var(--radius-sm);
+    animation: key-binding-flash 1500ms ease-out;
+}
+
+@keyframes key-binding-flash {
+    0%,
+    66.666% {
+        background-color: var(--warning-bg-color);
+        box-shadow: 0 0 0 3px var(--warning-bg-color);
+    }
+    100% {
+        background-color: transparent;
+        box-shadow: none;
+    }
 }
 
 section h2 {

--- a/src/options-app/use-key-binding-flash.ts
+++ b/src/options-app/use-key-binding-flash.ts
@@ -1,0 +1,47 @@
+import { onMounted, onUnmounted, ref } from "vue";
+import { ImeKeySettingKind, KeyBindingUnboundEventDetail, keyBindingUnboundEvent } from "./key-binding-events";
+
+/**
+ * How long the "this key was just unbound" highlight stays on, in milliseconds.
+ * Must match the `key-binding-flash` CSS animation duration in options-page.vue.
+ */
+const FLASH_DURATION_MS = 1500;
+
+/**
+ * Briefly highlight a key-binding setting when its binding is unbound by a
+ * collision in the *other* section. Both the Han/Yong and Hanja sections use
+ * this: each listens for the shared unbound event and flashes only when the
+ * event targets its own `kind`.
+ *
+ * Returns a `keyBindingFlash` ref to bind to the `.key-binding-flash` class.
+ */
+export function useKeyBindingFlash(kind: ImeKeySettingKind) {
+    const keyBindingFlash = ref(false);
+    let flashTimeout: number | undefined;
+
+    function onKeyBindingUnbound(event: Event) {
+        const detail = (event as CustomEvent<KeyBindingUnboundEventDetail>).detail;
+        if (detail.kind !== kind) {
+            return;
+        }
+
+        // Restart the animation even if a previous flash is still showing: clear
+        // the class, then re-add it on the next frame so the keyframes replay.
+        keyBindingFlash.value = false;
+        window.clearTimeout(flashTimeout);
+        window.requestAnimationFrame(() => {
+            keyBindingFlash.value = true;
+            flashTimeout = window.setTimeout(() => {
+                keyBindingFlash.value = false;
+            }, FLASH_DURATION_MS);
+        });
+    }
+
+    onMounted(() => window.addEventListener(keyBindingUnboundEvent, onKeyBindingUnbound));
+    onUnmounted(() => {
+        window.removeEventListener(keyBindingUnboundEvent, onKeyBindingUnbound);
+        window.clearTimeout(flashTimeout);
+    });
+
+    return { keyBindingFlash };
+}

--- a/src/service-worker/state-manager.test.ts
+++ b/src/service-worker/state-manager.test.ts
@@ -75,9 +75,10 @@ beforeEach(() => {
 });
 
 function withSettings(
-    overrides: Omit<Partial<Settings>, "onScreenKeyboard" | "hanYong"> & {
+    overrides: Omit<Partial<Settings>, "onScreenKeyboard" | "hanYong" | "hanja"> & {
         onScreenKeyboard?: Partial<Settings["onScreenKeyboard"]>;
         hanYong?: Partial<Settings["hanYong"]>;
+        hanja?: Partial<Settings["hanja"]>;
     }
 ) {
     sync = {
@@ -85,6 +86,7 @@ function withSettings(
         ...overrides,
         onScreenKeyboard: { ...defaultSettings.onScreenKeyboard, ...overrides.onScreenKeyboard },
         hanYong: { ...defaultSettings.hanYong, ...overrides.hanYong },
+        hanja: { ...defaultSettings.hanja, ...overrides.hanja },
     };
 }
 
@@ -103,6 +105,17 @@ describe("fresh-session seeding from persistence", () => {
         await manager.sendStateToTab(1);
 
         expect(lastSentTo(1)?.isHanYongEnabled).toBe(true);
+    });
+
+    it("enables Hanja conversion display by default", async () => {
+        withSettings({});
+        const manager = new StateManager();
+
+        await manager.sendStateToTab(1);
+
+        expect(lastSentTo(1)?.isHanjaEnabled).toBe(true);
+        expect(lastSentTo(1)?.showHanjaSimplified).toBe(true);
+        expect(lastSentTo(1)?.showHanjaPinyin).toBe(true);
     });
 
     it("AlwaysOff starts the feature off", async () => {
@@ -404,6 +417,22 @@ describe("sync across tabs", () => {
         expect(lastSentTo(2)?.isHanYongEnabled).toBe(true);
         expect(lastSentTo(2)?.koreanKeyboardMode).toBe(KoreanKeyboardMode.Hangul);
         expect(lastSentTo(2)?.isOnScreenKeyboardEnabled).toBe(true);
+    });
+
+    it("pushes Hanja setting changes to open tabs immediately", async () => {
+        withSettings({});
+        tabs = [{ id: 1, active: true }, { id: 2 }];
+        const manager = new StateManager();
+
+        withSettings({ hanja: { enabled: false, showSimplified: false, showPinyin: true } });
+        await manager.onSettingsChanged();
+
+        expect(lastSentTo(1)?.isHanjaEnabled).toBe(false);
+        expect(lastSentTo(1)?.showHanjaSimplified).toBe(false);
+        expect(lastSentTo(1)?.showHanjaPinyin).toBe(true);
+        expect(lastSentTo(2)?.isHanjaEnabled).toBe(false);
+        expect(lastSentTo(2)?.showHanjaSimplified).toBe(false);
+        expect(lastSentTo(2)?.showHanjaPinyin).toBe(true);
     });
 });
 

--- a/src/service-worker/state-manager.ts
+++ b/src/service-worker/state-manager.ts
@@ -451,6 +451,9 @@ export class StateManager {
 
         return {
             isHanYongEnabled,
+            isHanjaEnabled: settings.hanja.enabled,
+            showHanjaSimplified: settings.hanja.showSimplified,
+            showHanjaPinyin: settings.hanja.showPinyin,
             isOnScreenKeyboardEnabled: tabState.isOnScreenKeyboardEnabled ?? false,
             koreanKeyboardMode:
                 isHanYongEnabled && tabState.koreanKeyboardMode === KoreanKeyboardMode.Hangul

--- a/src/settings/hanja-key-store.test.ts
+++ b/src/settings/hanja-key-store.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment node
+ *
+ * Pure storage logic — run in the `node` env (the project default is jsdom)
+ * which has a real `structuredClone`, matching the browser runtimes this ships
+ * to. jsdom does not provide it.
+ */
+import { HANJA_KEY_STORAGE_KEY, loadHanjaKeyBinding, saveHanjaKeyBinding } from "./hanja-key-store";
+import { KeyBinding } from "../keyboard/key-binding";
+import { KeyCode } from "../keyboard/korean-keyboard-map";
+import { defaultHanjaKeyBinding, macDefaultHanjaKeyBinding } from "../composition/hanja/hanja-key";
+
+let get: ReturnType<typeof jest.fn>;
+let set: ReturnType<typeof jest.fn>;
+
+beforeEach(() => {
+    get = jest.fn();
+    set = jest.fn(() => Promise.resolve());
+    Object.assign(globalThis, { chrome: { storage: { local: { get, set } } } });
+});
+
+describe("loadHanjaKeyBinding", () => {
+    it("returns the default Right Ctrl binding when nothing is stored on non-Mac platforms", async () => {
+        get.mockReturnValue(Promise.resolve({}));
+
+        const binding = await loadHanjaKeyBinding("default");
+
+        expect(binding).toEqual(defaultHanjaKeyBinding);
+        expect(binding).not.toBe(defaultHanjaKeyBinding);
+    });
+
+    it("returns the default Right Option binding when nothing is stored on macOS", async () => {
+        get.mockReturnValue(Promise.resolve({}));
+
+        const binding = await loadHanjaKeyBinding("mac");
+
+        expect(binding).toEqual(macDefaultHanjaKeyBinding);
+        expect(binding).not.toBe(macDefaultHanjaKeyBinding);
+    });
+
+    it("returns null when the Hanja key was explicitly turned off", async () => {
+        get.mockReturnValue(Promise.resolve({ [HANJA_KEY_STORAGE_KEY]: null }));
+
+        expect(await loadHanjaKeyBinding()).toBeNull();
+    });
+
+    it("returns the stored custom binding regardless of platform", async () => {
+        const altS: KeyBinding = { code: KeyCode.KeyS, ctrl: false, alt: true, shift: false, meta: false };
+        get.mockReturnValue(Promise.resolve({ [HANJA_KEY_STORAGE_KEY]: altS }));
+
+        expect(await loadHanjaKeyBinding()).toEqual(altS);
+        expect(await loadHanjaKeyBinding("mac")).toEqual(altS);
+    });
+});
+
+describe("saveHanjaKeyBinding", () => {
+    it("writes a binding to storage.local under the Hanja key", async () => {
+        const altS: KeyBinding = { code: KeyCode.KeyS, ctrl: false, alt: true, shift: false, meta: false };
+
+        await saveHanjaKeyBinding(altS);
+
+        expect(set).toHaveBeenCalledWith({ [HANJA_KEY_STORAGE_KEY]: altS });
+    });
+
+    it("writes null to turn the Hanja key off", async () => {
+        await saveHanjaKeyBinding(null);
+
+        expect(set).toHaveBeenCalledWith({ [HANJA_KEY_STORAGE_KEY]: null });
+    });
+});

--- a/src/settings/hanja-key-store.ts
+++ b/src/settings/hanja-key-store.ts
@@ -1,0 +1,29 @@
+import { api } from "../platform/browser-api";
+import { KeyBinding, KeyBindingPlatform, currentKeyBindingPlatform } from "../keyboard/key-binding";
+import { defaultHanjaKeyBindingForPlatform } from "../composition/hanja/hanja-key";
+
+/**
+ * The Hanja conversion key is stored per machine in `api.storage.local`, for
+ * the same reason as the Han/Yong toggle key: useful physical keys vary across
+ * keyboards and operating systems.
+ *
+ * Stored value semantics:
+ *   - key absent  → never set → fall back to the platform default
+ *   - `null`      → the user explicitly turned the Hanja key off
+ *   - a binding   → the user's chosen key/combo
+ */
+export const HANJA_KEY_STORAGE_KEY = "hanjaConversionKey";
+
+export async function loadHanjaKeyBinding(
+    platform: KeyBindingPlatform = currentKeyBindingPlatform()
+): Promise<KeyBinding | null> {
+    const result = (await api.storage.local.get(HANJA_KEY_STORAGE_KEY)) as Record<string, unknown>;
+    if (!(HANJA_KEY_STORAGE_KEY in result)) {
+        return defaultHanjaKeyBindingForPlatform(platform);
+    }
+    return (result[HANJA_KEY_STORAGE_KEY] as KeyBinding | null) ?? null;
+}
+
+export async function saveHanjaKeyBinding(binding: KeyBinding | null): Promise<void> {
+    await api.storage.local.set({ [HANJA_KEY_STORAGE_KEY]: binding });
+}

--- a/src/settings/settings-store.test.ts
+++ b/src/settings/settings-store.test.ts
@@ -40,6 +40,7 @@ describe("loadSettings", () => {
     it("overlays stored values, keeping defaults for untouched keys", async () => {
         stored({
             hanYong: { persistence: Persistence.KeepLastState, syncAcrossTabs: true },
+            hanja: { enabled: false, showPinyin: false },
         });
 
         const settings = await loadSettings();
@@ -47,6 +48,9 @@ describe("loadSettings", () => {
         expect(settings.hanYong.persistence).toBe(Persistence.KeepLastState);
         expect(settings.hanYong.syncAcrossTabs).toBe(true);
         expect(settings.hanYong.enabled).toBe(true);
+        expect(settings.hanja.enabled).toBe(false);
+        expect(settings.hanja.showSimplified).toBe(true);
+        expect(settings.hanja.showPinyin).toBe(false);
         expect(settings.onScreenKeyboard.persistence).toBe(Persistence.AlwaysOff);
     });
 
@@ -101,6 +105,12 @@ describe("loadSettings", () => {
         stored({ hanYong: { persistence: Persistence.KeepLastState } });
 
         expect((await loadSettings()).hanYong.enabled).toBe(true);
+    });
+
+    it("keeps Hanja defaults when older stored settings omit them", async () => {
+        stored({ hanYong: { persistence: Persistence.KeepLastState } });
+
+        expect((await loadSettings()).hanja).toEqual(defaultSettings.hanja);
     });
 });
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -28,19 +28,29 @@ export interface HanYongSettings extends FeatureSettings {
     enabled: boolean;
 }
 
+export interface HanjaSettings {
+    /** Whether Hanja conversion is enabled. */
+    enabled: boolean;
+    /** Show simplified Chinese metadata for each candidate when available. */
+    showSimplified: boolean;
+    /** Show pinyin metadata for each candidate when available. */
+    showPinyin: boolean;
+}
+
 /**
  * The extension's settings. A plain, typed object — persisted to
  * `chrome.storage.sync` (see `settings-store.ts`) and edited by the options
  * page. Every context reads the same global config from storage; there is no
  * per-tab dimension here (live per-tab state lives in `StateManager`).
  *
- * The Han/Yong toggle **key** is deliberately *not* here: it is stored per
- * machine in `api.storage.local` (see `toggle-key-store.ts`), so it doesn't
+ * The Han/Yong toggle **key** and Hanja conversion **key** are deliberately
+ * *not* here: they are stored per machine in `api.storage.local`, so they don't
  * sync across machines whose keyboards differ.
  */
 export interface Settings {
     onScreenKeyboard: OnScreenKeyboardSettings;
     hanYong: HanYongSettings;
+    hanja: HanjaSettings;
 }
 
 export const defaultSettings: Settings = {
@@ -53,6 +63,11 @@ export const defaultSettings: Settings = {
         enabled: true,
         persistence: Persistence.AlwaysOff,
         syncAcrossTabs: false,
+    },
+    hanja: {
+        enabled: true,
+        showSimplified: true,
+        showPinyin: true,
     },
 };
 

--- a/src/styles/_design-tokens.scss
+++ b/src/styles/_design-tokens.scss
@@ -43,6 +43,8 @@
     --button-hover-bg: light-dark(#f1f5f9, #292929);
     --success-color: light-dark(#168a45, #63d38a);
     --error-color: light-dark(#c0392b, #f87171);
+    --warning-bg-color: light-dark(#ffecd0, #503000);
+    --warning-text-color: light-dark(#ff9800, #ff9800);
 
     /* Notice / error banners (were inline light-dark() literals in
        GettingStartedPage). */

--- a/src/styles/_design-tokens.scss
+++ b/src/styles/_design-tokens.scss
@@ -44,7 +44,9 @@
     --success-color: light-dark(#168a45, #63d38a);
     --error-color: light-dark(#c0392b, #f87171);
     --warning-bg-color: light-dark(#ffecd0, #503000);
-    --warning-text-color: light-dark(#ff9800, #ff9800);
+    /* Light value is a darker amber than the dark value so warning text keeps
+       AA contrast on the light section background (#ff9800 alone is ~2:1). */
+    --warning-text-color: light-dark(#9a5b00, #ff9800);
 
     /* Notice / error banners (were inline light-dark() literals in
        GettingStartedPage). */


### PR DESCRIPTION
## Summary
- add synced Hanja enable/display settings and local Hanja conversion key storage
- add feature-flagged Hanja options UI with key-collision unbinding feedback
- wire content scripts/controllers to react to Hanja settings and key changes without reload

## Verification
- npm run validate

Closes #190