### PR TITLE
Extract HanjaCandidateController from HangulImeController

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -121,9 +121,9 @@ flowchart LR
     end
 
     opts -->|write settings| sync
-    opts -->|write toggle key| local
+    opts -->|write key bindings| local
     csc <-->|read / write arrangement| sync
-    csc -->|read toggle key| local
+    csc -->|read key bindings| local
     sm <-->|tab + live state| session
     sm <-->|lastState| local
     sync -->|read settings| sm
@@ -133,15 +133,15 @@ flowchart LR
 
     sync -. "onChanged ⇒ re-derive & push state" .-> sm
     sync -. "onChanged ⇒ re-apply arrangement" .-> csc
-    local -. "onChanged ⇒ reload toggle key" .-> csc
+    local -. "onChanged ⇒ reload key bindings" .-> csc
 ```
 
 - **`sync`** — the user's `Settings` (incl. the keyboard's key arrangement).
   Roams across devices.
 - **`local`** — per-device things: the remembered `lastState` (for "keep last
-  state"), the Han/Yong **toggle key** binding, and the keyboard's pixel
-  **position** per site. These are device-specific, so they deliberately don't
-  roam.
+  state"), the **key bindings** (the Han/Yong toggle key and the Hanja conversion
+  key), and the keyboard's pixel **position** per site. These are device-specific,
+  so they deliberately don't roam.
 - **`session`** — per-tab runtime state (`tabState-<id>`), the global `liveState`
   new tabs inherit, the `focusedFrame-<id>` used to route keys, and the handed-off
   romanize **popup text**. Cleared on browser close.
@@ -160,13 +160,14 @@ flowchart TB
     factory -->|CKEditor| ckAd["CkEditorAdapter"]
     factory -. "Google Docs ⇒ no adapter (unsupported)" .-> none(("∅"))
 
-    tim --> ime["HangulImeController"]
+    tim --> ime["HangulImeController<br/>(keystroke interpreter)"]
     ime --> compositor["HangulCompositor<br/>jamo ⇒ syllable blocks"]
     compositor --> blocks["hangul-block / hangul-maps"]
     ime --> box["compositing-box<br/>(composing overlay)"]
     ime --> adapter["chosen CompositionAdapter"]
     adapter --> el["Editable element"]
 
+    ime --> hanja["HanjaCandidateController<br/>(Hanja lifecycle)"]
     subgraph hanjaUI["Hanja conversion (on the convert key)"]
         hkey["hanja-key"]
         conv["hanja-converter"]
@@ -174,8 +175,8 @@ flowchart TB
         win["hanja-candidate-window"]
         ov["hanja-composition-overlay"]
     end
-    ime --> hanjaUI
-    ime --> client["Hanja provider client<br/>→ service worker lookup"]
+    hanja --> hanjaUI
+    hanja --> client["Hanja provider client<br/>→ service worker lookup"]
 ```
 
 - **`TextInputManager`** owns one `HangulImeController` for the focused element,
@@ -183,7 +184,10 @@ flowchart TB
   `CompositionAdapterFactory` based on the editor type (plain input,
   contentEditable, CKEditor). **Google Docs gets no adapter** and is unsupported.
 - **`HangulCompositor`** is the heart: it assembles jamo into syllable blocks.
-- **Hanja** conversion is layered on top: pressing the convert key asks the
-  service-worker dictionary (via the client), then drives the candidate window,
-  pager, and overlay.
+- **`HanjaCandidateController`** owns the whole Hanja conversion lifecycle —
+  whether a key starts a conversion, the service-worker dictionary lookup (via the
+  client), and the candidate window, pager, and overlay. `HangulImeController`
+  just offers it each keydown. It's deliberately independent of Han/Yong mode, so
+  it converts existing Hangul (including text typed by the OS IME) even while our
+  Hangul typing is off.
 ```

--- a/src/composition/hangul-ime-controller.test.ts
+++ b/src/composition/hangul-ime-controller.test.ts
@@ -827,6 +827,38 @@ describe("HangulImeController Hanja candidate selection (KIME_ENABLE_HANJA)", ()
         expect(element.value).toBe("韓");
     });
 
+    // The candidate window can be open while inactive, so candidate keys must be
+    // intercepted in the capture phase (ahead of a rich editor) regardless of mode —
+    // not just by the bubble handler. A body capture listener fires only if the
+    // event got past window-capture.
+    it("intercepts candidate keys in the capture phase while inactive", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const element = document.createElement("textarea");
+        element.value = "한";
+        element.selectionStart = element.selectionEnd = 1;
+        document.body.appendChild(element); // connected so the window-capture guard runs
+        const controller = makeController(element); // deliberately NOT activated
+        expect(controller.isActive).toBe(false);
+
+        pressRightCtrl(element);
+        await settleHanjaLookup();
+        expect(document.querySelector(HANJA_CANDIDATE_WINDOW_SELECTOR)).not.toBeNull();
+
+        let reachedBodyCapture = false;
+        document.body.addEventListener("keydown", () => (reachedBodyCapture = true), true);
+
+        const arrow = new KeyboardEvent("keydown", {
+            code: "ArrowDown",
+            key: "ArrowDown",
+            bubbles: true,
+            cancelable: true,
+        });
+        element.dispatchEvent(arrow);
+
+        expect(arrow.defaultPrevented).toBe(true); // handled
+        expect(reachedBodyCapture).toBe(false); // intercepted at window-capture, not left to the editor
+    });
+
     // The active-state guard was dropped, but staleness must still hold: a mode
     // change mid-lookup bumps the lookup generation, so the resolved window is
     // discarded rather than shown late.

--- a/src/composition/hangul-ime-controller.ts
+++ b/src/composition/hangul-ime-controller.ts
@@ -1,48 +1,15 @@
-﻿import { isKimeEvent } from "../messaging/dom-events";
+﻿import { cancelEvent, isKimeEvent } from "../messaging/dom-events";
 import { isModifierKey, isModifierKeyActive, KeyCode, keyMap } from "../keyboard/korean-keyboard-map";
-import {
-    KeyBinding,
-    defaultToggleKeyBindingForPlatform,
-    isModifierOnlyBinding,
-    matchesKeyBinding,
-} from "../keyboard/key-binding";
+import { KeyBinding, defaultToggleKeyBindingForPlatform, isModifierOnlyBinding } from "../keyboard/key-binding";
 import { HangulCompositor } from "./hangul-compositor";
 import { CompositionAdapterFactory } from "./composition-adapter-factory";
 import { CompositionAdapter } from "./composition-adapters/composition-adapter";
-import { HanjaCandidatePager } from "./hanja/hanja-candidate-pager";
-import {
-    HanjaCandidateDisplayOptions,
-    HanjaCandidateWindow,
-    HanjaCandidateWindowPage,
-} from "./hanja/hanja-candidate-window";
-import { HanjaCompositionOverlay } from "./hanja/hanja-composition-overlay";
-import { commitHanjaCandidate, getHanjaConversionTarget, HanjaConversionTarget } from "./hanja/hanja-converter";
-import { HanjaCandidate } from "./hanja/hanja-candidate";
+import { HanjaCandidateController, type HanjaImeOptions } from "./hanja/hanja-candidate-controller";
 import { HanjaDictionaryProvider, StaticHanjaDictionaryProvider } from "./hanja/hanja-dictionary-provider";
-import { defaultHanjaKeyBindingForPlatform } from "./hanja/hanja-key";
 
-type HanjaCandidateSelection = {
-    target: HanjaConversionTarget;
-    pager: HanjaCandidatePager<HanjaCandidate>;
-    overlay: HanjaCompositionOverlay;
-    window: HanjaCandidateWindow;
-};
-
-export type HanjaImeOptions = {
-    enabled: boolean;
-    keyBinding: KeyBinding | null;
-    showSimplified: boolean;
-    showPinyin: boolean;
-};
-
-function defaultHanjaImeOptions(): HanjaImeOptions {
-    return {
-        enabled: true,
-        keyBinding: defaultHanjaKeyBindingForPlatform(),
-        showSimplified: true,
-        showPinyin: true,
-    };
-}
+// Re-exported so existing importers (TextInputManager, tests) keep resolving it
+// from here even though it now lives with the Hanja controller.
+export type { HanjaImeOptions } from "./hanja/hanja-candidate-controller";
 
 /**
  * Controls the Hangul IME for a given element.
@@ -52,9 +19,7 @@ export class HangulImeController {
     private _isActive = false;
     private compositor = new HangulCompositor();
     private compositionAdapter: CompositionAdapter;
-    private hanjaCandidateSelection?: HanjaCandidateSelection;
-    private hanjaLookupGeneration = 0;
-    private hanjaOptions: HanjaImeOptions;
+    private hanja: HanjaCandidateController;
 
     private changeListeners: (() => void)[] = [];
     private eventListeners: {
@@ -79,7 +44,7 @@ export class HangulImeController {
     constructor(
         private readonly element: HTMLElement,
         compositionAdapter = CompositionAdapterFactory.createCompositionAdapter(element),
-        private readonly hanjaDictionaryProvider: HanjaDictionaryProvider = new StaticHanjaDictionaryProvider(),
+        hanjaDictionaryProvider: HanjaDictionaryProvider = new StaticHanjaDictionaryProvider(),
         hanjaOptions: Partial<HanjaImeOptions> = {}
     ) {
         if (!compositionAdapter) {
@@ -87,7 +52,14 @@ export class HangulImeController {
         }
 
         this.compositionAdapter = compositionAdapter;
-        this.hanjaOptions = { ...defaultHanjaImeOptions(), ...hanjaOptions };
+        this.hanja = new HanjaCandidateController(
+            this.element,
+            this.compositor,
+            this.compositionAdapter,
+            hanjaDictionaryProvider,
+            () => this.notifyOnEntry(),
+            hanjaOptions
+        );
 
         // Backspace during composition must be intercepted in the *capture* phase, on
         // window (the earliest point in event propagation). Rich editors like Word for
@@ -122,8 +94,8 @@ export class HangulImeController {
     }
 
     deactivate() {
-        this.invalidateHanjaLookup();
-        this.closeHanjaCandidateSelection();
+        this.hanja.cancelPendingLookup();
+        this.hanja.close();
 
         if (this.compositor.isCompositing()) {
             // Ending the composition with the current value is the correct thing to do with Korean.
@@ -143,10 +115,10 @@ export class HangulImeController {
      */
     dispose() {
         try {
-            this.invalidateHanjaLookup();
+            this.hanja.cancelPendingLookup();
             this.flushComposition();
         } finally {
-            this.closeHanjaCandidateSelection();
+            this.hanja.close();
             this._isActive = false;
             for (const { target, type, listener, capture } of this.eventListeners) {
                 target.removeEventListener(type, listener, capture);
@@ -170,22 +142,7 @@ export class HangulImeController {
     }
 
     setHanjaOptions(options: Partial<HanjaImeOptions>) {
-        const previousDisplayOptions = this.hanjaCandidateDisplayOptions();
-        this.hanjaOptions = { ...this.hanjaOptions, ...options };
-
-        if (!this.hanjaOptions.enabled || !this.hanjaOptions.keyBinding) {
-            this.invalidateHanjaLookup();
-            this.closeHanjaCandidateSelection();
-            return;
-        }
-
-        const nextDisplayOptions = this.hanjaCandidateDisplayOptions();
-        if (
-            previousDisplayOptions.showSimplified !== nextDisplayOptions.showSimplified ||
-            previousDisplayOptions.showPinyin !== nextDisplayOptions.showPinyin
-        ) {
-            this.refreshHanjaCandidateWindow();
-        }
+        this.hanja.setOptions(options);
     }
 
     private notifyOnEntry() {
@@ -207,26 +164,17 @@ export class HangulImeController {
 
             const code = event.code as KeyCode;
 
-            if (this.hanjaCandidateSelection && this.handleHanjaCandidateSelectionKey(event)) {
+            // Give the Hanja controller first dibs: it consumes candidate-window keys
+            // (and closes the window on any other key), then may start a conversion.
+            if (this.hanja.handleKey(event)) {
                 return;
             }
 
-            if (this.hanjaCandidateSelection) {
-                this.closeHanjaCandidateSelection();
+            if (this.hanja.tryStartConversion(event)) {
+                return;
             }
 
-            if (
-                process.env.KIME_ENABLE_HANJA === "true" &&
-                this.hanjaOptions.enabled &&
-                this.hanjaOptions.keyBinding &&
-                matchesKeyBinding(event, this.hanjaOptions.keyBinding)
-            ) {
-                if (this.startHanjaCandidateSelection(event)) {
-                    return;
-                }
-            }
-
-            this.invalidateHanjaLookup();
+            this.hanja.cancelPendingLookup();
 
             // Record the most recent modifier key (any side) and stop — modifier keys
             // aren't text. Tracking which one lets isToggleKeyHeld tell the configured
@@ -249,7 +197,7 @@ export class HangulImeController {
                     // character instead of letting the OS treat Alt/Cmd+key as a
                     // shortcut or menu trigger.
                     this.compositionAdapter.inputCharacter(event.key, code);
-                    this.cancelEvent(event);
+                    cancelEvent(event);
                     return;
                 }
 
@@ -322,7 +270,7 @@ export class HangulImeController {
             this.flushComposition();
         },
         mousedown: () => {
-            this.invalidateHanjaLookup();
+            this.hanja.cancelPendingLookup();
             this.flushComposition();
         },
     };
@@ -340,16 +288,20 @@ export class HangulImeController {
      * Everything else is left to the bubble-phase handler.
      */
     private keydownCaptureGuard = (event: KeyboardEvent): void => {
-        if (isKimeEvent(event) || !this._isActive) {
+        if (isKimeEvent(event)) {
             return;
         }
 
-        if (this.hanjaCandidateSelection && this.handleHanjaCandidateSelectionKey(event)) {
+        // The candidate window can be open regardless of Han/Yong mode, so handle it
+        // here (ahead of the editor) without gating on `_isActive`. A candidate key is
+        // consumed; any other key closes the window — either way the guard is done.
+        if (this.hanja.isOpen) {
+            this.hanja.handleKey(event);
             return;
         }
 
-        if (this.hanjaCandidateSelection) {
-            this.closeHanjaCandidateSelection();
+        // The composition-capture handling below only applies while Hangul typing is active.
+        if (!this._isActive) {
             return;
         }
 
@@ -433,7 +385,7 @@ export class HangulImeController {
         this.compositionAdapter.deleteContentBackwards();
         this.compositionAdapter.beginComposition(character!, KeyCode.Backspace);
 
-        this.cancelEvent(event);
+        cancelEvent(event);
         return true;
     }
 
@@ -452,7 +404,7 @@ export class HangulImeController {
         const jamo = event.shiftKey && key.jamo.shift ? key.jamo.shift : key.jamo.normal;
         this.addJamo(jamo, code);
 
-        this.cancelEvent(event);
+        cancelEvent(event);
     }
 
     /**
@@ -472,216 +424,10 @@ export class HangulImeController {
             this.compositionAdapter.updateComposition(block, KeyCode.Backspace);
             this.notifyOnEntry();
 
-            this.cancelEvent(event);
+            cancelEvent(event);
         } else {
             this.compositionAdapter.endComposition("x");
         }
-    }
-
-    private startHanjaCandidateSelection(event: KeyboardEvent): boolean {
-        const target = getHanjaConversionTarget(this.compositor, this.compositionAdapter);
-        if (!target) {
-            return false;
-        }
-
-        this.closeHanjaCandidateSelection();
-        const lookupGeneration = this.beginHanjaLookup();
-        this.cancelEvent(event);
-
-        if (target.kind === "composition") {
-            this.compositionAdapter.endComposition(target.reading);
-            this.compositor.reset();
-        }
-
-        const committedTarget: HanjaConversionTarget = {
-            ...target,
-            kind: "previous-character",
-        };
-        void this.openHanjaCandidateSelection(committedTarget, lookupGeneration);
-        return true;
-    }
-
-    private async openHanjaCandidateSelection(target: HanjaConversionTarget, lookupGeneration: number): Promise<void> {
-        let candidates: readonly HanjaCandidate[];
-        try {
-            candidates = await this.hanjaDictionaryProvider.lookup(target.reading);
-        } catch (error) {
-            console.error(error);
-            return;
-        }
-
-        // Deliberately not gated on `_isActive`: Hanja conversion is independent of
-        // Han/Yong mode (it converts existing Hangul, including text from the OS
-        // IME while our Hangul typing is off), matching the Microsoft IME, where the
-        // Hanja key works in 영 mode too. Staleness from a mode change mid-lookup is
-        // still covered — `deactivate()` bumps `hanjaLookupGeneration`.
-        if (lookupGeneration !== this.hanjaLookupGeneration || candidates.length === 0) {
-            return;
-        }
-
-        const overlay = new HanjaCompositionOverlay(this.element, this.compositionAdapter);
-        const overlayRect = overlay.show(target.reading);
-        const pager = new HanjaCandidatePager(candidates);
-        this.hanjaCandidateSelection = {
-            target,
-            pager,
-            overlay,
-            window: new HanjaCandidateWindow(this.element, this.hanjaCandidatePage(pager), overlayRect, {
-                onPreviousPage: () => this.moveHanjaCandidatePage(-1),
-                onNextPage: () => this.moveHanjaCandidatePage(1),
-                onMoveSelection: (delta) => this.moveHanjaCandidateSelection(delta),
-                onSelectCandidate: (visibleIndex) => this.commitVisibleHanjaCandidate(visibleIndex, KeyCode.Lang2),
-                displayOptions: this.hanjaCandidateDisplayOptions(),
-            }),
-        };
-    }
-
-    private handleHanjaCandidateSelectionKey(event: KeyboardEvent): boolean {
-        const selection = this.hanjaCandidateSelection;
-        if (!selection) {
-            return false;
-        }
-
-        const numberedIndex = hanjaCandidateNumberIndex(event);
-        const candidateIndex =
-            numberedIndex === undefined ? undefined : selection.pager.selectByVisibleIndex(numberedIndex);
-        if (candidateIndex !== undefined) {
-            this.commitHanjaCandidate(candidateIndex, event.code as KeyCode);
-            this.cancelEvent(event);
-            return true;
-        }
-
-        switch (event.key) {
-            case "ArrowDown":
-                this.moveHanjaCandidateSelection(1);
-                this.cancelEvent(event);
-                return true;
-
-            case "ArrowUp":
-                this.moveHanjaCandidateSelection(-1);
-                this.cancelEvent(event);
-                return true;
-
-            case "ArrowRight":
-                this.moveHanjaCandidatePage(1);
-                this.cancelEvent(event);
-                return true;
-
-            case "ArrowLeft":
-                this.moveHanjaCandidatePage(-1);
-                this.cancelEvent(event);
-                return true;
-
-            case "Enter":
-                this.commitHanjaCandidate(selection.pager.selectedIndex, event.code as KeyCode);
-                this.cancelEvent(event);
-                return true;
-
-            case "Escape":
-                this.closeHanjaCandidateSelection();
-                this.cancelEvent(event);
-                return true;
-
-            case "Backspace":
-            case "Delete":
-                this.closeHanjaCandidateSelection();
-                this.cancelEvent(event);
-                return true;
-
-            default:
-                return false;
-        }
-    }
-
-    private moveHanjaCandidateSelection(delta: number): void {
-        const selection = this.hanjaCandidateSelection;
-        if (!selection) {
-            return;
-        }
-
-        selection.pager.moveSelection(delta);
-        this.refreshHanjaCandidateWindow();
-    }
-
-    private moveHanjaCandidatePage(delta: number): void {
-        const selection = this.hanjaCandidateSelection;
-        if (!selection) {
-            return;
-        }
-
-        selection.pager.movePage(delta);
-        this.refreshHanjaCandidateWindow();
-    }
-
-    private commitVisibleHanjaCandidate(visibleIndex: number, keyCode: KeyCode): void {
-        const selection = this.hanjaCandidateSelection;
-        if (!selection) {
-            return;
-        }
-
-        const candidateIndex = selection.pager.selectByVisibleIndex(visibleIndex);
-        if (candidateIndex === undefined) {
-            return;
-        }
-
-        this.commitHanjaCandidate(candidateIndex, keyCode);
-    }
-
-    private commitHanjaCandidate(index: number, keyCode: KeyCode): void {
-        const selection = this.hanjaCandidateSelection;
-        if (!selection) {
-            return;
-        }
-
-        const candidate = selection.pager.candidateAt(index);
-        if (!candidate) {
-            return;
-        }
-
-        this.closeHanjaCandidateSelection();
-        commitHanjaCandidate(selection.target, candidate, this.compositor, this.compositionAdapter, keyCode);
-        this.notifyOnEntry();
-    }
-
-    private hanjaCandidatePage(pager: HanjaCandidatePager<HanjaCandidate>): HanjaCandidateWindowPage {
-        return {
-            candidates: pager.visibleCandidates,
-            selectedIndex: pager.selectedPageIndex,
-            pageIndex: pager.pageIndex,
-            pageCount: pager.pageCount,
-        };
-    }
-
-    private hanjaCandidateDisplayOptions(): HanjaCandidateDisplayOptions {
-        return {
-            showSimplified: this.hanjaOptions.showSimplified,
-            showPinyin: this.hanjaOptions.showPinyin,
-        };
-    }
-
-    private refreshHanjaCandidateWindow(): void {
-        const selection = this.hanjaCandidateSelection;
-        if (!selection) {
-            return;
-        }
-
-        selection.window.setDisplayOptions(this.hanjaCandidateDisplayOptions());
-        selection.window.update(this.hanjaCandidatePage(selection.pager));
-    }
-
-    private closeHanjaCandidateSelection(): void {
-        this.hanjaCandidateSelection?.overlay.remove();
-        this.hanjaCandidateSelection?.window.remove();
-        this.hanjaCandidateSelection = undefined;
-    }
-
-    private beginHanjaLookup(): number {
-        this.hanjaLookupGeneration += 1;
-        return this.hanjaLookupGeneration;
-    }
-
-    private invalidateHanjaLookup(): void {
-        this.hanjaLookupGeneration += 1;
     }
 
     // Commit and clear any in-progress composition. Runs when the controller is
@@ -690,7 +436,7 @@ export class HangulImeController {
     // inactive (Hangul typing disabled), so a focus/caret change or a physical
     // keystroke must still flush it, or the next OSK jamo attaches to a stale block.
     private flushComposition() {
-        this.closeHanjaCandidateSelection();
+        this.hanja.close();
 
         if (!this._isActive && !this.compositor.isCompositing()) {
             return;
@@ -751,12 +497,6 @@ export class HangulImeController {
         target.addEventListener(type, listener, capture);
         this.eventListeners.push({ target, type, listener, capture });
     }
-
-    private cancelEvent(event: KeyboardEvent): void {
-        event.preventDefault();
-        event.stopPropagation();
-        event.stopImmediatePropagation();
-    }
 }
 
 /**
@@ -768,12 +508,4 @@ export class HangulImeController {
  */
 function hasShortcutModifier(event: KeyboardEvent): boolean {
     return event.ctrlKey || event.metaKey;
-}
-
-function hanjaCandidateNumberIndex(event: KeyboardEvent): number | undefined {
-    if (!/^[1-9]$/.test(event.key)) {
-        return undefined;
-    }
-
-    return Number(event.key) - 1;
 }

--- a/src/composition/hanja/hanja-candidate-controller.ts
+++ b/src/composition/hanja/hanja-candidate-controller.ts
@@ -1,0 +1,333 @@
+import { KeyBinding, matchesKeyBinding } from "../../keyboard/key-binding";
+import { KeyCode } from "../../keyboard/korean-keyboard-map";
+import { cancelEvent } from "../../messaging/dom-events";
+import { HangulCompositor } from "../hangul-compositor";
+import { CompositionAdapter } from "../composition-adapters/composition-adapter";
+import { HanjaCandidate } from "./hanja-candidate";
+import { HanjaCandidatePager } from "./hanja-candidate-pager";
+import { HanjaCandidateDisplayOptions, HanjaCandidateWindow, HanjaCandidateWindowPage } from "./hanja-candidate-window";
+import { HanjaCompositionOverlay } from "./hanja-composition-overlay";
+import { commitHanjaCandidate, getHanjaConversionTarget, HanjaConversionTarget } from "./hanja-converter";
+import { HanjaDictionaryProvider } from "./hanja-dictionary-provider";
+import { defaultHanjaKeyBindingForPlatform } from "./hanja-key";
+
+/** All user-configurable Hanja settings, owned here (not by the IME controller). */
+export type HanjaImeOptions = {
+    enabled: boolean;
+    keyBinding: KeyBinding | null;
+    showSimplified: boolean;
+    showPinyin: boolean;
+};
+
+export function defaultHanjaImeOptions(): HanjaImeOptions {
+    return {
+        enabled: true,
+        keyBinding: defaultHanjaKeyBindingForPlatform(),
+        showSimplified: true,
+        showPinyin: true,
+    };
+}
+
+type HanjaCandidateSelection = {
+    target: HanjaConversionTarget;
+    pager: HanjaCandidatePager<HanjaCandidate>;
+    overlay: HanjaCompositionOverlay;
+    window: HanjaCandidateWindow;
+};
+
+/**
+ * Owns the Hanja conversion lifecycle for one element: deciding whether a key
+ * starts a conversion, resolving the target, the dictionary lookup (with
+ * staleness tracking), and the candidate window/overlay/pager plus its
+ * navigation, paging, and commit.
+ *
+ * Deliberately independent of the IME's Han/Yong (active) mode: the owning
+ * {@link HangulImeController} simply offers it each keydown. It converts existing
+ * Hangul — a composing syllable or the character before the caret — including
+ * text typed by the OS IME while our Hangul typing is off.
+ */
+export class HanjaCandidateController {
+    private selection?: HanjaCandidateSelection;
+    private lookupGeneration = 0;
+    private options: HanjaImeOptions;
+
+    constructor(
+        private readonly element: HTMLElement,
+        private readonly compositor: HangulCompositor,
+        private readonly adapter: CompositionAdapter,
+        private readonly dictionaryProvider: HanjaDictionaryProvider,
+        private readonly onCommitted: () => void,
+        options: Partial<HanjaImeOptions> = {}
+    ) {
+        this.options = { ...defaultHanjaImeOptions(), ...options };
+    }
+
+    get isOpen(): boolean {
+        return this.selection !== undefined;
+    }
+
+    setOptions(options: Partial<HanjaImeOptions>): void {
+        const previousDisplayOptions = this.displayOptions();
+        this.options = { ...this.options, ...options };
+
+        if (!this.options.enabled || !this.options.keyBinding) {
+            this.cancelPendingLookup();
+            this.close();
+            return;
+        }
+
+        const nextDisplayOptions = this.displayOptions();
+        if (
+            previousDisplayOptions.showSimplified !== nextDisplayOptions.showSimplified ||
+            previousDisplayOptions.showPinyin !== nextDisplayOptions.showPinyin
+        ) {
+            this.refresh();
+        }
+    }
+
+    /**
+     * If this keydown is the configured Hanja key (and the feature is on) and
+     * there's a convertible Hangul syllable, open the candidate window. Returns
+     * whether the key was consumed.
+     */
+    tryStartConversion(event: KeyboardEvent): boolean {
+        if (process.env.KIME_ENABLE_HANJA !== "true" || !this.options.enabled || !this.options.keyBinding) {
+            return false;
+        }
+        if (!matchesKeyBinding(event, this.options.keyBinding)) {
+            return false;
+        }
+        return this.start(event);
+    }
+
+    /**
+     * Drive an open candidate window. Returns true when the key was a candidate
+     * action (number/arrow/Enter/Escape/Backspace) and was consumed. Any other key
+     * while the window is open closes it and returns false, so the caller can let
+     * that key fall through to normal handling.
+     */
+    handleKey(event: KeyboardEvent): boolean {
+        if (!this.selection) {
+            return false;
+        }
+        if (this.handleSelectionKey(event)) {
+            return true;
+        }
+        this.close();
+        return false;
+    }
+
+    /** Invalidate any in-flight lookup so its window never opens (e.g. a mode change). */
+    cancelPendingLookup(): void {
+        this.lookupGeneration += 1;
+    }
+
+    close(): void {
+        this.selection?.overlay.remove();
+        this.selection?.window.remove();
+        this.selection = undefined;
+    }
+
+    private start(event: KeyboardEvent): boolean {
+        const target = getHanjaConversionTarget(this.compositor, this.adapter);
+        if (!target) {
+            return false;
+        }
+
+        this.close();
+        const lookupGeneration = this.beginLookup();
+        cancelEvent(event);
+
+        if (target.kind === "composition") {
+            this.adapter.endComposition(target.reading);
+            this.compositor.reset();
+        }
+
+        const committedTarget: HanjaConversionTarget = {
+            ...target,
+            kind: "previous-character",
+        };
+        void this.openCandidates(committedTarget, lookupGeneration);
+        return true;
+    }
+
+    private async openCandidates(target: HanjaConversionTarget, lookupGeneration: number): Promise<void> {
+        let candidates: readonly HanjaCandidate[];
+        try {
+            candidates = await this.dictionaryProvider.lookup(target.reading);
+        } catch (error) {
+            console.error(error);
+            return;
+        }
+
+        // Not gated on the IME's active state: Hanja conversion is independent of
+        // Han/Yong mode (matching the Microsoft IME, where the Hanja key works in
+        // 영 mode too). Staleness from a mode change mid-lookup is still covered —
+        // the owner calls cancelPendingLookup(), which bumps the generation.
+        if (lookupGeneration !== this.lookupGeneration || candidates.length === 0) {
+            return;
+        }
+
+        const overlay = new HanjaCompositionOverlay(this.element, this.adapter);
+        const overlayRect = overlay.show(target.reading);
+        const pager = new HanjaCandidatePager(candidates);
+        this.selection = {
+            target,
+            pager,
+            overlay,
+            window: new HanjaCandidateWindow(this.element, this.page(pager), overlayRect, {
+                onPreviousPage: () => this.movePage(-1),
+                onNextPage: () => this.movePage(1),
+                onMoveSelection: (delta) => this.moveSelection(delta),
+                onSelectCandidate: (visibleIndex) => this.commitVisible(visibleIndex, KeyCode.Lang2),
+                displayOptions: this.displayOptions(),
+            }),
+        };
+    }
+
+    private handleSelectionKey(event: KeyboardEvent): boolean {
+        const selection = this.selection;
+        if (!selection) {
+            return false;
+        }
+
+        const numberedIndex = hanjaCandidateNumberIndex(event);
+        const candidateIndex =
+            numberedIndex === undefined ? undefined : selection.pager.selectByVisibleIndex(numberedIndex);
+        if (candidateIndex !== undefined) {
+            this.commit(candidateIndex, event.code as KeyCode);
+            cancelEvent(event);
+            return true;
+        }
+
+        switch (event.key) {
+            case "ArrowDown":
+                this.moveSelection(1);
+                cancelEvent(event);
+                return true;
+
+            case "ArrowUp":
+                this.moveSelection(-1);
+                cancelEvent(event);
+                return true;
+
+            case "ArrowRight":
+                this.movePage(1);
+                cancelEvent(event);
+                return true;
+
+            case "ArrowLeft":
+                this.movePage(-1);
+                cancelEvent(event);
+                return true;
+
+            case "Enter":
+                this.commit(selection.pager.selectedIndex, event.code as KeyCode);
+                cancelEvent(event);
+                return true;
+
+            case "Escape":
+                this.close();
+                cancelEvent(event);
+                return true;
+
+            case "Backspace":
+            case "Delete":
+                this.close();
+                cancelEvent(event);
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private moveSelection(delta: number): void {
+        const selection = this.selection;
+        if (!selection) {
+            return;
+        }
+
+        selection.pager.moveSelection(delta);
+        this.refresh();
+    }
+
+    private movePage(delta: number): void {
+        const selection = this.selection;
+        if (!selection) {
+            return;
+        }
+
+        selection.pager.movePage(delta);
+        this.refresh();
+    }
+
+    private commitVisible(visibleIndex: number, keyCode: KeyCode): void {
+        const selection = this.selection;
+        if (!selection) {
+            return;
+        }
+
+        const candidateIndex = selection.pager.selectByVisibleIndex(visibleIndex);
+        if (candidateIndex === undefined) {
+            return;
+        }
+
+        this.commit(candidateIndex, keyCode);
+    }
+
+    private commit(index: number, keyCode: KeyCode): void {
+        const selection = this.selection;
+        if (!selection) {
+            return;
+        }
+
+        const candidate = selection.pager.candidateAt(index);
+        if (!candidate) {
+            return;
+        }
+
+        this.close();
+        commitHanjaCandidate(selection.target, candidate, this.compositor, this.adapter, keyCode);
+        this.onCommitted();
+    }
+
+    private page(pager: HanjaCandidatePager<HanjaCandidate>): HanjaCandidateWindowPage {
+        return {
+            candidates: pager.visibleCandidates,
+            selectedIndex: pager.selectedPageIndex,
+            pageIndex: pager.pageIndex,
+            pageCount: pager.pageCount,
+        };
+    }
+
+    private displayOptions(): HanjaCandidateDisplayOptions {
+        return {
+            showSimplified: this.options.showSimplified,
+            showPinyin: this.options.showPinyin,
+        };
+    }
+
+    private refresh(): void {
+        const selection = this.selection;
+        if (!selection) {
+            return;
+        }
+
+        selection.window.setDisplayOptions(this.displayOptions());
+        selection.window.update(this.page(selection.pager));
+    }
+
+    private beginLookup(): number {
+        this.lookupGeneration += 1;
+        return this.lookupGeneration;
+    }
+}
+
+function hanjaCandidateNumberIndex(event: KeyboardEvent): number | undefined {
+    if (!/^[1-9]$/.test(event.key)) {
+        return undefined;
+    }
+
+    return Number(event.key) - 1;
+}

--- a/src/messaging/dom-events.ts
+++ b/src/messaging/dom-events.ts
@@ -14,3 +14,13 @@ export function isKimeEvent<T extends Event>(event: T | KimeEvent): event is Kim
 export function setAsKimeEvent(event: Event) {
     (event as KimeEvent).isKimeEvent = true;
 }
+
+/**
+ * Fully swallow a keyboard event so neither the page nor a rich editor acts on
+ * the key we've handled ourselves. Shared by the composition and Hanja paths.
+ */
+export function cancelEvent(event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+}


### PR DESCRIPTION
Closes #198

Moves the Hanja candidate lifecycle out of `HangulImeController` into a dedicated `HanjaCandidateController` that owns all Hanja config, target resolution, the dictionary lookup + staleness, and the candidate window/overlay/pager. The IME controller now just offers each keydown to it and otherwise composes — it holds no Hanja state and no longer knows the Hanja key. Controller drops from ~780 to ~510 lines.

Behaviour-preserving (public API unchanged), with one intrinsic fix: candidate keys are now intercepted in the capture phase regardless of Han/Yong mode, so they can't reach a rich editor first while the window is open in 영 mode. Shared `cancelEvent` helper moved to `messaging/dom-events`.

Tests: existing Hanja suite passes unchanged; added a capture-phase-while-inactive test (419 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)