### PR TITLE
Clean up Hanja candidate selection

### DIFF
--- a/src/composition/hanja/hanja-candidate-controller.ts
+++ b/src/composition/hanja/hanja-candidate-controller.ts
@@ -53,7 +53,6 @@ export class HanjaCandidateController {
     private selection?: HanjaCandidateSelection;
     private lookupGeneration = 0;
     private options: HanjaImeOptions;
-    private readonly heldShiftKeys = new Set<KeyCode>();
     private isSelectingSimplified = false;
 
     constructor(
@@ -107,7 +106,7 @@ export class HanjaCandidateController {
      * that key fall through to normal handling.
      */
     handleKey(event: KeyboardEvent): boolean {
-        const shiftKey = this.syncShiftStateFromKeydown(event);
+        const shiftKey = this.syncShiftState(event);
         if (!this.selection) {
             return false;
         }
@@ -127,7 +126,7 @@ export class HanjaCandidateController {
      * true only when an open candidate window consumed the keyup.
      */
     handleKeyUp(event: KeyboardEvent): boolean {
-        const shiftKey = this.syncShiftStateFromKeyup(event);
+        const shiftKey = this.syncShiftState(event);
         if (!this.selection || !shiftKey) {
             return false;
         }
@@ -146,7 +145,6 @@ export class HanjaCandidateController {
         this.selection?.window.remove();
         this.selection = undefined;
         this.isSelectingSimplified = false;
-        this.heldShiftKeys.clear();
     }
 
     /**
@@ -155,7 +153,7 @@ export class HanjaCandidateController {
      */
     startConversion(event: KeyboardEvent): void {
         this.close();
-        this.syncShiftStateFromKeydown(event);
+        this.syncShiftState(event);
         const lookupGeneration = this.beginLookup();
         cancelEvent(event);
 
@@ -279,11 +277,7 @@ export class HanjaCandidateController {
         this.refresh();
     }
 
-    private commitVisible(
-        visibleIndex: number,
-        keyCode: KeyCode,
-        modifiers: HanjaCandidateSelectionModifiers = { shiftKey: this.isSelectingSimplified }
-    ): void {
+    private commitVisible(visibleIndex: number, keyCode: KeyCode, modifiers: HanjaCandidateSelectionModifiers): void {
         const selection = this.selection;
         if (!selection) {
             return;
@@ -297,7 +291,7 @@ export class HanjaCandidateController {
         this.commit(candidateIndex, keyCode, modifiers.shiftKey);
     }
 
-    private commit(index: number, keyCode: KeyCode, useSimplified = this.isSelectingSimplified): void {
+    private commit(index: number, keyCode: KeyCode, useSimplified: boolean): void {
         const selection = this.selection;
         if (!selection) {
             return;
@@ -347,30 +341,10 @@ export class HanjaCandidateController {
         return this.lookupGeneration;
     }
 
-    private syncShiftStateFromKeydown(event: KeyboardEvent): boolean {
+    private syncShiftState(event: KeyboardEvent): boolean {
         const code = event.code as KeyCode;
-        if (isShiftKey(code)) {
-            this.heldShiftKeys.add(code);
-        } else if (!event.shiftKey) {
-            this.heldShiftKeys.clear();
-        }
-
-        this.setSelectingSimplified(event.shiftKey || this.heldShiftKeys.size > 0);
+        this.setSelectingSimplified(event.shiftKey);
         return isShiftKey(code);
-    }
-
-    private syncShiftStateFromKeyup(event: KeyboardEvent): boolean {
-        const code = event.code as KeyCode;
-        if (!isShiftKey(code)) {
-            if (!event.shiftKey) {
-                this.setSelectingSimplified(false);
-            }
-            return false;
-        }
-
-        this.heldShiftKeys.delete(code);
-        this.setSelectingSimplified(event.shiftKey || this.heldShiftKeys.size > 0);
-        return true;
     }
 
     private setSelectingSimplified(active: boolean): void {
@@ -386,6 +360,9 @@ export class HanjaCandidateController {
 
 function hanjaCandidateNumberIndex(event: KeyboardEvent): number | undefined {
     if (!/^[1-9]$/.test(event.key)) {
+        // Candidate shortcuts follow the physical Korean number row even when
+        // the host layout reports a symbol (for example, "&" on AZERTY) or
+        // Shift changes the key value to punctuation.
         return digitKeyIndex(event.code);
     }
 

--- a/src/composition/hanja/hanja-candidate-controller.ts
+++ b/src/composition/hanja/hanja-candidate-controller.ts
@@ -101,14 +101,19 @@ export class HanjaCandidateController {
 
     /**
      * Drive an open candidate window. Returns true when the key was a candidate
-     * action (number/arrow/Enter/Escape/Backspace) and was consumed. Any other key
-     * while the window is open closes it and returns false, so the caller can let
-     * that key fall through to normal handling.
+     * action (Hanja/number/arrow/Enter/Escape/Backspace) and was consumed. Any
+     * other key while the window is open closes it and returns false, so the caller
+     * can let that key fall through to normal handling.
      */
     handleKey(event: KeyboardEvent): boolean {
         const shiftKey = this.syncShiftState(event);
         if (!this.selection) {
             return false;
+        }
+        if (this.isConversionKey(event)) {
+            this.close();
+            cancelEvent(event);
+            return true;
         }
         if (shiftKey) {
             cancelEvent(event);

--- a/src/composition/key-listener.test.ts
+++ b/src/composition/key-listener.test.ts
@@ -856,6 +856,21 @@ describe("KeyListener Hanja candidate selection (KIME_ENABLE_HANJA)", () => {
         expect(candidateTexts()).toEqual(["1安", "2岸"]);
     });
 
+    it("closes an open candidate list when the Hanja key is pressed again", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element } = composingController();
+        composeHan(element);
+        pressRightCtrl(element);
+        await settleHanjaLookup();
+
+        const ctrl = pressRightCtrl(element);
+        await settleHanjaLookup();
+
+        expect(element.value).toBe("한");
+        expect(document.querySelector(HANJA_CANDIDATE_WINDOW_SELECTOR)).toBeNull();
+        expect(ctrl.defaultPrevented).toBe(true);
+    });
+
     it("commits a composing candidate selected by number", async () => {
         process.env.KIME_ENABLE_HANJA = "true";
         const { element, deleteContentBackwards, inputCharacter } = composingController();

--- a/src/composition/key-listener.test.ts
+++ b/src/composition/key-listener.test.ts
@@ -978,6 +978,42 @@ describe("KeyListener Hanja candidate selection (KIME_ENABLE_HANJA)", () => {
         expect(digit.defaultPrevented).toBe(true);
     });
 
+    it("selects by physical number-row position when the host layout reports a symbol", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element } = await controllerAfterCommittedSyllable("한", { provider: simplifiedProvider() });
+
+        const digit = dispatchKeydown(element, "Digit1", "&");
+
+        expect(element.value).toBe("韓");
+        expect(document.querySelector(HANJA_CANDIDATE_WINDOW_SELECTOR)).toBeNull();
+        expect(digit.defaultPrevented).toBe(true);
+    });
+
+    it("commits the simplified form with Enter while Shift is held", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element } = await controllerAfterCommittedSyllable("한", { provider: simplifiedProvider() });
+
+        dispatchKeydown(element, "ShiftLeft", "Shift", { shiftKey: true });
+        const enter = dispatchKeydown(element, "Enter", "Enter", { shiftKey: true });
+
+        expect(element.value).toBe("韩");
+        expect(document.querySelector(HANJA_CANDIDATE_WINDOW_SELECTOR)).toBeNull();
+        expect(enter.defaultPrevented).toBe(true);
+    });
+
+    it("commits the normal form with a number after Shift is released", async () => {
+        process.env.KIME_ENABLE_HANJA = "true";
+        const { element } = await controllerAfterCommittedSyllable("한", { provider: simplifiedProvider() });
+
+        dispatchKeydown(element, "ShiftLeft", "Shift", { shiftKey: true });
+        dispatchKeyup(element, "ShiftLeft", "Shift", { shiftKey: false });
+        const digit = dispatchKeydown(element, "Digit1", "1");
+
+        expect(element.value).toBe("韓");
+        expect(document.querySelector(HANJA_CANDIDATE_WINDOW_SELECTOR)).toBeNull();
+        expect(digit.defaultPrevented).toBe(true);
+    });
+
     it("falls back to normal Hanja when a shifted candidate has no simplified form", async () => {
         process.env.KIME_ENABLE_HANJA = "true";
         const { element } = await controllerAfterCommittedSyllable("한", { provider: simplifiedProvider() });


### PR DESCRIPTION
## Summary

- use `KeyboardEvent.shiftKey` directly instead of tracking held Shift keys separately
- document and preserve physical number-row candidate selection across host keyboard layouts
- make candidate commit modifier arguments explicit and cover the missing selection paths
- close and consume an open candidate window when the Hanja key is pressed again

## Testing

- `npm run validate`

Closes #218
