### PR TITLE
Make blur-keeps-candidate-window behaviour intentional

### DIFF
--- a/src/composition/key-listener.test.ts
+++ b/src/composition/key-listener.test.ts
@@ -852,6 +852,24 @@ describe("KeyListener Hanja candidate selection (KIME_ENABLE_HANJA)", () => {
         expect(element.value).toBe("韓");
     });
 
+    // Deliberate behaviour (#206): incidental focus loss must not dismiss an open
+    // candidate window — only a mousedown / focus change / mode toggle / disposal does.
+    it("keeps an open candidate window open on blur", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const element = document.createElement("textarea");
+        element.value = "한";
+        element.selectionStart = element.selectionEnd = 1;
+        makeController(element);
+
+        pressRightCtrl(element);
+        await settleHanjaLookup();
+        expect(document.querySelector(HANJA_CANDIDATE_WINDOW_SELECTOR)).not.toBeNull();
+
+        element.dispatchEvent(new FocusEvent("blur"));
+
+        expect(document.querySelector(HANJA_CANDIDATE_WINDOW_SELECTOR)).not.toBeNull();
+    });
+
     // The candidate window can be open while inactive, so candidate keys must be
     // intercepted in the capture phase (ahead of a rich editor) regardless of mode —
     // not just by the bubble handler. A body capture listener fires only if the

--- a/src/composition/key-listener.ts
+++ b/src/composition/key-listener.ts
@@ -78,6 +78,11 @@ export class KeyListener {
             this.hangul.handleKey(event);
         },
         blur: () => {
+            // Only flush Hangul composition; deliberately leave an open Hanja candidate
+            // window alone (see #206). Incidental focus loss — Tab away, switching
+            // apps/tabs, or a focus shift caused by opening the window itself — should
+            // not dismiss it. A deliberate mousedown elsewhere still closes it, as do a
+            // focus change to another field, a mode toggle, and disposal.
             this.hangul.flushComposition();
         },
         mousedown: () => {


### PR DESCRIPTION
Closes #206

Since #205, a bare `blur` no longer closes an open Hanja candidate window (only a mousedown / focus change / mode toggle / disposal does). It started as an accidental side effect of moving `flushComposition` into `HangulController`, but it's a nice result — so this adopts it deliberately: a comment on `KeyListener`'s blur handler plus a guard test, so it isn't silently reverted (notably by #204, which reworks these listeners).

No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)