### PR TITLE
Let Hanja conversion work regardless of Han/Yong mode

### DIFF
--- a/src/composition/hangul-ime-controller.test.ts
+++ b/src/composition/hangul-ime-controller.test.ts
@@ -613,7 +613,7 @@ describe("HangulImeController Hanja candidate selection (KIME_ENABLE_HANJA)", ()
         const element = document.createElement("textarea");
         const controller = makeController(element, undefined, hanjaOptions);
         controller.activate();
-        return { element, endComposition, deleteContentBackwards, inputCharacter };
+        return { element, controller, endComposition, deleteContentBackwards, inputCharacter };
     }
 
     function composeHan(element: HTMLElement) {
@@ -804,6 +804,41 @@ describe("HangulImeController Hanja candidate selection (KIME_ENABLE_HANJA)", ()
         dispatchKeydown(element, "Digit3", "3");
 
         expect(element.value).toBe("恨");
+        expect(document.querySelector(HANJA_CANDIDATE_WINDOW_SELECTOR)).toBeNull();
+    });
+
+    // Hanja conversion is independent of Han/Yong mode: it must work on a preceding
+    // Hangul syllable even when the controller is inactive (영 mode, or our Hangul
+    // typing disabled while the OS IME supplies the Hangul).
+    it("opens candidates and commits while inactive", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const element = document.createElement("textarea");
+        element.value = "한";
+        element.selectionStart = element.selectionEnd = 1;
+        const controller = makeController(element); // deliberately NOT activated
+        expect(controller.isActive).toBe(false);
+
+        pressRightCtrl(element);
+        await settleHanjaLookup();
+
+        expect(candidateValues()).toEqual(["韓", "寒", "恨"]);
+
+        dispatchKeydown(element, "Digit1", "1");
+        expect(element.value).toBe("韓");
+    });
+
+    // The active-state guard was dropped, but staleness must still hold: a mode
+    // change mid-lookup bumps the lookup generation, so the resolved window is
+    // discarded rather than shown late.
+    it("does not open a stale candidate window when the mode changes mid-lookup", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element, controller } = composingController();
+        composeHan(element);
+
+        pressRightCtrl(element); // starts the async lookup
+        controller.deactivate(); // mode change bumps the lookup generation
+        await settleHanjaLookup();
+
         expect(document.querySelector(HANJA_CANDIDATE_WINDOW_SELECTOR)).toBeNull();
     });
 

--- a/src/composition/hangul-ime-controller.ts
+++ b/src/composition/hangul-ime-controller.ts
@@ -510,7 +510,12 @@ export class HangulImeController {
             return;
         }
 
-        if (lookupGeneration !== this.hanjaLookupGeneration || candidates.length === 0 || !this._isActive) {
+        // Deliberately not gated on `_isActive`: Hanja conversion is independent of
+        // Han/Yong mode (it converts existing Hangul, including text from the OS
+        // IME while our Hangul typing is off), matching the Microsoft IME, where the
+        // Hanja key works in 영 mode too. Staleness from a mode change mid-lookup is
+        // still covered — `deactivate()` bumps `hanjaLookupGeneration`.
+        if (lookupGeneration !== this.hanjaLookupGeneration || candidates.length === 0) {
             return;
         }
 


### PR DESCRIPTION
Closes #196

Hanja conversion no longer requires the IME to be in Han mode. It now converts a composing or preceding Hangul syllable regardless of Han/Yong mode — including Hangul from the OS IME while our Hangul typing is off — by dropping the `!this._isActive` clause in `openHanjaCandidateSelection`. Staleness is preserved by the existing lookup-generation check.

Tests cover conversion while inactive and that a mode change mid-lookup doesn't show a stale window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)