### PR TITLE
Allow selecting simplified Chinese Hanja forms

### DIFF
--- a/src/composition/hanja/hanja-candidate-controller.ts
+++ b/src/composition/hanja/hanja-candidate-controller.ts
@@ -4,7 +4,12 @@ import { cancelEvent } from "../../messaging/dom-events";
 import { CompositionAdapter } from "../composition-adapters/composition-adapter";
 import { HanjaCandidate } from "./hanja-candidate";
 import { HanjaCandidatePager } from "./hanja-candidate-pager";
-import { HanjaCandidateDisplayOptions, HanjaCandidateWindow, HanjaCandidateWindowPage } from "./hanja-candidate-window";
+import {
+    HanjaCandidateDisplayOptions,
+    HanjaCandidateSelectionModifiers,
+    HanjaCandidateWindow,
+    HanjaCandidateWindowPage,
+} from "./hanja-candidate-window";
 import { HanjaCompositionOverlay } from "./hanja-composition-overlay";
 import { commitHanjaCandidate, getHanjaConversionTarget, HanjaConversionTarget } from "./hanja-converter";
 import { HanjaDictionaryProvider } from "./hanja-dictionary-provider";
@@ -48,6 +53,8 @@ export class HanjaCandidateController {
     private selection?: HanjaCandidateSelection;
     private lookupGeneration = 0;
     private options: HanjaImeOptions;
+    private readonly heldShiftKeys = new Set<KeyCode>();
+    private isSelectingSimplified = false;
 
     constructor(
         private readonly element: HTMLElement,
@@ -76,7 +83,8 @@ export class HanjaCandidateController {
         const nextDisplayOptions = this.displayOptions();
         if (
             previousDisplayOptions.showSimplified !== nextDisplayOptions.showSimplified ||
-            previousDisplayOptions.showPinyin !== nextDisplayOptions.showPinyin
+            previousDisplayOptions.showPinyin !== nextDisplayOptions.showPinyin ||
+            previousDisplayOptions.selectSimplified !== nextDisplayOptions.selectSimplified
         ) {
             this.refresh();
         }
@@ -99,14 +107,33 @@ export class HanjaCandidateController {
      * that key fall through to normal handling.
      */
     handleKey(event: KeyboardEvent): boolean {
+        const shiftKey = this.syncShiftStateFromKeydown(event);
         if (!this.selection) {
             return false;
+        }
+        if (shiftKey) {
+            cancelEvent(event);
+            return true;
         }
         if (this.handleSelectionKey(event)) {
             return true;
         }
         this.close();
         return false;
+    }
+
+    /**
+     * Keep simplified-form highlighting in sync when Shift is released. Returns
+     * true only when an open candidate window consumed the keyup.
+     */
+    handleKeyUp(event: KeyboardEvent): boolean {
+        const shiftKey = this.syncShiftStateFromKeyup(event);
+        if (!this.selection || !shiftKey) {
+            return false;
+        }
+
+        cancelEvent(event);
+        return true;
     }
 
     /** Invalidate any in-flight lookup so its window never opens (e.g. a mode change). */
@@ -118,6 +145,8 @@ export class HanjaCandidateController {
         this.selection?.overlay.remove();
         this.selection?.window.remove();
         this.selection = undefined;
+        this.isSelectingSimplified = false;
+        this.heldShiftKeys.clear();
     }
 
     /**
@@ -126,6 +155,7 @@ export class HanjaCandidateController {
      */
     startConversion(event: KeyboardEvent): void {
         this.close();
+        this.syncShiftStateFromKeydown(event);
         const lookupGeneration = this.beginLookup();
         cancelEvent(event);
 
@@ -165,7 +195,8 @@ export class HanjaCandidateController {
                 onPreviousPage: () => this.movePage(-1),
                 onNextPage: () => this.movePage(1),
                 onMoveSelection: (delta) => this.moveSelection(delta),
-                onSelectCandidate: (visibleIndex) => this.commitVisible(visibleIndex, KeyCode.Lang2),
+                onSelectCandidate: (visibleIndex, modifiers) =>
+                    this.commitVisible(visibleIndex, KeyCode.Lang2, modifiers),
                 displayOptions: this.displayOptions(),
             }),
         };
@@ -181,7 +212,7 @@ export class HanjaCandidateController {
         const candidateIndex =
             numberedIndex === undefined ? undefined : selection.pager.selectByVisibleIndex(numberedIndex);
         if (candidateIndex !== undefined) {
-            this.commit(candidateIndex, event.code as KeyCode);
+            this.commit(candidateIndex, event.code as KeyCode, this.isSelectingSimplified);
             cancelEvent(event);
             return true;
         }
@@ -208,7 +239,7 @@ export class HanjaCandidateController {
                 return true;
 
             case "Enter":
-                this.commit(selection.pager.selectedIndex, event.code as KeyCode);
+                this.commit(selection.pager.selectedIndex, event.code as KeyCode, this.isSelectingSimplified);
                 cancelEvent(event);
                 return true;
 
@@ -248,7 +279,11 @@ export class HanjaCandidateController {
         this.refresh();
     }
 
-    private commitVisible(visibleIndex: number, keyCode: KeyCode): void {
+    private commitVisible(
+        visibleIndex: number,
+        keyCode: KeyCode,
+        modifiers: HanjaCandidateSelectionModifiers = { shiftKey: this.isSelectingSimplified }
+    ): void {
         const selection = this.selection;
         if (!selection) {
             return;
@@ -259,10 +294,10 @@ export class HanjaCandidateController {
             return;
         }
 
-        this.commit(candidateIndex, keyCode);
+        this.commit(candidateIndex, keyCode, modifiers.shiftKey);
     }
 
-    private commit(index: number, keyCode: KeyCode): void {
+    private commit(index: number, keyCode: KeyCode, useSimplified = this.isSelectingSimplified): void {
         const selection = this.selection;
         if (!selection) {
             return;
@@ -274,7 +309,9 @@ export class HanjaCandidateController {
         }
 
         this.close();
-        commitHanjaCandidate(candidate, this.adapter, keyCode);
+        commitHanjaCandidate(candidate, this.adapter, keyCode, {
+            useSimplified: this.options.showSimplified && useSimplified,
+        });
         this.onCommitted();
     }
 
@@ -291,6 +328,7 @@ export class HanjaCandidateController {
         return {
             showSimplified: this.options.showSimplified,
             showPinyin: this.options.showPinyin,
+            selectSimplified: this.options.showSimplified && this.isSelectingSimplified,
         };
     }
 
@@ -308,12 +346,69 @@ export class HanjaCandidateController {
         this.lookupGeneration += 1;
         return this.lookupGeneration;
     }
+
+    private syncShiftStateFromKeydown(event: KeyboardEvent): boolean {
+        const code = event.code as KeyCode;
+        if (isShiftKey(code)) {
+            this.heldShiftKeys.add(code);
+        } else if (!event.shiftKey) {
+            this.heldShiftKeys.clear();
+        }
+
+        this.setSelectingSimplified(event.shiftKey || this.heldShiftKeys.size > 0);
+        return isShiftKey(code);
+    }
+
+    private syncShiftStateFromKeyup(event: KeyboardEvent): boolean {
+        const code = event.code as KeyCode;
+        if (!isShiftKey(code)) {
+            if (!event.shiftKey) {
+                this.setSelectingSimplified(false);
+            }
+            return false;
+        }
+
+        this.heldShiftKeys.delete(code);
+        this.setSelectingSimplified(event.shiftKey || this.heldShiftKeys.size > 0);
+        return true;
+    }
+
+    private setSelectingSimplified(active: boolean): void {
+        const next = this.options.showSimplified && active;
+        if (this.isSelectingSimplified === next) {
+            return;
+        }
+
+        this.isSelectingSimplified = next;
+        this.refresh();
+    }
 }
 
 function hanjaCandidateNumberIndex(event: KeyboardEvent): number | undefined {
     if (!/^[1-9]$/.test(event.key)) {
-        return undefined;
+        return digitKeyIndex(event.code);
     }
 
     return Number(event.key) - 1;
+}
+
+const digitKeyCodes = [
+    KeyCode.Digit1,
+    KeyCode.Digit2,
+    KeyCode.Digit3,
+    KeyCode.Digit4,
+    KeyCode.Digit5,
+    KeyCode.Digit6,
+    KeyCode.Digit7,
+    KeyCode.Digit8,
+    KeyCode.Digit9,
+] as const;
+
+function digitKeyIndex(code: string): number | undefined {
+    const index = digitKeyCodes.indexOf(code as (typeof digitKeyCodes)[number]);
+    return index === -1 ? undefined : index;
+}
+
+function isShiftKey(code: KeyCode): code is KeyCode.ShiftLeft | KeyCode.ShiftRight {
+    return code === KeyCode.ShiftLeft || code === KeyCode.ShiftRight;
 }

--- a/src/composition/hanja/hanja-candidate-window.scss
+++ b/src/composition/hanja/hanja-candidate-window.scss
@@ -112,6 +112,13 @@
         .can-simplified {
             grid-row: 2;
             font-size: 18px;
+
+            &.is-selecting-simplified {
+                border-radius: 3px;
+                background: var(--toggle-on-bg);
+                box-shadow: 0 0 0 2px var(--toggle-on-bg);
+                color: var(--accent-on);
+            }
         }
     }
 

--- a/src/composition/hanja/hanja-candidate-window.test.ts
+++ b/src/composition/hanja/hanja-candidate-window.test.ts
@@ -214,7 +214,21 @@ describe("HanjaCandidateWindow", () => {
 
         candidateItems()[1].click();
 
-        expect(options.onSelectCandidate).toHaveBeenCalledWith(1);
+        expect(options.onSelectCandidate).toHaveBeenCalledWith(1, { shiftKey: false });
+    });
+
+    it("passes the Shift state when a candidate is clicked", () => {
+        const options = windowOptions();
+        new HanjaCandidateWindow(
+            document.createElement("textarea"),
+            page({ candidates: [candidate("韓"), candidate("寒"), candidate("恨")] }),
+            rect(100, 20, 10, 10),
+            options
+        );
+
+        candidateItems()[1].dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, shiftKey: true }));
+
+        expect(options.onSelectCandidate).toHaveBeenCalledWith(1, { shiftKey: true });
     });
 
     it("renders Hanja candidate metadata", () => {
@@ -283,6 +297,32 @@ describe("HanjaCandidateWindow", () => {
         expect(document.querySelector(".can-korean")?.textContent).toBe("나라 이름 한, 한나라 한");
         expect(document.querySelector(".can-simplified")).toBeNull();
         expect(document.querySelector(".can-pinyin")).toBeNull();
+    });
+
+    it("marks displayed simplified forms when simplified selection is active", () => {
+        new HanjaCandidateWindow(
+            document.createElement("textarea"),
+            page({
+                candidates: [
+                    candidate("韓", {
+                        korean: "나라 이름 한, 한나라 한",
+                        simplified: "韩",
+                        pinyin: "hán",
+                    }),
+                    candidate("寒"),
+                ],
+            }),
+            rect(100, 20, 10, 10),
+            {
+                ...windowOptions(),
+                displayOptions: { showSimplified: true, showPinyin: true, selectSimplified: true },
+            }
+        );
+
+        const simplified = Array.from(document.querySelectorAll<HTMLElement>(".can-simplified"));
+
+        expect(simplified.map((item) => item.textContent)).toEqual(["韩", ""]);
+        expect(simplified.map((item) => item.classList.contains("is-selecting-simplified"))).toEqual([true, false]);
     });
 
     it("can update metadata visibility for an already-open candidate window", () => {

--- a/src/composition/hanja/hanja-candidate-window.ts
+++ b/src/composition/hanja/hanja-candidate-window.ts
@@ -15,18 +15,24 @@ export type HanjaCandidateWindowPage = {
 export type HanjaCandidateDisplayOptions = {
     showSimplified: boolean;
     showPinyin: boolean;
+    selectSimplified?: boolean;
 };
 
 export const defaultHanjaCandidateDisplayOptions: HanjaCandidateDisplayOptions = {
     showSimplified: true,
     showPinyin: true,
+    selectSimplified: false,
+};
+
+export type HanjaCandidateSelectionModifiers = {
+    shiftKey: boolean;
 };
 
 type HanjaCandidateWindowOptions = {
     onPreviousPage: () => void;
     onNextPage: () => void;
     onMoveSelection: (delta: number) => void;
-    onSelectCandidate: (visibleIndex: number) => void;
+    onSelectCandidate: (visibleIndex: number, modifiers: HanjaCandidateSelectionModifiers) => void;
     displayOptions?: HanjaCandidateDisplayOptions;
 };
 
@@ -37,7 +43,7 @@ export class HanjaCandidateWindow {
     private readonly candidateList: HTMLDivElement;
     private readonly controls: HTMLDivElement;
     private readonly pageHint: HTMLDivElement;
-    private readonly onSelectCandidate: (visibleIndex: number) => void;
+    private readonly onSelectCandidate: (visibleIndex: number, modifiers: HanjaCandidateSelectionModifiers) => void;
     private displayOptions: HanjaCandidateDisplayOptions;
     private hoveredIndex: number | undefined;
 
@@ -175,7 +181,7 @@ export class HanjaCandidateWindow {
         item.addEventListener("click", (event) => {
             event.preventDefault();
             event.stopPropagation();
-            this.onSelectCandidate(index);
+            this.onSelectCandidate(index, { shiftKey: event.shiftKey });
         });
 
         const number = document.createElement("span");
@@ -194,6 +200,9 @@ export class HanjaCandidateWindow {
             const span = document.createElement("span");
             span.className = `can-${key}`;
             span.textContent = candidate[key] ?? "";
+            if (key === "simplified" && candidate.simplified) {
+                span.classList.toggle("is-selecting-simplified", this.displayOptions.selectSimplified === true);
+            }
             elements.push(span);
         }
 

--- a/src/composition/hanja/hanja-converter.test.ts
+++ b/src/composition/hanja/hanja-converter.test.ts
@@ -78,4 +78,27 @@ describe("commitHanjaCandidate", () => {
         expect(adapter.deleteContentBackwards).toHaveBeenCalled();
         expect(adapter.inputCharacter).toHaveBeenCalledWith("恨", KeyCode.Digit3);
     });
+
+    it("replaces the preceding syllable with the simplified form when requested", () => {
+        const adapter = fakeAdapter({ getPreviousCharacter: jest.fn().mockReturnValue("한") });
+
+        commitHanjaCandidate(
+            { hanja: "韓", korean: "나라 이름 한, 한나라 한", simplified: "韩" },
+            asAdapter(adapter),
+            KeyCode.Digit1,
+            { useSimplified: true }
+        );
+
+        expect(adapter.deleteContentBackwards).toHaveBeenCalled();
+        expect(adapter.inputCharacter).toHaveBeenCalledWith("韩", KeyCode.Digit1);
+    });
+
+    it("falls back to Hanja when simplified selection is requested but unavailable", () => {
+        const adapter = fakeAdapter({ getPreviousCharacter: jest.fn().mockReturnValue("한") });
+
+        commitHanjaCandidate(hanCandidates[1], asAdapter(adapter), KeyCode.Digit2, { useSimplified: true });
+
+        expect(adapter.deleteContentBackwards).toHaveBeenCalled();
+        expect(adapter.inputCharacter).toHaveBeenCalledWith("寒", KeyCode.Digit2);
+    });
 });

--- a/src/composition/hanja/hanja-converter.ts
+++ b/src/composition/hanja/hanja-converter.ts
@@ -7,6 +7,10 @@ export type HanjaConversionTarget = {
     reading: string;
 };
 
+export type CommitHanjaCandidateOptions = {
+    useSimplified?: boolean;
+};
+
 /**
  * Hanja conversion — the distinct phase that turns an already-composed Hangul
  * syllable into Hanja. The key listener commits any in-progress Hangul block before
@@ -25,9 +29,17 @@ export function getHanjaConversionTarget(adapter: CompositionAdapter): HanjaConv
     return isSingleHangulSyllable(reading) ? { kind: "previous-character", reading } : undefined;
 }
 
-export function commitHanjaCandidate(candidate: HanjaCandidate, adapter: CompositionAdapter, keyCode: KeyCode): void {
+export function commitHanjaCandidate(
+    candidate: HanjaCandidate,
+    adapter: CompositionAdapter,
+    keyCode: KeyCode,
+    options: CommitHanjaCandidateOptions = {}
+): void {
     adapter.deleteContentBackwards();
-    adapter.inputCharacter(candidate.hanja, keyCode);
+    adapter.inputCharacter(
+        options.useSimplified && candidate.simplified ? candidate.simplified : candidate.hanja,
+        keyCode
+    );
 }
 
 function isSingleHangulSyllable(text: string): boolean {

--- a/src/composition/key-listener.test.ts
+++ b/src/composition/key-listener.test.ts
@@ -12,8 +12,24 @@ import { HANJA_CANDIDATE_WINDOW_SELECTOR } from "./hanja/hanja-candidate-window"
 
 jest.mock("./hanja/hanja-candidate-window.scss", () => ({}), { virtual: true });
 
-function dispatchKeydown(target: EventTarget, code: string, key: string): KeyboardEvent {
-    const event = new KeyboardEvent("keydown", { code, key, bubbles: true, cancelable: true });
+function dispatchKeydown(
+    target: EventTarget,
+    code: string,
+    key: string,
+    init: Omit<KeyboardEventInit, "code" | "key"> = {}
+): KeyboardEvent {
+    const event = new KeyboardEvent("keydown", { code, key, bubbles: true, cancelable: true, ...init });
+    target.dispatchEvent(event);
+    return event;
+}
+
+function dispatchKeyup(
+    target: EventTarget,
+    code: string,
+    key: string,
+    init: Omit<KeyboardEventInit, "code" | "key"> = {}
+): KeyboardEvent {
+    const event = new KeyboardEvent("keyup", { code, key, bubbles: true, cancelable: true, ...init });
     target.dispatchEvent(event);
     return event;
 }
@@ -744,16 +760,51 @@ describe("KeyListener Hanja candidate selection (KIME_ENABLE_HANJA)", () => {
         )?.textContent;
     }
 
-    async function controllerAfterCommittedSyllable(reading: string) {
+    async function controllerAfterCommittedSyllable(
+        reading: string,
+        options: {
+            hanjaOptions?: Partial<HanjaImeOptions>;
+            provider?: HanjaDictionaryProvider;
+        } = {}
+    ) {
         const element = document.createElement("textarea");
         element.value = reading;
         element.selectionStart = reading.length;
         element.selectionEnd = reading.length;
-        const controller = makeController(element);
+        const controller = makeController(element, options.provider, options.hanjaOptions);
         controller.activate();
         pressRightCtrl(element);
         await settleHanjaLookup();
         return { element };
+    }
+
+    function simplifiedProvider(): HanjaDictionaryProvider {
+        return new StaticHanjaDictionaryProvider(
+            new Map([
+                [
+                    "한",
+                    [
+                        { hanja: "韓", korean: "나라 이름 한, 한나라 한", simplified: "韩", pinyin: "hán" },
+                        { hanja: "寒", korean: "찰 한" },
+                        { hanja: "漢", korean: "한수 한", simplified: "汉", pinyin: "hàn" },
+                    ],
+                ],
+            ])
+        );
+    }
+
+    function simplifiedValues() {
+        return Array.from(
+            document.querySelectorAll<HTMLElement>(`${HANJA_CANDIDATE_WINDOW_SELECTOR} .can-simplified`)
+        ).map((item) => item.textContent);
+    }
+
+    function highlightedSimplifiedValues() {
+        return Array.from(
+            document.querySelectorAll<HTMLElement>(
+                `${HANJA_CANDIDATE_WINDOW_SELECTOR} .can-simplified.is-selecting-simplified`
+            )
+        ).map((item) => item.textContent);
     }
 
     function clickNextPage() {
@@ -772,6 +823,12 @@ describe("KeyListener Hanja candidate selection (KIME_ENABLE_HANJA)", () => {
 
     function clickCandidate(index: number) {
         document.querySelectorAll<HTMLElement>(`${HANJA_CANDIDATE_WINDOW_SELECTOR} .candidate`)[index].click();
+    }
+
+    function shiftClickCandidate(index: number) {
+        document
+            .querySelectorAll<HTMLElement>(`${HANJA_CANDIDATE_WINDOW_SELECTOR} .candidate`)
+            [index].dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, shiftKey: true }));
     }
 
     it("shows candidates for a composing 한 and swallows the Hanja key when the flag is on", async () => {
@@ -885,6 +942,73 @@ describe("KeyListener Hanja candidate selection (KIME_ENABLE_HANJA)", () => {
         dispatchKeydown(element, "Digit3", "3");
 
         expect(element.value).toBe("恨");
+        expect(document.querySelector(HANJA_CANDIDATE_WINDOW_SELECTOR)).toBeNull();
+    });
+
+    it("highlights simplified forms while either Shift key is held", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element } = await controllerAfterCommittedSyllable("한", { provider: simplifiedProvider() });
+
+        expect(simplifiedValues()).toEqual(["韩", "", "汉"]);
+        expect(highlightedSimplifiedValues()).toEqual([]);
+
+        const leftDown = dispatchKeydown(element, "ShiftLeft", "Shift", { shiftKey: true });
+        const rightDown = dispatchKeydown(element, "ShiftRight", "Shift", { shiftKey: true });
+        const leftUp = dispatchKeyup(element, "ShiftLeft", "Shift", { shiftKey: true });
+
+        expect(highlightedSimplifiedValues()).toEqual(["韩", "汉"]);
+
+        const rightUp = dispatchKeyup(element, "ShiftRight", "Shift", { shiftKey: false });
+
+        expect(highlightedSimplifiedValues()).toEqual([]);
+        expect(leftDown.defaultPrevented).toBe(true);
+        expect(rightDown.defaultPrevented).toBe(true);
+        expect(leftUp.defaultPrevented).toBe(true);
+        expect(rightUp.defaultPrevented).toBe(true);
+    });
+
+    it("commits the simplified form when a numbered candidate is chosen while Shift is down", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element } = await controllerAfterCommittedSyllable("한", { provider: simplifiedProvider() });
+
+        const digit = dispatchKeydown(element, "Digit1", "!", { shiftKey: true });
+
+        expect(element.value).toBe("韩");
+        expect(document.querySelector(HANJA_CANDIDATE_WINDOW_SELECTOR)).toBeNull();
+        expect(digit.defaultPrevented).toBe(true);
+    });
+
+    it("falls back to normal Hanja when a shifted candidate has no simplified form", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element } = await controllerAfterCommittedSyllable("한", { provider: simplifiedProvider() });
+
+        dispatchKeydown(element, "Digit2", "@", { shiftKey: true });
+
+        expect(element.value).toBe("寒");
+    });
+
+    it("does not select simplified forms when simplified display is disabled", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element } = await controllerAfterCommittedSyllable("한", {
+            hanjaOptions: { showSimplified: false },
+            provider: simplifiedProvider(),
+        });
+
+        expect(simplifiedValues()).toEqual([]);
+        dispatchKeydown(element, "ShiftLeft", "Shift", { shiftKey: true });
+        expect(highlightedSimplifiedValues()).toEqual([]);
+        dispatchKeydown(element, "Digit1", "!", { shiftKey: true });
+
+        expect(element.value).toBe("韓");
+    });
+
+    it("commits the simplified form when a candidate is shift-clicked", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element } = await controllerAfterCommittedSyllable("한", { provider: simplifiedProvider() });
+
+        shiftClickCandidate(2);
+
+        expect(element.value).toBe("汉");
         expect(document.querySelector(HANJA_CANDIDATE_WINDOW_SELECTOR)).toBeNull();
     });
 

--- a/src/composition/key-listener.ts
+++ b/src/composition/key-listener.ts
@@ -141,7 +141,7 @@ export class KeyListener {
         }
 
         try {
-            this.toggleKeyupConsumer?.(event);
+            this.dispatchKeyup(event);
         } finally {
             this.notifyObservers("keyup", event);
         }
@@ -174,6 +174,16 @@ export class KeyListener {
             activeRoute.hanja.cancelPendingLookup();
             activeRoute.hangul.handleKey(event);
         }
+    }
+
+    private dispatchKeyup(event: KeyboardEvent): void {
+        const activeRoute = this.routeForEvent(event);
+
+        if (activeRoute?.hanja.handleKeyUp(event)) {
+            return;
+        }
+
+        this.toggleKeyupConsumer?.(event);
     }
 
     private blur = (): void => {


### PR DESCRIPTION
## Summary

- highlight available simplified forms while either Shift key is held
- commit simplified candidates with Shift+number or Shift-click, falling back to the normal Hanja form when needed
- keep simplified selection disabled when the setting is off and cover modifier behavior with unit tests

## Testing

- `npm run validate`

Closes #214